### PR TITLE
PARQUET-18: Fix all-null value pages with dict encoding.

### DIFF
--- a/parquet-column/src/test/java/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/parquet/column/values/dictionary/TestDictionary.java
@@ -417,6 +417,20 @@ public class TestDictionary {
     roundTripFloat(cw, reader, maxDictionaryByteSize);
   }
 
+  @Test
+  public void testZeroValues() throws IOException {
+    DictionaryValuesWriter cw = new PlainIntegerDictionaryValuesWriter(100, 100);
+    cw.writeInteger(34);
+    cw.writeInteger(34);
+    getBytesAndCheckEncoding(cw, PLAIN_DICTIONARY);
+    DictionaryValuesReader reader = initDicReader(cw, INT32);
+
+    // pretend there are 100 nulls. what matters is offset = bytes.length.
+    byte[] bytes = {0x00, 0x01, 0x02, 0x03}; // data doesn't matter
+    int offset = bytes.length;
+    reader.initFromPage(100, bytes, offset);
+  }
+
   private DictionaryValuesReader initDicReader(ValuesWriter cw, PrimitiveTypeName type)
       throws IOException {
     final DictionaryPage dictionaryPage = cw.createDictionaryPage().copy();


### PR DESCRIPTION
TestDictionary#testZeroValues demonstrates the problem, where a page of
all null values is decoded using the DicitonaryValuesReader. Because
there are no non-null values, the page values section is 0 byte, but the
DictionaryValuesReader assumes there is at least one encoded value and
attempts to read a bit width. The test passes a byte array to
initFromPage with the offset equal to the array's length.

The fix is to detect that there are no input bytes to read. To avoid
adding validity checks to the read path, this sets the internal decoder
to one that will throw an exception if any reads are attempted.
