### PR TITLE
PARQUET-19: Fix NPE when an empty file is included in a Hive query that uses CombineHiveInputFormat

### DIFF
--- a/parquet-hive/parquet-hive-storage-handler/src/main/java/org/apache/hadoop/hive/ql/io/parquet/read/ParquetRecordReaderWrapper.java
+++ b/parquet-hive/parquet-hive-storage-handler/src/main/java/org/apache/hadoop/hive/ql/io/parquet/read/ParquetRecordReaderWrapper.java
@@ -106,9 +106,9 @@ public class ParquetRecordReaderWrapper  implements RecordReader<Void, ArrayWrit
     } else {
       realReader = null;
       eof = true;
-      if (valueObj == null) { // Should initialize the value for createValue
-        valueObj = new ArrayWritable(Writable.class, new Writable[schemaSize]);
-      }
+    }
+    if (valueObj == null) { // Should initialize the value for createValue
+      valueObj = new ArrayWritable(Writable.class, new Writable[schemaSize]);
     }
   }
 


### PR DESCRIPTION
Make sure the valueObj instance variable is always initialized.  This change is neeeded when running a Hive query that uses the CombineHiveInputFormat and the first file in the combined split is empty.  This can lead to a NullPointerException because the valueObj is null when the CombineHiveInputFormat calls the createValue method.
