### PR TITLE
Only call put() when needed in SchemaCompatibilityValidator#validateColumn()

### DIFF
--- a/parquet-column/src/main/java/parquet/filter2/predicate/SchemaCompatibilityValidator.java
+++ b/parquet-column/src/main/java/parquet/filter2/predicate/SchemaCompatibilityValidator.java
@@ -152,7 +152,10 @@ public class SchemaCompatibilityValidator implements FilterPredicate.Visitor<Voi
           + " was provided with different types in the same predicate."
           + " Found both: (" + alreadySeen + ", " + column.getColumnType() + ")");
     }
-    columnTypesEncountered.put(path, column.getColumnType());
+
+    if (alreadySeen == null) {
+      columnTypesEncountered.put(path, column.getColumnType());
+    }
 
     ColumnDescriptor descriptor = getColumnDescriptor(path);
 


### PR DESCRIPTION
This is some minor cleanup suggested by @tsdeng
