### PR TITLE
PARQUET-56: Added an accessor for the Long column type.

### DIFF
--- a/parquet-column/src/main/java/parquet/example/data/GroupValueSource.java
+++ b/parquet-column/src/main/java/parquet/example/data/GroupValueSource.java
@@ -36,6 +36,10 @@ abstract public class GroupValueSource {
     return getInteger(getType().getFieldIndex(field), index);
   }
 
+  public long getLong(String field, int index) {
+    return getLong(getType().getFieldIndex(field), index);
+  }
+
   public boolean getBoolean(String field, int index) {
     return getBoolean(getType().getFieldIndex(field), index);
   }
@@ -55,6 +59,8 @@ abstract public class GroupValueSource {
   abstract public String getString(int fieldIndex, int index);
 
   abstract public int getInteger(int fieldIndex, int index);
+
+  abstract public long getLong(int fieldIndex, int index);
 
   abstract public boolean getBoolean(int fieldIndex, int index);
 

--- a/parquet-column/src/main/java/parquet/example/data/simple/SimpleGroup.java
+++ b/parquet-column/src/main/java/parquet/example/data/simple/SimpleGroup.java
@@ -127,6 +127,11 @@ public class SimpleGroup extends Group {
   }
 
   @Override
+  public long getLong(int fieldIndex, int index) {
+    return ((LongValue)getValue(fieldIndex, index)).getLong();
+  }
+
+  @Override
   public boolean getBoolean(int fieldIndex, int index) {
     return ((BooleanValue)getValue(fieldIndex, index)).getBoolean();
   }


### PR DESCRIPTION
I noticed there was a missing accessor for the Long column type in the example Group. 
