### PR TITLE
do ProtocolEvents fixing only when there is required fields missing in the requested schema

### DIFF
--- a/parquet-thrift/src/main/java/parquet/thrift/ThriftRecordConverter.java
+++ b/parquet-thrift/src/main/java/parquet/thrift/ThriftRecordConverter.java
@@ -804,8 +804,11 @@ public class ThriftRecordConverter<T> extends RecordMaterializer<T> {
         Type requestedType = requested.getType(field.getName());
         // if a field is in requested schema and the type of it is a group type, then do recursive check
         if (!field.isPrimitive()) {
-          if (hasMissingRequiredFieldInGroupType(requestedType.asGroupType(), field.asGroupType()))
+          if (hasMissingRequiredFieldInGroupType(requestedType.asGroupType(), field.asGroupType())) {
             return true;
+          } else {
+            continue;// check next field
+          }
         }
       } else {
         if (field.getRepetition() == Type.Repetition.REQUIRED) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/PARQUET-61
This PR is trying to redo the https://github.com/apache/incubator-parquet-mr/pull/7

In this PR, it fixes the protocol event in a more precise condition:
Only when the requested schema missing some required fields that are present in the full schema

So even if there a projection, as long as the projection is not getting rid of the required field, the protocol events amender will not be called.

Could you take a look at this ? @dvryaboy @yan-qi
