### PR TITLE
PARQUET-75: Fixed string decode performance issue

### DIFF
--- a/parquet-column/src/main/java/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/parquet/io/api/Binary.java
@@ -168,7 +168,7 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
 
     @Override
     public String toStringUsingUTF8() {
-      return new String(value, BytesUtils.UTF8);
+      return UTF8.decode(ByteBuffer.wrap(value)).toString();
     }
 
     @Override
@@ -236,7 +236,7 @@ abstract public class Binary implements Comparable<Binary>, Serializable {
 
     @Override
     public String toStringUsingUTF8() {
-      return new String(getBytes(), BytesUtils.UTF8);
+      return UTF8.decode(value).toString();
     }
 
     @Override


### PR DESCRIPTION
Switch to using 'UTF8.decode' as opposed to 'new String'

https://issues.apache.org/jira/browse/PARQUET-75
