### PR TITLE
fixes the semver enforcer error on parquet-column

### DIFF
--- a/parquet-column/src/main/java/parquet/column/values/dictionary/DictionaryValuesWriter.java
+++ b/parquet-column/src/main/java/parquet/column/values/dictionary/DictionaryValuesWriter.java
@@ -321,7 +321,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter {
       }
     }
 
-    protected static Binary copy(Binary binary) {
+    static Binary copy(Binary binary) {
       return Binary.fromByteArray(
           Arrays.copyOf(binary.getBytes(), binary.length()));
     }


### PR DESCRIPTION
make copy method package visible only
