### PR TITLE
bump the scala version for parquet-scrooge and parquet-scala to 2.10

### DIFF
--- a/parquet-scala/pom.xml
+++ b/parquet-scala/pom.xml
@@ -42,7 +42,7 @@
     </dependency>
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.9.3</artifactId>
+      <artifactId>scalatest_2.10</artifactId>
       <version>1.9.2</version>
       <scope>test</scope>
     </dependency>

--- a/parquet-scrooge/pom.xml
+++ b/parquet-scrooge/pom.xml
@@ -73,7 +73,7 @@
     </dependency>
     <dependency>
       <groupId>com.twitter</groupId>
-      <artifactId>scrooge-core_2.9.2</artifactId>
+      <artifactId>scrooge-core_2.10</artifactId>
       <version>3.12.1</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <log4j.version>1.2.17</log4j.version>
     <previous.version>1.6.0rc1</previous.version>
     <thrift.executable>thrift</thrift.executable>
-    <scala.version>2.9.2</scala.version>
+    <scala.version>2.10.3</scala.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
We use 2.10 at Stripe, and it's a bit less ancient than 2.9. I'll leave this here in case it's useful - feel free to close if you'd rather stay with 2.9. 
