### PR TITLE
PARQUET-80: upgrade semver plugin version to 0.9.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
             <dependency>
               <groupId>org.semver</groupId>
               <artifactId>enforcer-rule</artifactId>
-              <version>0.9.23</version>
+              <version>0.9.27</version>
             </dependency>
          </dependencies>
          <executions>


### PR DESCRIPTION
To include the fix in:
https://github.com/jeluard/semantic-versioning/pull/39
