### PR TITLE
PARQUET-92: Pig parallel control

### DIFF
--- a/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/ParquetFileReader.java
@@ -79,7 +79,7 @@ public class ParquetFileReader implements Closeable {
 
   private static final Log LOG = Log.getLog(ParquetFileReader.class);
 
-  public static String PARQUET_READ_PARALLELISM = "parquet.pig.read.parallelism";
+  public static String PARQUET_READ_PARALLELISM = "parquet.metadata.read.parallelism";
 
   private static ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
 


### PR DESCRIPTION
The parallelism for reading footers was fixed at '5', which isn't optimal for using pig with S3.  Just adding a property to adjust the parallelism.

JIRA: https://issues.apache.org/jira/browse/PARQUET-92
