### PR TITLE
PARQUET-96: fill out some missing methods on parquet.example classes

### DIFF
--- a/parquet-column/src/main/java/parquet/example/data/Group.java
+++ b/parquet-column/src/main/java/parquet/example/data/Group.java
@@ -56,6 +56,10 @@ abstract public class Group extends GroupValueSource {
     add(getType().getFieldIndex(field), value);
   }
 
+  public void add(String field, Group value) {
+    add(getType().getFieldIndex(field), value);
+  }
+
   public Group addGroup(String field) {
     if (DEBUG) logger.debug("add group "+field+" to "+getType().getName());
     return addGroup(getType().getFieldIndex(field));
@@ -80,6 +84,8 @@ abstract public class Group extends GroupValueSource {
   abstract public void add(int fieldIndex, float value);
 
   abstract public void add(int fieldIndex, double value);
+
+  abstract public void add(int fieldIndex, Group value);
 
   abstract public Group addGroup(int fieldIndex);
 

--- a/parquet-column/src/main/java/parquet/example/data/GroupValueSource.java
+++ b/parquet-column/src/main/java/parquet/example/data/GroupValueSource.java
@@ -40,6 +40,14 @@ abstract public class GroupValueSource {
     return getLong(getType().getFieldIndex(field), index);
   }
 
+  public double getDouble(String field, int index) {
+    return getDouble(getType().getFieldIndex(field), index);
+  }
+
+  public float getFloat(String field, int index) {
+    return getFloat(getType().getFieldIndex(field), index);
+  }
+
   public boolean getBoolean(String field, int index) {
     return getBoolean(getType().getFieldIndex(field), index);
   }
@@ -61,6 +69,10 @@ abstract public class GroupValueSource {
   abstract public int getInteger(int fieldIndex, int index);
 
   abstract public long getLong(int fieldIndex, int index);
+
+  abstract public double getDouble(int fieldIndex, int index);
+
+  abstract public float getFloat(int fieldIndex, int index);
 
   abstract public boolean getBoolean(int fieldIndex, int index);
 

--- a/parquet-column/src/main/java/parquet/example/data/simple/SimpleGroup.java
+++ b/parquet-column/src/main/java/parquet/example/data/simple/SimpleGroup.java
@@ -72,7 +72,7 @@ public class SimpleGroup extends Group {
   @Override
   public Group addGroup(int fieldIndex) {
     SimpleGroup g = new SimpleGroup(schema.getType(fieldIndex).asGroupType());
-    data[fieldIndex].add(g);
+    add(fieldIndex, g);
     return g;
   }
 
@@ -129,6 +129,16 @@ public class SimpleGroup extends Group {
   @Override
   public long getLong(int fieldIndex, int index) {
     return ((LongValue)getValue(fieldIndex, index)).getLong();
+  }
+
+  @Override
+  public double getDouble(int fieldIndex, int index) {
+    return ((DoubleValue)getValue(fieldIndex, index)).getDouble();
+  }
+
+  @Override
+  public float getFloat(int fieldIndex, int index) {
+    return ((FloatValue)getValue(fieldIndex, index)).getFloat();
   }
 
   @Override
@@ -199,6 +209,11 @@ public class SimpleGroup extends Group {
   @Override
   public void add(int fieldIndex, double value) {
     add(fieldIndex, new DoubleValue(value));
+  }
+
+  @Override
+  public void add(int fieldIndex, Group value) {
+    data[fieldIndex].add(value);
   }
 
   @Override


### PR DESCRIPTION
I'm slightly embarrassed to say that we use these, and we'd really like to stop needing a fork, so here we are.
