### PR TITLE
PARQUET-114: Sample NanoTime class serializes and deserializes Timestamp incorrectly

### DIFF
--- a/parquet-column/src/main/java/parquet/example/data/simple/NanoTime.java
+++ b/parquet-column/src/main/java/parquet/example/data/simple/NanoTime.java
@@ -1,6 +1,7 @@
 package parquet.example.data.simple;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import parquet.Preconditions;
 import parquet.io.api.Binary;
 import parquet.io.api.RecordConsumer;
@@ -12,7 +13,10 @@ public class NanoTime extends Primitive {
   public static NanoTime fromBinary(Binary bytes) {
     Preconditions.checkArgument(bytes.length() == 12, "Must be 12 bytes");
     ByteBuffer buf = bytes.toByteBuffer();
-    return new NanoTime(buf.getInt(), buf.getLong());
+    buf.order(ByteOrder.LITTLE_ENDIAN);
+    long timeOfDayNanos = buf.getLong();
+    int julianDay = buf.getInt();
+    return new NanoTime(julianDay, timeOfDayNanos);
   }
 
   public static NanoTime fromInt96(Int96Value int96) {
@@ -35,8 +39,9 @@ public class NanoTime extends Primitive {
 
   public Binary toBinary() {
     ByteBuffer buf = ByteBuffer.allocate(12);
-    buf.putInt(julianDay);
+    buf.order(ByteOrder.LITTLE_ENDIAN);
     buf.putLong(timeOfDayNanos);
+    buf.putInt(julianDay);
     buf.flip();
     return Binary.fromByteBuffer(buf);
   }


### PR DESCRIPTION
I ran the Parquet Column tests and they passed.

FYI @rdblue 
