### PR TITLE
PARQUET-145 InternalParquetRecordReader.close() should not throw an exception if initialization has failed

### DIFF
--- a/parquet-hadoop/src/main/java/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/parquet/hadoop/InternalParquetRecordReader.java
@@ -131,7 +131,9 @@ class InternalParquetRecordReader<T> {
   }
 
   public void close() throws IOException {
-    reader.close();
+    if (reader != null) {
+      reader.close();
+    }
   }
 
   public Void getCurrentKey() throws IOException, InterruptedException {


### PR DESCRIPTION
PARQUET-145 InternalParquetRecordReader.close() should not throw an exception if initialization has failed
