### PR TITLE
PARQUET-150 Update merge script issue id matching.

### DIFF
--- a/dev/merge_parquet_pr.py
+++ b/dev/merge_parquet_pr.py
@@ -212,7 +212,7 @@ def fix_version_from_branch(branch, versions):
         return filter(lambda x: x.name.startswith(branch_ver), versions)[-1]
 
 def exctract_jira_id(title):
-    m = re.search('^(PARQUET-[0-9]+):.*$', title)
+    m = re.search(r'^(PARQUET-[0-9]+)\b.*$', title)
     if m and m.groups > 0:
         return m.group(1)
     else:


### PR DESCRIPTION
This matches a word boundary after the issue id rather than a colon.
