### PR TITLE
PARQUET-1462: Allow specifying new development version in prepare-release.sh

### DIFF
--- a/dev/prepare-release.sh
+++ b/dev/prepare-release.sh
@@ -18,16 +18,22 @@
 # under the License.
 #
 
-if [ -z "$1" ]; then
-  echo "Usage: $0 <version>"
-  exit
+set -e
+
+if [ -z "$2" ]; then
+    cat <<EOF
+Usage: $0 <release-version> <new-development-version-without-SNAPSHOT-suffix>
+Example: $0 1.6.0 1.7.0
+EOF
+  exit 1
 fi
 
-version=$1
+release_version="$1"
+new_development_version="$2-SNAPSHOT"
 
-tag=apache-parquet-$version
+tag="apache-parquet-$release_version"
 
 mvn release:clean
-mvn release:prepare -Dtag=$tag -DreleaseVersion=$version
+mvn release:prepare -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
 
 echo "Finish staging binary artifacts by running: mvn release:perform"


### PR DESCRIPTION
prepare-release.sh used to take only the release version as a
parameter, the new development version was asked interactively for each
individual pom.xml file, which made answering them tedious.