### PR TITLE
PARQUET-1641 Do not cache decompressors in CodecFactory if the decompressor is not meant to be pooled

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/compression/CompressionCodecFactory.java
+++ b/parquet-common/src/main/java/org/apache/parquet/compression/CompressionCodecFactory.java
@@ -42,6 +42,7 @@ public interface CompressionCodecFactory {
     BytesInput decompress(BytesInput bytes, int uncompressedSize) throws IOException;
     void decompress(ByteBuffer input, int compressedSize, ByteBuffer output, int uncompressedSize) throws IOException;
     void release();
+    boolean isPooled();
   }
 
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -24,6 +24,8 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
@@ -32,6 +34,7 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.io.compress.DoNotPool;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import org.apache.parquet.bytes.ByteBufferAllocator;
@@ -46,6 +49,7 @@ public class CodecFactory implements CompressionCodecFactory {
 
   private final Map<CompressionCodecName, BytesCompressor> compressors = new HashMap<CompressionCodecName, BytesCompressor>();
   private final Map<CompressionCodecName, BytesDecompressor> decompressors = new HashMap<CompressionCodecName, BytesDecompressor>();
+  private final List<BytesDecompressor> unpooledDecompressors = new LinkedList<>();
 
   protected final Configuration configuration;
   protected final int pageSize;
@@ -125,6 +129,14 @@ public class CodecFactory implements CompressionCodecFactory {
         CodecPool.returnDecompressor(decompressor);
       }
     }
+
+    @Override
+    public boolean isPooled() {
+      if (decompressor != null) {
+        return !decompressor.getClass().isAnnotationPresent(DoNotPool.class);
+      }
+      return true;
+    }
   }
 
   /**
@@ -197,7 +209,11 @@ public class CodecFactory implements CompressionCodecFactory {
     BytesDecompressor decomp = decompressors.get(codecName);
     if (decomp == null) {
       decomp = createDecompressor(codecName);
-      decompressors.put(codecName, decomp);
+      if (decomp.isPooled()) {
+        decompressors.put(codecName, decomp);
+      } else {
+        unpooledDecompressors.add(decomp);
+      }
     }
     return decomp;
   }
@@ -246,6 +262,10 @@ public class CodecFactory implements CompressionCodecFactory {
       decompressor.release();
     }
     decompressors.clear();
+    for (BytesDecompressor decompressor : unpooledDecompressors) {
+      decompressor.release();
+    }
+    unpooledDecompressors.clear();
   }
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.hadoop.io.compress.DoNotPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xerial.snappy.Snappy;
@@ -182,6 +183,11 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
     public void release() {
       DirectCodecPool.INSTANCE.returnDecompressor(decompressor);
     }
+
+    @Override
+    public boolean isPooled() {
+      return true;
+    }
   }
 
   /**
@@ -226,6 +232,10 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
       extraDecompressor.release();
     }
 
+    @Override
+    public boolean isPooled() {
+      return true;
+    }
   }
 
   public class NoopDecompressor extends BytesDecompressor {
@@ -246,6 +256,11 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
 
     @Override
     public void release() {}
+
+    @Override
+    public boolean isPooled() {
+      return false;
+    }
 
   }
 
@@ -270,6 +285,11 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
 
     @Override
     public void release() {}
+
+    @Override
+    public boolean isPooled() {
+      return extraDecompressor.isPooled();
+    }
   }
 
   public class SnappyCompressor extends BytesCompressor {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestCodecFactory.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestCodecFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import java.nio.ByteBuffer;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TestCodecFactory {
+
+  @Test
+  public void testCreationOfPooledAndUnpooledDecompressors() {
+    CodecFactory factory = null;
+    try {
+      factory = new CodecFactory(new Configuration(), 0);
+      CodecFactory.BytesInputDecompressor gd1 = factory.getDecompressor(CompressionCodecName.GZIP);
+      CodecFactory.BytesInputDecompressor gd2 = factory.getDecompressor(CompressionCodecName.GZIP);
+      Assert.assertNotEquals(gd1, gd2);
+      CodecFactory.BytesInputDecompressor sd1 = factory.getDecompressor(CompressionCodecName.SNAPPY);
+      CodecFactory.BytesInputDecompressor sd2 = factory.getDecompressor(CompressionCodecName.SNAPPY);
+      Assert.assertEquals(sd1, sd2);
+    } finally {
+      if (factory != null) {
+        factory.release();
+      }
+    }
+  }
+
+  @Test
+  public void testReleasingDecompressors() {
+    final CodecFactory spyFactory = Mockito.spy(new CodecFactory(new Configuration(), 1));
+    CodecFactory.BytesDecompressor unpooledDecompressor = new CodecFactory.BytesDecompressor() {
+      @Override
+      public BytesInput decompress(BytesInput bytes, int uncompressedSize) {
+        return null;
+      }
+
+      @Override
+      public void decompress(ByteBuffer input, int compressedSize, ByteBuffer output, int uncompressedSize) {
+      }
+
+      @Override
+      public void release() {
+      }
+
+      @Override
+      public boolean isPooled() {
+        return false;
+      }
+    };
+    CodecFactory.BytesDecompressor spyUnpooled = spy(unpooledDecompressor);
+    when(spyFactory.createDecompressor(CompressionCodecName.GZIP)).thenReturn(spyUnpooled);
+
+    CodecFactory.BytesDecompressor pooledDecompressor = new CodecFactory.BytesDecompressor() {
+      @Override
+      public BytesInput decompress(BytesInput bytes, int uncompressedSize) {
+        return null;
+      }
+
+      @Override
+      public void decompress(ByteBuffer input, int compressedSize, ByteBuffer output, int uncompressedSize) {
+      }
+
+      @Override
+      public void release() {
+      }
+
+      @Override
+      public boolean isPooled() {
+        return true;
+      }
+    };
+    CodecFactory.BytesDecompressor spyPooled = spy(pooledDecompressor);
+    when(spyFactory.createDecompressor(CompressionCodecName.SNAPPY)).thenReturn(spyPooled);
+
+    Assert.assertEquals(spyUnpooled, spyFactory.getDecompressor(CompressionCodecName.GZIP));
+    Assert.assertEquals(spyPooled, spyFactory.getDecompressor(CompressionCodecName.SNAPPY));
+    spyFactory.release();
+    verify(spyFactory).release();
+    verify(spyUnpooled).release();
+    verify(spyPooled).release();
+  }
+}


### PR DESCRIPTION
Decompressors like GZipDecompressor are not meant to be pooled. However, the CodecFactory was still caching them. With this change we now check if the Decompressor is annotated with @DoNotPool. If it is, then we don't cache the decompressor in CodecFactory.

