### PR TITLE
PARQUET-1758: InternalParquetRecordReader Logging is Too Verbose

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordReader.java
@@ -111,18 +111,18 @@ class InternalParquetRecordReader<T> {
     if (current == totalCountLoadedSoFar) {
       if (current != 0) {
         totalTimeSpentProcessingRecords += (System.currentTimeMillis() - startedAssemblingCurrentBlockAt);
-        if (LOG.isInfoEnabled()) {
-            LOG.info("Assembled and processed " + totalCountLoadedSoFar + " records from " + columnCount + " columns in " + totalTimeSpentProcessingRecords + " ms: "+((float)totalCountLoadedSoFar / totalTimeSpentProcessingRecords) + " rec/ms, " + ((float)totalCountLoadedSoFar * columnCount / totalTimeSpentProcessingRecords) + " cell/ms");
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Assembled and processed " + totalCountLoadedSoFar + " records from " + columnCount + " columns in " + totalTimeSpentProcessingRecords + " ms: "+((float)totalCountLoadedSoFar / totalTimeSpentProcessingRecords) + " rec/ms, " + ((float)totalCountLoadedSoFar * columnCount / totalTimeSpentProcessingRecords) + " cell/ms");
             final long totalTime = totalTimeSpentProcessingRecords + totalTimeSpentReadingBytes;
             if (totalTime != 0) {
                 final long percentReading = 100 * totalTimeSpentReadingBytes / totalTime;
                 final long percentProcessing = 100 * totalTimeSpentProcessingRecords / totalTime;
-                LOG.info("time spent so far " + percentReading + "% reading ("+totalTimeSpentReadingBytes+" ms) and " + percentProcessing + "% processing ("+totalTimeSpentProcessingRecords+" ms)");
+                LOG.debug("time spent so far " + percentReading + "% reading ("+totalTimeSpentReadingBytes+" ms) and " + percentProcessing + "% processing ("+totalTimeSpentProcessingRecords+" ms)");
             }
         }
       }
 
-      LOG.info("at row " + current + ". reading next block");
+      LOG.debug("at row {}. reading next block", current);
       long t0 = System.currentTimeMillis();
       PageReadStore pages = reader.readNextFilteredRowGroup();
       if (pages == null) {
@@ -131,8 +131,10 @@ class InternalParquetRecordReader<T> {
       long timeSpentReading = System.currentTimeMillis() - t0;
       totalTimeSpentReadingBytes += timeSpentReading;
       BenchmarkCounter.incrementTime(timeSpentReading);
-      if (LOG.isInfoEnabled()) LOG.info("block read in memory in {} ms. row count = {}", timeSpentReading, pages.getRowCount());
-      LOG.debug("initializing Record assembly with requested schema {}", requestedSchema);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("block read in memory in {} ms. row count = {}", timeSpentReading, pages.getRowCount());
+        LOG.debug("initializing Record assembly with requested schema {}", requestedSchema);
+      }
       MessageColumnIO columnIO = columnIOFactory.getColumnIO(requestedSchema, fileSchema, strictTypeChecking);
       recordReader = columnIO.getRecordReader(pages, recordConverter,
           filterRecords ? filter : FilterCompat.NOOP);
@@ -186,7 +188,7 @@ class InternalParquetRecordReader<T> {
     this.unmaterializableRecordCounter = new UnmaterializableRecordCounter(options, total);
     this.filterRecords = options.useRecordFilter();
     reader.setRequestedSchema(requestedSchema);
-    LOG.info("RecordReader initialized will read a total of {} records.", total);
+    LOG.debug("RecordReader initialized will read a total of {} records", total);
   }
 
   public void initialize(ParquetFileReader reader, Configuration configuration)
@@ -208,7 +210,7 @@ class InternalParquetRecordReader<T> {
     this.unmaterializableRecordCounter = new UnmaterializableRecordCounter(configuration, total);
     this.filterRecords = configuration.getBoolean(RECORD_FILTERING_ENABLED, true);
     reader.setRequestedSchema(requestedSchema);
-    LOG.info("RecordReader initialized will read a total of {} records.", total);
+    LOG.debug("RecordReader initialized will read a total of {} records", total);
   }
 
   public boolean nextKeyValue() throws IOException, InterruptedException {


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [PARQUET-1758](https://issues.apache.org/jira/browse/PARQUET/PARQUET-1758) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-1758
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [X] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
