### PR TITLE
PARQUET-1767: InternalParquetRecordWriter doesn't immediately limit current row group to threshold

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -51,7 +51,7 @@ class InternalParquetRecordWriter<T> {
   private final Map<String, String> extraMetaData;
   private final long rowGroupSize;
   private long rowGroupSizeThreshold;
-  private long nextRowGroupSize;
+  private volatile long nextRowGroupSize;
   private final BytesCompressor compressor;
   private final boolean validating;
   private final ParquetProperties props;
@@ -186,8 +186,9 @@ class InternalParquetRecordWriter<T> {
     return rowGroupSizeThreshold;
   }
 
-  void setRowGroupSizeThreshold(long rowGroupSizeThreshold) {
+  void updateRowGroupSizeThreshold(long rowGroupSizeThreshold) {
     this.rowGroupSizeThreshold = rowGroupSizeThreshold;
+    this.nextRowGroupSize = Math.min(this.rowGroupSizeThreshold, this.nextRowGroupSize);
   }
 
   MessageType getSchema() {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/MemoryManager.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/MemoryManager.java
@@ -1,4 +1,4 @@
-/* 
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -132,7 +132,7 @@ public class MemoryManager {
           " is smaller than the minimum allocation size of %d bytes.",
               newSize, minMemoryAllocation)){};
       }
-      entry.getKey().setRowGroupSizeThreshold(newSize);
+      entry.getKey().updateRowGroupSizeThreshold(newSize);
       LOG.debug(String.format("Adjust block size from %,d to %,d for writer: %s",
             entry.getValue(), newSize, entry.getKey()));
     }


### PR DESCRIPTION
This PR addresses [PARQUET-1767](https://issues.apache.org/jira/browse/PARQUET-1767)

The MemoryManager adjust the row group size threshold of writers when the allocated memory pool fills up.
**Problem**: However InternalParquetRecordWriter only re-adjusts the row group size on the next flush meaning they still use the old size. 
This opens up a possibility of getting an OOM error if all writers are started at relatively the same time and progress in tandem(I saw this when investigating failing jobs while writing to disk in Spark)