### PR TITLE
Parquet - 1804 :Provide pluggable APIs to support user customized com…

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecConfigurationKeys.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecConfigurationKeys.java
@@ -9,6 +9,5 @@ public class CodecConfigurationKeys extends CommonConfigurationKeys{
 
   /** Customized Compression Codec class name */
   public static final String CUSTOMIZED_COMPRESSION_CODEC_CLASS_NAME =
-    "io.compression.codec.name";
-
+    "io.compression.codec.classname";
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecConfigurationKeys.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecConfigurationKeys.java
@@ -1,5 +1,7 @@
 package org.apache.parquet.hadoop;
 
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+
 public class CodecConfigurationKeys extends CommonConfigurationKeys{
   /** Customized Compression Codec name */
   public static final String CUSTOMIZED_COMPRESSION_CODEC_NAME =

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecConfigurationKeys.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecConfigurationKeys.java
@@ -1,0 +1,12 @@
+package org.apache.parquet.hadoop;
+
+public class CodecConfigurationKeys extends CommonConfigurationKeys{
+  /** Customized Compression Codec name */
+  public static final String CUSTOMIZED_COMPRESSION_CODEC_NAME =
+    "io.compression.codec.name";
+
+  /** Customized Compression Codec class name */
+  public static final String CUSTOMIZED_COMPRESSION_CODEC_CLASS_NAME =
+    "io.compression.codec.name";
+
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecConfigurationKeys.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecConfigurationKeys.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.parquet.hadoop;
 
 import org.apache.hadoop.fs.CommonConfigurationKeys;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -220,14 +220,14 @@ public class CodecFactory implements CompressionCodecFactory {
   protected CompressionCodec getCodec(CompressionCodecName codecName,Configuration conf) {
     String[] configCodecNames = conf.getStrings(CodecConfigurationKeys.CUSTOMIZED_COMPRESSION_CODEC_NAME);
     String codecClassName = null;
-    if(configCodecNames != null && configCodecNames.length > 0 && codecName != null){
+    if(configCodecNames != null && configCodecNames.length > 0 && codecName != null) {
       int codecIdx = Arrays.asList(configCodecNames).indexOf(codecName.toString());
-      if(codecIdx >= 0){
+      if(codecIdx >= 0) {
         String[] configCodecClassNames=conf.getStrings(CodecConfigurationKeys.CUSTOMIZED_COMPRESSION_CODEC_CLASS_NAME);
         codecClassName = configCodecClassNames[codecIdx];
       }
     }
-    if(codecClassName == null ||codecClassName.isEmpty()){
+    if(codecClassName == null ||codecClassName.isEmpty()) {
       codecClassName = codecName.getHadoopCompressionCodecClassName();
     }
     if (codecClassName == null) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -220,10 +220,12 @@ public class CodecFactory implements CompressionCodecFactory {
   protected CompressionCodec getCodec(CompressionCodecName codecName,Configuration conf) {
     String[] configCodecNames = conf.getStrings(CodecConfigurationKeys.CUSTOMIZED_COMPRESSION_CODEC_NAME);
     String codecClassName = null;
-    int codecIdx = Arrays.asList(configCodecNames).indexOf(codecName.toString());
-    if(codecIdx > 0){
-      String[] configCodecClassNames=conf.getStrings(CodecConfigurationKeys.CUSTOMIZED_COMPRESSION_CODEC_CLASS_NAME);
-      codecClassName = configCodecClassNames[codecIdx];
+    if(configCodecNames != null && configCodecNames.length > 0 && codecName != null){
+      int codecIdx = Arrays.asList(configCodecNames).indexOf(codecName.toString());
+      if(codecIdx >= 0){
+        String[] configCodecClassNames=conf.getStrings(CodecConfigurationKeys.CUSTOMIZED_COMPRESSION_CODEC_CLASS_NAME);
+        codecClassName = configCodecClassNames[codecIdx];
+      }
     }
     if(codecClassName == null ||codecClassName.isEmpty()){
       codecClassName = codecName.getHadoopCompressionCodecClassName();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java
@@ -112,7 +112,7 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
   @Override
   protected BytesCompressor createCompressor(final CompressionCodecName codecName) {
 
-    CompressionCodec codec = getCodec(codecName);
+    CompressionCodec codec = getCodec(codecName,configuration);
     if (codec == null) {
       return new NoopCompressor();
     } else if (codecName == CompressionCodecName.SNAPPY) {
@@ -121,13 +121,13 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
     } else {
       // todo: create class similar to the SnappyCompressor for zlib and exclude it as
       // snappy is above since it also generates allocateDirect calls.
-      return new HeapBytesCompressor(codecName);
+      return new HeapBytesCompressor(codecName,configuration);
     }
   }
 
   @Override
   protected BytesDecompressor createDecompressor(final CompressionCodecName codecName) {
-    CompressionCodec codec = getCodec(codecName);
+    CompressionCodec codec = getCodec(codecName,configuration);
     if (codec == null) {
       return new NoopDecompressor();
     } else if (codecName == CompressionCodecName.SNAPPY ) {
@@ -197,9 +197,9 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
     private final Object decompressor;
     private HeapBytesDecompressor extraDecompressor;
     public FullDirectDecompressor(CompressionCodecName codecName){
-      CompressionCodec codec = getCodec(codecName);
+      CompressionCodec codec = getCodec(codecName,configuration);
       this.decompressor = DirectCodecPool.INSTANCE.codec(codec).borrowDirectDecompressor();
-      this.extraDecompressor = new HeapBytesDecompressor(codecName);
+      this.extraDecompressor = new HeapBytesDecompressor(codecName,configuration);
     }
 
     @Override
@@ -252,7 +252,7 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
 
     private HeapBytesDecompressor extraDecompressor;
     public SnappyDecompressor() {
-      this.extraDecompressor = new HeapBytesDecompressor(CompressionCodecName.SNAPPY);
+      this.extraDecompressor = new HeapBytesDecompressor(CompressionCodecName.SNAPPY,configuration);
     }
 
     @Override


### PR DESCRIPTION
…pression codecProvide pluggable APIs to support user customized compression codec

Signed-off-by: Dong <xin.dong@intel.com>

Make sure you have checked _all_ steps below.

### [Parquet - 1804:Provide pluggable APIs to support user customized compression codec](https://issues.apache.org/jira/browse/PARQUET-1804)

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
