### PR TITLE
PARQUET-1776: NIO wrapper for Output/Input File

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/io/LocalInputFile.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/LocalInputFile.java
@@ -1,0 +1,46 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.io;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+public class LocalInputFile implements InputFile {
+  private final Path path;
+
+  private LocalInputFile(Path path) throws IOException {
+    if(! Files.exists(path)) {
+      throw new IOException("Specified local file does not exist");
+    }
+    this.path = path;
+  }
+
+	@Override
+	public long getLength() throws IOException {
+		return Files.size(path);
+	}
+
+	@Override
+	public SeekableInputStream newStream() throws IOException {
+		return new LocalSeekableInputStream(Files.newInputStream(path));
+	}
+}

--- a/parquet-common/src/main/java/org/apache/parquet/io/LocalOutputFile.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/LocalOutputFile.java
@@ -1,0 +1,59 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.io;
+
+import com.sun.tools.doclets.standard.Standard;
+
+import java.io.IOException;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+public class LocalOutputFile implements OutputFile {
+  private final FileSystem fs;
+  private final Path path;
+
+  public LocalOutputFile(FileSystem fs, Path path) {
+    this.fs = fs;
+    this.path = path;
+  }
+
+  @Override
+	public PositionOutputStream create(long blockSizeHint) throws IOException {
+    return new LocalOutputStream(Files.newOutputStream(path, StandardOpenOption.CREATE_NEW));
+	}
+
+	@Override
+	public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+    return new LocalOutputStream(Files.newOutputStream(path));
+  }
+
+	@Override
+	public boolean supportsBlockSize() {
+    return false;
+	}
+
+	@Override
+	public long defaultBlockSize() {
+    return 0;
+	}
+}

--- a/parquet-common/src/main/java/org/apache/parquet/io/LocalOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/LocalOutputStream.java
@@ -1,0 +1,51 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class LocalOutputStream extends PositionOutputStream {
+  private final OutputStream stream;
+
+  public LocalOutputStream(OutputStream stream) {
+    this.stream = stream;
+  }
+
+  public OutputStream getStream() {
+    return stream;
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return 0;
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    stream.write(b);
+  }
+
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    stream.write(b, off, len);
+  }
+}

--- a/parquet-common/src/main/java/org/apache/parquet/io/LocalSeekableInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/LocalSeekableInputStream.java
@@ -1,0 +1,47 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LocalSeekableInputStream extends DelegatingSeekableInputStream {
+  private long pos;
+
+  public LocalSeekableInputStream(InputStream stream) {
+    super(stream);
+    this.pos = 0;
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return pos;
+  }
+
+  @Override
+  public void seek(long newPos) throws IOException {
+    getStream().skip(newPos);
+    pos = newPos;
+  }
+
+  public void resetPos() throws IOException {
+    getStream().reset();
+  }
+}


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
