### PR TITLE
PARQUET-2149:  Async IO implementation for ParquetFileReader

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
@@ -18,10 +18,13 @@
  */
 package org.apache.parquet.column.page;
 
+import java.io.Closeable;
+import java.io.IOException;
+
 /**
  * Reader for a sequence a page from a given column chunk
  */
-public interface PageReader {
+public interface PageReader extends Closeable {
 
   /**
    * @return the dictionary page in that chunk or null if none
@@ -37,4 +40,9 @@ public interface PageReader {
    * @return the next page in that chunk or null if after the last page
    */
   DataPage readPage();
+
+  /**
+   * Close the page reader. By default it is no-op.
+   */
+  default void close() throws IOException {}
 }

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/AsyncMultiBufferInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/AsyncMultiBufferInputStream.java
@@ -1,0 +1,166 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.bytes;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+import org.apache.parquet.io.SeekableInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AsyncMultiBufferInputStream extends MultiBufferInputStream {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncMultiBufferInputStream.class);
+
+  private int fetchIndex = 0;
+  private final SeekableInputStream fileInputStream;
+  private int readIndex = 0;
+  private ExecutorService threadPool;
+  private LinkedBlockingQueue<Future<Void>> readFutures;
+  private boolean closed = false;
+
+  private LongAdder totalTimeBlocked = new LongAdder();
+  private LongAdder totalCountBlocked = new LongAdder();
+  private LongAccumulator maxTimeBlocked = new LongAccumulator(Long::max, 0L);
+
+  AsyncMultiBufferInputStream(
+      ExecutorService threadPool, SeekableInputStream fileInputStream, List<ByteBuffer> buffers) {
+    super(buffers);
+    this.fileInputStream = fileInputStream;
+    this.threadPool = threadPool;
+    readFutures = new LinkedBlockingQueue<>(buffers.size());
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("ASYNC: Begin read into buffers ");
+      for (ByteBuffer buf : buffers) {
+        LOG.debug("ASYNC: buffer {} ", buf);
+      }
+    }
+    fetchAll();
+  }
+
+  private void checkState() {
+    if (closed) {
+      throw new RuntimeException("Stream is closed");
+    }
+  }
+
+  private void fetchAll() {
+    checkState();
+    submitReadTask(0);
+  }
+
+  private void submitReadTask(int bufferNo) {
+    ByteBuffer buffer = buffers.get(bufferNo);
+    try {
+      readFutures.put(threadPool.submit(() -> {
+        readOneBuffer(buffer);
+        if (bufferNo < buffers.size() - 1) {
+          submitReadTask(bufferNo + 1);
+        }
+        return null;
+      }));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void readOneBuffer(ByteBuffer buffer) {
+    long startTime = System.nanoTime();
+    try {
+      fileInputStream.readFully(buffer);
+      buffer.flip();
+      long readCompleted = System.nanoTime();
+      long timeSpent = readCompleted - startTime;
+      LOG.debug("ASYNC Stream: READ - {}", timeSpent / 1000.0);
+      fetchIndex++;
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  @Override
+  public boolean nextBuffer() {
+    checkState();
+    // hack: parent constructor can call this method before this class is fully initialized.
+    // Just return without doing anything.
+    if (readFutures == null) {
+      return false;
+    }
+    if (readIndex < buffers.size()) {
+      long start = System.nanoTime();
+      try {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("ASYNC (next): Getting next buffer");
+        }
+        Future<Void> future = readFutures.take();
+        future.get();
+        long timeSpent = System.nanoTime() - start;
+        totalCountBlocked.add(1);
+        totalTimeBlocked.add(timeSpent);
+        maxTimeBlocked.accumulate(timeSpent);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("ASYNC (next): {}: Time blocked for read {} ns", this, timeSpent);
+        }
+      } catch (InterruptedException | ExecutionException e) {
+        if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+        }
+        LOG.error("Async (next): exception while getting next buffer: ", e);
+        throw new RuntimeException(e);
+      }
+      readIndex++;
+    }
+    return super.nextBuffer();
+  }
+
+  public void close() {
+    LOG.debug(
+        "ASYNC Stream: Blocked: {} {} {}",
+        totalTimeBlocked.longValue() / 1000.0,
+        totalCountBlocked.longValue(),
+        maxTimeBlocked.longValue() / 1000.0);
+    Future<Void> readResult;
+    while (!readFutures.isEmpty()) {
+      try {
+        readResult = readFutures.poll();
+        readResult.get();
+        if (!readResult.isDone() && !readResult.isCancelled()) {
+          readResult.cancel(true);
+        } else {
+          readResult.get(1, TimeUnit.MILLISECONDS);
+        }
+      } catch (ExecutionException | InterruptedException | TimeoutException e) {
+        // Do nothing
+      }
+    }
+    closed = true;
+  }
+}

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/ByteBufferInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/ByteBufferInputStream.java
@@ -25,7 +25,9 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import org.apache.parquet.ShouldNeverHappenException;
+import org.apache.parquet.io.SeekableInputStream;
 
 public class ByteBufferInputStream extends InputStream {
 
@@ -46,6 +48,11 @@ public class ByteBufferInputStream extends InputStream {
     } else {
       return new MultiBufferInputStream(buffers);
     }
+  }
+
+  public static ByteBufferInputStream wrapAsync(
+      ExecutorService threadPool, SeekableInputStream fileInputStream, List<ByteBuffer> buffers) {
+    return new AsyncMultiBufferInputStream(threadPool, fileInputStream, buffers);
   }
 
   ByteBufferInputStream() {

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/MultiBufferInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/MultiBufferInputStream.java
@@ -31,7 +31,7 @@ import java.util.NoSuchElementException;
 class MultiBufferInputStream extends ByteBufferInputStream {
   private static final ByteBuffer EMPTY = ByteBuffer.allocate(0);
 
-  private final List<ByteBuffer> buffers;
+  protected final List<ByteBuffer> buffers;
   private final long length;
 
   private Iterator<ByteBuffer> iterator;
@@ -41,6 +41,11 @@ class MultiBufferInputStream extends ByteBufferInputStream {
   private long mark = -1;
   private long markLimit = 0;
   private List<ByteBuffer> markBuffers = new ArrayList<>();
+
+  @Override
+  public String toString() {
+    return "MultiBufferInputStream{" + "length=" + length + ", current=" + current + ", position=" + position + '}';
+  }
 
   MultiBufferInputStream(List<ByteBuffer> buffers) {
     this.buffers = buffers;
@@ -303,7 +308,7 @@ class MultiBufferInputStream extends ByteBufferInputStream {
     return true;
   }
 
-  private boolean nextBuffer() {
+  protected boolean nextBuffer() {
     if (!iterator.hasNext()) {
       this.current = null;
       return false;

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/SequenceByteBufferInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/SequenceByteBufferInputStream.java
@@ -1,0 +1,268 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.bytes;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ *   A bare minimum implementation of a {@link java.io.SequenceInputStream} that wraps an
+ *   <i>ordered</i> collection of ByteBufferInputStreams.
+ *   <p>
+ *   This class, as implemented, is intended only for a specific use in the ParquetFileReader and
+ *   throws {@link UnsupportedOperationException} in unimplemented methods to catch any unintended
+ *   use in other cases.
+ *   <p>
+ *   Even though this class is derived from ByteBufferInputStream it explicitly does not support any
+ *   byte buffer related methods like slice. It does, however support sliceBuffers which is a
+ *   curious case of reading data from underlying streams
+ *   <p>
+ *   Even though this class changes the state of the underlying streams (by reading from them)
+ *   it does not own them and so the close method does not close the streams. To avoid resource
+ *   leaks the calling code should close the underlying streams
+ */
+public class SequenceByteBufferInputStream extends ByteBufferInputStream {
+
+  Collection<ByteBufferInputStream> collection;
+  Iterator<ByteBufferInputStream> iterator;
+  ByteBufferInputStream current;
+  long position = 0;
+
+  @Override
+  public String toString() {
+    return "SequenceByteBufferInputStream{" + "collection="
+        + collection + ", current="
+        + current + ", position="
+        + position + '}';
+  }
+
+  public SequenceByteBufferInputStream(Collection<ByteBufferInputStream> collection) {
+    this.collection = collection;
+    iterator = collection.iterator();
+    current = iterator.hasNext() ? iterator.next() : null;
+    if (current == null) {
+      throw new UnsupportedOperationException(
+          "Initializing SequenceByteBufferInputStream with an empty collection is not supported");
+    }
+  }
+
+  @Override
+  public long position() {
+    return position;
+  }
+
+  @Override
+  public int read(ByteBuffer out) {
+    int len = out.remaining();
+    if (len <= 0) {
+      return 0;
+    }
+    if (current == null) {
+      return -1;
+    }
+    int totalBytesRead = 0;
+    while (totalBytesRead < len) {
+      int bytesRead = current.read(out);
+      if (bytesRead == -1) {
+        if (iterator.hasNext()) {
+          current = iterator.next();
+        } else {
+          break;
+        }
+      } else {
+        totalBytesRead += bytesRead;
+      }
+    }
+    position += totalBytesRead;
+    return totalBytesRead;
+  }
+
+  @Override
+  public ByteBuffer slice(int length) throws EOFException {
+    throw new UnsupportedOperationException("slice is not supported");
+  }
+
+  @Override
+  /**
+   * This is a blocking call. Use with care when using in asynchronous mode.
+   */
+  public List<ByteBuffer> sliceBuffers(long len) throws EOFException {
+    if (len <= 0) {
+      return Collections.emptyList();
+    }
+
+    if (current == null) {
+      throw new EOFException();
+    }
+
+    List<ByteBuffer> buffers = new ArrayList<>();
+    long bytesAccumulated = 0;
+    while (bytesAccumulated < len) {
+      // This is not strictly according to the input stream contract, but once again the
+      // underlying implementations of ByteBufferInputStream return the available bytes
+      // based on the size of the underlying buffers rather than the bytes currently read
+      // into the buffers. This works for us because the underlying implementations will
+      // actually fill the buffers with the data before returning the slices we ask for
+      // (which is why this is a blocking call)
+      if (current.available() > 0) {
+        int bufLen = (int) Math.min(len - bytesAccumulated, current.available());
+        List<ByteBuffer> currentSlices = current.sliceBuffers(bufLen);
+        buffers.addAll(currentSlices);
+        bytesAccumulated += bufLen;
+
+        // update state; the bytes are considered read
+        this.position += bufLen;
+      } else {
+        if (iterator.hasNext()) {
+          current = iterator.next();
+        } else {
+          // there are no more streams
+          throw new EOFException();
+        }
+      }
+    }
+    position += bytesAccumulated;
+    return buffers;
+  }
+
+  @Override
+  public ByteBufferInputStream sliceStream(long length) throws EOFException {
+    throw new UnsupportedOperationException("sliceStream is not supported");
+  }
+
+  @Override
+  public List<ByteBuffer> remainingBuffers() {
+    throw new UnsupportedOperationException("remainingBuffers is not supported");
+  }
+
+  @Override
+  public ByteBufferInputStream remainingStream() {
+    throw new UnsupportedOperationException("remainingStream is not supported");
+  }
+
+  @Override
+  public int read() throws IOException {
+    int val;
+    while (true) {
+      try {
+        val = current.read() & 0xFF; // as unsigned
+        position += 1;
+        break;
+      } catch (EOFException e) {
+        if (iterator.hasNext()) {
+          current = iterator.next();
+        } else {
+          return -1;
+        }
+      }
+    }
+    return val;
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    if (len <= 0) {
+      if (len < 0) {
+        throw new IndexOutOfBoundsException("Read length must be greater than 0: " + len);
+      }
+      return 0;
+    }
+    if (current == null) {
+      return -1;
+    }
+    int totalBytes = 0;
+    while (totalBytes < len) {
+      int bytesRead = current.read(b, off + totalBytes, len - totalBytes);
+      if (bytesRead == -1) {
+        if (iterator.hasNext()) {
+          current = iterator.next();
+        } else {
+          break;
+        }
+      } else {
+        totalBytes += bytesRead;
+      }
+    }
+    position += totalBytes;
+    return totalBytes;
+  }
+
+  @Override
+  public long skip(long n) {
+    if (n <= 0) {
+      if (n < 0) {
+        throw new IndexOutOfBoundsException("Skip length must be greater than 0: " + n);
+      }
+      return 0;
+    }
+    if (current == null) {
+      return -1;
+    }
+    long totalBytesSkipped = 0;
+    while (totalBytesSkipped < n) {
+      long bytesSkipped = current.skip(n - totalBytesSkipped);
+      // the contract for skip specifies that skip may return 0 if EOF is reached in which case
+      // we have no good way of knowing the end of stream has been reached. We depend on the
+      // fact that all implementations of ByteBufferInputStream return -1 on EOF
+      if (bytesSkipped == -1) {
+        if (iterator.hasNext()) {
+          current = iterator.next();
+        } else {
+          break;
+        }
+      } else {
+        totalBytesSkipped += bytesSkipped;
+      }
+    }
+    position += totalBytesSkipped;
+    return totalBytesSkipped;
+  }
+
+  @Override
+  public int available() {
+    return current.available();
+  }
+
+  @Override
+  public void close() throws IOException {
+    super.close();
+  }
+
+  @Override
+  public void mark(int readlimit) {
+    throw new UnsupportedOperationException("mark is not supported");
+  }
+
+  @Override
+  public void reset() throws IOException {
+    throw new UnsupportedOperationException("reset is not supported");
+  }
+
+  @Override
+  public boolean markSupported() {
+    return false;
+  }
+}

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestAsyncMultiBufferInputStream.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestAsyncMultiBufferInputStream.java
@@ -1,0 +1,253 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.bytes;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.parquet.io.DelegatingSeekableInputStream;
+import org.apache.parquet.io.SeekableInputStream;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TestAsyncMultiBufferInputStream extends TestMultiBufferInputStream {
+  private static final List<ByteBuffer> DATA = Arrays.asList(
+      ByteBuffer.allocate(9),
+      ByteBuffer.allocate(4),
+      ByteBuffer.allocate(0),
+      ByteBuffer.allocate(12),
+      ByteBuffer.allocate(1),
+      ByteBuffer.allocate(7),
+      ByteBuffer.allocate(2));
+
+  private static final List<ByteBuffer> WRITEDATA = Arrays.asList(
+      ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8}),
+      ByteBuffer.wrap(new byte[] {9, 10, 11, 12}),
+      ByteBuffer.wrap(new byte[] {}),
+      ByteBuffer.wrap(new byte[] {13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24}),
+      ByteBuffer.wrap(new byte[] {25}),
+      ByteBuffer.wrap(new byte[] {26, 27, 28, 29, 30, 31, 32}),
+      ByteBuffer.wrap(new byte[] {33, 34}));
+
+  private static Path tempPath;
+  private static String filename;
+  private static SeekableInputStream seekableInputStream;
+  private static ExecutorService threadPool = Executors.newFixedThreadPool(
+      Runtime.getRuntime().availableProcessors() * 2, r -> new Thread(r, "test-parquet-async-io"));
+
+  @BeforeClass
+  public static void init() throws IOException {
+    tempPath = Files.createTempDirectory("asyncstream");
+    filename = tempPath.toAbsolutePath() + "/async_mbinput";
+    OutputStream outputStream = new FileOutputStream(filename);
+    for (ByteBuffer writedatum : WRITEDATA) {
+      outputStream.write(writedatum.array());
+    }
+  }
+
+  @AfterClass
+  public static void close() throws IOException {
+    threadPool.shutdownNow();
+    Files.deleteIfExists(Paths.get(filename));
+    Files.deleteIfExists(tempPath);
+  }
+
+  @Override
+  protected ByteBufferInputStream newStream() {
+    try {
+      seekableInputStream = new LocalFSInputStream(new FileInputStream(filename));
+    } catch (FileNotFoundException e) {
+      throw new RuntimeException("Failed to initialize test input stream.", e);
+    }
+    AsyncMultiBufferInputStream stream = new AsyncMultiBufferInputStream(threadPool, seekableInputStream, DATA);
+    stream.nextBuffer();
+    return stream;
+  }
+
+  @Override
+  protected void checkOriginalData() {
+    for (ByteBuffer buffer : DATA) {
+      Assert.assertEquals("Position should not change", 0, buffer.position());
+      Assert.assertEquals("Limit should not change", buffer.array().length, buffer.limit());
+    }
+  }
+
+  @Test
+  public void testSliceData() throws Exception {
+    ByteBufferInputStream stream = newStream();
+    int length = stream.available();
+
+    List<ByteBuffer> buffers = new ArrayList<>();
+    // slice the stream into 3 8-byte buffers and 1 2-byte buffer
+    while (stream.available() > 0) {
+      int bytesToSlice = Math.min(stream.available(), 8);
+      buffers.add(stream.slice(bytesToSlice));
+    }
+
+    Assert.assertEquals("Position should be at end", length, stream.position());
+    Assert.assertEquals("Should produce 5 buffers", 5, buffers.size());
+
+    int i = 0;
+
+    // one is a view of the first buffer because it is smaller
+    ByteBuffer one = buffers.get(0);
+    Assert.assertSame(
+        "Should be a duplicate of the first array",
+        one.array(),
+        DATA.get(0).array());
+    Assert.assertEquals(8, one.remaining());
+    Assert.assertEquals(0, one.position());
+    Assert.assertEquals(8, one.limit());
+    Assert.assertEquals(9, one.capacity());
+    for (; i < 8; i += 1) {
+      Assert.assertEquals("Should produce correct values", i, one.get());
+    }
+
+    // two should be a copy of the next 8 bytes
+    ByteBuffer two = buffers.get(1);
+    Assert.assertEquals(8, two.remaining());
+    Assert.assertEquals(0, two.position());
+    Assert.assertEquals(8, two.limit());
+    Assert.assertEquals(8, two.capacity());
+    for (; i < 16; i += 1) {
+      Assert.assertEquals("Should produce correct values", i, two.get());
+    }
+
+    // three is a copy of part of the 4th buffer
+    ByteBuffer three = buffers.get(2);
+    Assert.assertSame(
+        "Should be a duplicate of the fourth array",
+        three.array(),
+        DATA.get(3).array());
+    Assert.assertEquals(8, three.remaining());
+    Assert.assertEquals(3, three.position());
+    Assert.assertEquals(11, three.limit());
+    Assert.assertEquals(12, three.capacity());
+    for (; i < 24; i += 1) {
+      Assert.assertEquals("Should produce correct values", i, three.get());
+    }
+
+    // four should be a copy of the next 8 bytes
+    ByteBuffer four = buffers.get(3);
+    Assert.assertEquals(8, four.remaining());
+    Assert.assertEquals(0, four.position());
+    Assert.assertEquals(8, four.limit());
+    Assert.assertEquals(8, four.capacity());
+    for (; i < 32; i += 1) {
+      Assert.assertEquals("Should produce correct values", i, four.get());
+    }
+
+    // five should be a copy of the next 8 bytes
+    ByteBuffer five = buffers.get(4);
+    Assert.assertEquals(3, five.remaining());
+    Assert.assertEquals(0, five.position());
+    Assert.assertEquals(3, five.limit());
+    Assert.assertEquals(3, five.capacity());
+    for (; i < 35; i += 1) {
+      Assert.assertEquals("Should produce correct values", i, five.get());
+    }
+  }
+
+  public static class LocalFSInputStream extends DelegatingSeekableInputStream {
+
+    long pos = 0;
+    private final InputStream stream;
+
+    public LocalFSInputStream(InputStream stream) {
+      super(stream);
+      this.stream = stream;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return pos;
+    }
+
+    @Override
+    public void seek(long newPos) throws IOException {
+      long skipBytes;
+      if (newPos < pos) {
+        stream.reset();
+        skipBytes = newPos;
+      } else {
+        skipBytes = newPos - pos;
+      }
+      while (skipBytes > 0) {
+        long n = stream.skip(skipBytes);
+        if (n == 0) break;
+        skipBytes -= n;
+      }
+      pos = newPos - skipBytes;
+    }
+
+    @Override
+    public int read() throws IOException {
+      pos++;
+      return super.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      pos += len;
+      return super.read(b, off, len);
+    }
+
+    @Override
+    public void readFully(byte[] bytes) throws IOException {
+      pos += bytes.length;
+      super.readFully(bytes);
+    }
+
+    @Override
+    public void readFully(byte[] bytes, int start, int len) throws IOException {
+      pos += len - start;
+      super.readFully(bytes, start, len);
+    }
+
+    @Override
+    public int read(ByteBuffer buf) throws IOException {
+      int n = super.read(buf);
+      if (n > 0) {
+        pos += n;
+      }
+      return n;
+    }
+
+    @Override
+    public void readFully(ByteBuffer buf) throws IOException {
+      pos += buf.remaining();
+      super.readFully(buf);
+    }
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/HadoopReadOptions.java
@@ -20,6 +20,7 @@
 package org.apache.parquet;
 
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.bytes.ByteBufferAllocator;
@@ -44,6 +45,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
       boolean useBloomFilter,
       boolean useOffHeapDecryptBuffer,
       boolean useHadoopVectoredIo,
+      boolean enableAsyncIOReader,
+      boolean enableParallelColumnReader,
       FilterCompat.Filter recordFilter,
       MetadataFilter metadataFilter,
       CompressionCodecFactory codecFactory,
@@ -52,6 +55,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
       Map<String, String> properties,
       Configuration conf,
       FileDecryptionProperties fileDecryptionProperties,
+      ExecutorService ioThreadPool,
+      ExecutorService processThreadPool,
       ParquetMetricsCallback metricsCallback) {
     super(
         useSignedStringMinMax,
@@ -63,6 +68,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
         useBloomFilter,
         useOffHeapDecryptBuffer,
         useHadoopVectoredIo,
+        enableAsyncIOReader,
+        enableParallelColumnReader,
         recordFilter,
         metadataFilter,
         codecFactory,
@@ -70,6 +77,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
         maxAllocationSize,
         properties,
         fileDecryptionProperties,
+        ioThreadPool,
+        processThreadPool,
         metricsCallback,
         new HadoopParquetConfiguration(conf));
     this.conf = conf;
@@ -126,6 +135,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
           useBloomFilter,
           useOffHeapDecryptBuffer,
           useHadoopVectoredIo,
+          enableAsyncIOReader,
+          enableParallelColumnReader,
           recordFilter,
           metadataFilter,
           codecFactory,
@@ -134,6 +145,8 @@ public class HadoopReadOptions extends ParquetReadOptions {
           properties,
           conf,
           fileDecryptionProperties,
+          ioThreadPool,
+          processThreadPool,
           metricsCallback);
     }
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/InternalFileDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/InternalFileDecryptor.java
@@ -60,10 +60,7 @@ public class InternalFileDecryptor {
 
   private BlockCipher.Decryptor getThriftModuleDecryptor(byte[] columnKey) {
     if (null == columnKey) { // Decryptor with footer key
-      if (null == aesGcmDecryptorWithFooterKey) {
-        aesGcmDecryptorWithFooterKey = ModuleCipherFactory.getDecryptor(AesMode.GCM, footerKey);
-      }
-      return aesGcmDecryptorWithFooterKey;
+      return ModuleCipherFactory.getDecryptor(AesMode.GCM, footerKey);
     } else { // Decryptor with column key
       return ModuleCipherFactory.getDecryptor(AesMode.GCM, columnKey);
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/FilePageReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/FilePageReader.java
@@ -1,0 +1,392 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAccumulator;
+import java.util.concurrent.atomic.LongAdder;
+import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.DataPageV1;
+import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.page.DictionaryPage;
+import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
+import org.apache.parquet.crypto.AesCipher;
+import org.apache.parquet.crypto.ModuleCipherFactory.ModuleType;
+import org.apache.parquet.format.BlockCipher;
+import org.apache.parquet.format.BlockCipher.Decryptor;
+import org.apache.parquet.format.DataPageHeader;
+import org.apache.parquet.format.DataPageHeaderV2;
+import org.apache.parquet.format.DictionaryPageHeader;
+import org.apache.parquet.format.PageHeader;
+import org.apache.parquet.hadoop.ParquetFileReader.Chunk;
+import org.apache.parquet.io.ParquetDecodingException;
+import org.apache.parquet.schema.PrimitiveType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Encapsulates the reading of a single page.
+ */
+public class FilePageReader implements Closeable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FilePageReader.class);
+
+  private final ParquetFileReader parquetFileReader;
+  private final Chunk chunk;
+  private final int currentBlock;
+  private final BlockCipher.Decryptor headerBlockDecryptor;
+  private final BlockCipher.Decryptor pageBlockDecryptor;
+  private final byte[] aadPrefix;
+  private final int rowGroupOrdinal;
+  private final int columnOrdinal;
+
+  // state
+  private final LinkedBlockingDeque<Optional<DataPage>> pagesInChunk = new LinkedBlockingDeque<>();
+  private DictionaryPage dictionaryPage = null;
+  private int pageIndex = 0;
+  private long valuesCountReadSoFar = 0;
+  private int dataPageCountReadSoFar = 0;
+
+  // derived
+  private final PrimitiveType type;
+  private final byte[] dataPageAAD;
+  private byte[] dataPageHeaderAAD = null;
+
+  private final BytesInputDecompressor decompressor;
+
+  private final ConcurrentLinkedQueue<Future<Void>> readFutures = new ConcurrentLinkedQueue<>();
+
+  private final LongAdder totalTimeReadOnePage = new LongAdder();
+  private final LongAdder totalCountReadOnePage = new LongAdder();
+  private final LongAccumulator maxTimeReadOnePage = new LongAccumulator(Long::max, 0L);
+  private final LongAdder totalTimeBlockedPagesInChunk = new LongAdder();
+  private final LongAdder totalCountBlockedPagesInChunk = new LongAdder();
+  private final LongAccumulator maxTimeBlockedPagesInChunk = new LongAccumulator(Long::max, 0L);
+
+  public FilePageReader(
+      ParquetFileReader parquetFileReader,
+      Chunk chunk,
+      int currentBlock,
+      Decryptor headerBlockDecryptor,
+      Decryptor pageBlockDecryptor,
+      byte[] aadPrefix,
+      int rowGroupOrdinal,
+      int columnOrdinal,
+      BytesInputDecompressor decompressor) {
+    this.parquetFileReader = parquetFileReader;
+    this.chunk = chunk;
+    this.currentBlock = currentBlock;
+    this.headerBlockDecryptor = headerBlockDecryptor;
+    this.pageBlockDecryptor = pageBlockDecryptor;
+    this.aadPrefix = aadPrefix;
+    this.rowGroupOrdinal = rowGroupOrdinal;
+    this.columnOrdinal = columnOrdinal;
+    this.decompressor = decompressor;
+
+    this.type = parquetFileReader
+        .getFileMetaData()
+        .getSchema()
+        .getType(chunk.getDescriptor().getCol().getPath())
+        .asPrimitiveType();
+
+    if (null != headerBlockDecryptor) {
+      dataPageHeaderAAD = AesCipher.createModuleAAD(
+          aadPrefix,
+          ModuleType.DataPageHeader,
+          rowGroupOrdinal,
+          columnOrdinal,
+          chunk.getPageOrdinal(dataPageCountReadSoFar));
+    }
+    if (null != pageBlockDecryptor) {
+      dataPageAAD = AesCipher.createModuleAAD(aadPrefix, ModuleType.DataPage, rowGroupOrdinal, columnOrdinal, 0);
+    } else {
+      dataPageAAD = null;
+    }
+  }
+
+  public DictionaryPage getDictionaryPage() {
+    return this.dictionaryPage;
+  }
+
+  public LinkedBlockingDeque<Optional<DataPage>> getPagesInChunk() {
+    return this.pagesInChunk;
+  }
+
+  void readAllRemainingPagesAsync() {
+    readFutures.offer(parquetFileReader.options.getProcessThreadPool().submit(new FilePageReaderTask(this)));
+  }
+
+  void readAllRemainingPages() throws IOException {
+    while (hasMorePages(valuesCountReadSoFar, dataPageCountReadSoFar)) {
+      readOnePage();
+    }
+    if (chunk.offsetIndex == null
+        && valuesCountReadSoFar != chunk.getDescriptor().getMetadata().getValueCount()) {
+      // Would be nice to have a CorruptParquetFileException or something as a subclass?
+      throw new IOException(
+          "Expected " + chunk.getDescriptor().getMetadata().getValueCount()
+              + " values in column chunk at " + parquetFileReader.getPath()
+              + " offset "
+              + chunk.descriptor.getMetadata().getFirstDataPageOffset() + " but got "
+              + valuesCountReadSoFar + " values instead over " + pagesInChunk.size()
+              + " pages ending at file offset "
+              + (chunk.getDescriptor().getFileOffset() + chunk.stream.position()));
+    }
+    try {
+      pagesInChunk.put(Optional.empty()); // add a marker for end of data
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while reading page data", e);
+    }
+  }
+
+  void readOnePage() throws IOException {
+    long startRead = System.nanoTime();
+    try {
+      byte[] pageHeaderAAD = dataPageHeaderAAD;
+      if (null != headerBlockDecryptor) {
+        // Important: this verifies file integrity (makes sure dictionary page had not been removed)
+        if (null == dictionaryPage
+            && chunk.getDescriptor().getMetadata().hasDictionaryPage()) {
+          pageHeaderAAD = AesCipher.createModuleAAD(
+              aadPrefix, ModuleType.DictionaryPageHeader, rowGroupOrdinal, columnOrdinal, -1);
+        } else {
+          int pageOrdinal = chunk.getPageOrdinal(dataPageCountReadSoFar);
+          AesCipher.quickUpdatePageAAD(dataPageHeaderAAD, pageOrdinal);
+        }
+      }
+      PageHeader pageHeader = chunk.readPageHeader(headerBlockDecryptor, pageHeaderAAD);
+      int uncompressedPageSize = pageHeader.getUncompressed_page_size();
+      int compressedPageSize = pageHeader.getCompressed_page_size();
+      final BytesInput pageBytes;
+      switch (pageHeader.type) {
+        case DICTIONARY_PAGE:
+          // there is only one dictionary page per column chunk
+          if (dictionaryPage != null) {
+            throw new ParquetDecodingException("more than one dictionary page in column "
+                + chunk.getDescriptor().getCol());
+          }
+          pageBytes = chunk.readAsBytesInput(compressedPageSize);
+          if (parquetFileReader.options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
+            chunk.verifyCrc(
+                pageHeader.getCrc(),
+                pageBytes,
+                "could not verify dictionary page integrity, CRC checksum verification failed");
+          }
+          DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
+          DictionaryPage compressedDictionaryPage = new DictionaryPage(
+              pageBytes,
+              uncompressedPageSize,
+              dicHeader.getNum_values(),
+              parquetFileReader.converter.getEncoding(dicHeader.getEncoding()));
+          // Copy crc to new page, used for testing
+          if (pageHeader.isSetCrc()) {
+            compressedDictionaryPage.setCrc(pageHeader.getCrc());
+          }
+          dictionaryPage = compressedDictionaryPage;
+          break;
+        case DATA_PAGE:
+          DataPageHeader dataHeaderV1 = pageHeader.getData_page_header();
+          pageBytes = chunk.readAsBytesInput(compressedPageSize);
+          if (null != pageBlockDecryptor) {
+            AesCipher.quickUpdatePageAAD(dataPageAAD, chunk.getPageOrdinal(pageIndex));
+          }
+          if (parquetFileReader.options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
+            chunk.verifyCrc(
+                pageHeader.getCrc(),
+                pageBytes,
+                "could not verify page integrity, CRC checksum verification failed");
+          }
+          DataPageV1 dataPageV1 = new DataPageV1(
+              pageBytes,
+              dataHeaderV1.getNum_values(),
+              uncompressedPageSize,
+              parquetFileReader.converter.fromParquetStatistics(
+                  parquetFileReader.getFileMetaData().getCreatedBy(),
+                  dataHeaderV1.getStatistics(),
+                  type),
+              parquetFileReader.converter.getEncoding(dataHeaderV1.getRepetition_level_encoding()),
+              parquetFileReader.converter.getEncoding(dataHeaderV1.getDefinition_level_encoding()),
+              parquetFileReader.converter.getEncoding(dataHeaderV1.getEncoding()));
+          // Copy crc to new page, used for testing
+          if (pageHeader.isSetCrc()) {
+            dataPageV1.setCrc(pageHeader.getCrc());
+          }
+          writePageToChunk(dataPageV1);
+          valuesCountReadSoFar += dataHeaderV1.getNum_values();
+          ++dataPageCountReadSoFar;
+          pageIndex++;
+          break;
+        case DATA_PAGE_V2:
+          DataPageHeaderV2 dataHeaderV2 = pageHeader.getData_page_header_v2();
+          int dataSize = compressedPageSize
+              - dataHeaderV2.getRepetition_levels_byte_length()
+              - dataHeaderV2.getDefinition_levels_byte_length();
+          if (null != pageBlockDecryptor) {
+            AesCipher.quickUpdatePageAAD(dataPageAAD, chunk.getPageOrdinal(pageIndex));
+          }
+          final BytesInput repetitionLevels =
+              chunk.readAsBytesInput(dataHeaderV2.getRepetition_levels_byte_length());
+          final BytesInput definitionLevels =
+              chunk.readAsBytesInput(dataHeaderV2.getDefinition_levels_byte_length());
+          final BytesInput values = chunk.readAsBytesInput(dataSize);
+          if (parquetFileReader.options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
+            pageBytes = BytesInput.concat(repetitionLevels, definitionLevels, values);
+            chunk.verifyCrc(
+                pageHeader.getCrc(),
+                pageBytes,
+                "could not verify page integrity, CRC checksum verification failed");
+          }
+          DataPage dataPageV2 = new DataPageV2(
+              dataHeaderV2.getNum_rows(),
+              dataHeaderV2.getNum_nulls(),
+              dataHeaderV2.getNum_values(),
+              repetitionLevels,
+              definitionLevels,
+              parquetFileReader.converter.getEncoding(dataHeaderV2.getEncoding()),
+              values,
+              uncompressedPageSize,
+              parquetFileReader.converter.fromParquetStatistics(
+                  parquetFileReader.getFileMetaData().getCreatedBy(),
+                  dataHeaderV2.getStatistics(),
+                  type),
+              dataHeaderV2.isIs_compressed());
+          // Copy crc to new page, used for testing
+          if (pageHeader.isSetCrc()) {
+            dataPageV2.setCrc(pageHeader.getCrc());
+          }
+          writePageToChunk(dataPageV2);
+          valuesCountReadSoFar += dataHeaderV2.getNum_values();
+          ++dataPageCountReadSoFar;
+          pageIndex++;
+          break;
+        default:
+          LOG.debug("skipping page of type {} of size {}", pageHeader.getType(), compressedPageSize);
+          chunk.stream.skipFully(compressedPageSize);
+          break;
+      }
+    } catch (Exception e) {
+      LOG.info(
+          "Exception while reading one more page for: [{} ]: {} ",
+          Thread.currentThread().getName(),
+          this);
+      throw e;
+    } finally {
+      long timeSpentInRead = System.nanoTime() - startRead;
+      totalCountReadOnePage.add(1);
+      totalTimeReadOnePage.add(timeSpentInRead);
+      maxTimeReadOnePage.accumulate(timeSpentInRead);
+    }
+  }
+
+  private void writePageToChunk(DataPage page) {
+    long writeStart = System.nanoTime();
+    try {
+      pagesInChunk.put(Optional.of(page));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while reading page data", e);
+    }
+    long timeSpent = System.nanoTime() - writeStart;
+    totalTimeBlockedPagesInChunk.add(timeSpent);
+    totalCountBlockedPagesInChunk.add(1);
+    maxTimeBlockedPagesInChunk.accumulate(timeSpent);
+  }
+
+  private boolean hasMorePages(long valuesCountReadSoFar, int dataPageCountReadSoFar) {
+    return chunk.offsetIndex == null
+        ? valuesCountReadSoFar < chunk.getDescriptor().getMetadata().getValueCount()
+        : dataPageCountReadSoFar < chunk.offsetIndex.getPageCount();
+  }
+
+  @Override
+  public void close() throws IOException {
+    Future<Void> readResult;
+    while (!readFutures.isEmpty()) {
+      try {
+        readResult = readFutures.poll();
+        readResult.get();
+        if (!readResult.isDone() && !readResult.isCancelled()) {
+          readResult.cancel(true);
+        } else {
+          readResult.get(1, TimeUnit.MILLISECONDS);
+        }
+      } catch (Exception e) {
+        // Do nothing
+      }
+    }
+    if (LOG.isDebugEnabled()) {
+      String mode = parquetFileReader.isParallelColumnReaderEnabled() ? "ASYNC" : "SYNC";
+      LOG.debug(
+          "File Page Reader stats: {}, {}, {}, {}, {}, {}, {}",
+          mode,
+          totalTimeReadOnePage.longValue() / 1000.0,
+          totalCountReadOnePage.longValue(),
+          maxTimeReadOnePage.longValue() / 1000.0,
+          totalTimeBlockedPagesInChunk.longValue() / 1000.0,
+          totalCountBlockedPagesInChunk.longValue(),
+          maxTimeBlockedPagesInChunk.longValue() / 1000.0);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "PageReader{" + "chunk="
+        + chunk + ", currentBlock="
+        + currentBlock + ", headerBlockDecryptor="
+        + headerBlockDecryptor + ", pageBlockDecryptor="
+        + pageBlockDecryptor + ", aadPrefix="
+        + Arrays.toString(aadPrefix) + ", rowGroupOrdinal="
+        + rowGroupOrdinal + ", columnOrdinal="
+        + columnOrdinal + ", pagesInChunk="
+        + pagesInChunk + ", dictionaryPage="
+        + dictionaryPage + ", pageIndex="
+        + pageIndex + ", valuesCountReadSoFar="
+        + valuesCountReadSoFar + ", dataPageCountReadSoFar="
+        + dataPageCountReadSoFar + ", type="
+        + type + ", dataPageAAD="
+        + Arrays.toString(dataPageAAD) + ", dataPageHeaderAAD="
+        + Arrays.toString(dataPageHeaderAAD) + ", decompressor="
+        + decompressor + '}';
+  }
+
+  private static class FilePageReaderTask implements Callable<Void> {
+
+    final FilePageReader filePageReader;
+
+    FilePageReaderTask(FilePageReader filePageReader) {
+      this.filePageReader = filePageReader;
+    }
+
+    @Override
+    public Void call() throws Exception {
+      filePageReader.readAllRemainingPages();
+      return null;
+    }
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -48,12 +48,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -69,10 +71,9 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.ByteBufferReleaser;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.ReusingByteBufferAllocator;
+import org.apache.parquet.bytes.SequenceByteBufferInputStream;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.DataPage;
-import org.apache.parquet.column.page.DataPageV1;
-import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.DictionaryPageReadStore;
 import org.apache.parquet.column.page.PageReadStore;
@@ -89,8 +90,6 @@ import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.compat.RowGroupFilter;
 import org.apache.parquet.format.BlockCipher;
 import org.apache.parquet.format.BloomFilterHeader;
-import org.apache.parquet.format.DataPageHeader;
-import org.apache.parquet.format.DataPageHeaderV2;
 import org.apache.parquet.format.DictionaryPageHeader;
 import org.apache.parquet.format.FileCryptoMetaData;
 import org.apache.parquet.format.PageHeader;
@@ -118,7 +117,6 @@ import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.ParquetFileRange;
 import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.util.AutoCloseables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,7 +132,7 @@ public class ParquetFileReader implements Closeable {
 
   public static final long HADOOP_VECTORED_READ_TIMEOUT_SECONDS = 300;
 
-  private final ParquetMetadataConverter converter;
+  final ParquetMetadataConverter converter;
 
   private final CRC32 crc;
   private final ReusingByteBufferAllocator crcAllocator;
@@ -144,7 +142,7 @@ public class ParquetFileReader implements Closeable {
    * If a summary file is found it is used otherwise the file footer is used.
    *
    * @param configuration the hadoop conf to connect to the file system;
-   * @param partFiles     the part files to read
+   * @param partFiles the part files to read
    * @return the footers for those files using the summary file if possible.
    * @throws IOException if there is an exception while reading footers
    * @deprecated metadata files are not recommended and will be removed in 2.0.0
@@ -164,7 +162,7 @@ public class ParquetFileReader implements Closeable {
    * If a summary file is found it is used otherwise the file footer is used.
    *
    * @param configuration the hadoop conf to connect to the file system;
-   * @param partFiles     the part files to read
+   * @param partFiles the part files to read
    * @param skipRowGroups to skipRowGroups in the footers
    * @return the footers for those files using the summary file if possible.
    * @throws IOException if there is an exception while reading footers
@@ -265,7 +263,7 @@ public class ParquetFileReader implements Closeable {
 
   /**
    * @param configuration the conf to access the File System
-   * @param partFiles     the files to read
+   * @param partFiles the files to read
    * @return the footers
    * @throws IOException if an exception was raised while reading footers
    * @deprecated metadata files are not recommended and will be removed in 2.0.0
@@ -281,12 +279,12 @@ public class ParquetFileReader implements Closeable {
    * (not using summary files)
    *
    * @param configuration the conf to access the File System
-   * @param partFiles     the files to read
+   * @param partFiles the files to read
    * @param skipRowGroups to skip the rowGroup info
    * @return the footers
    * @throws IOException if there is an exception while reading footers
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static List<Footer> readAllFootersInParallel(
@@ -315,12 +313,12 @@ public class ParquetFileReader implements Closeable {
    * not using summary files.
    *
    * @param configuration a configuration
-   * @param fileStatus    a file status to recursively list
+   * @param fileStatus a file status to recursively list
    * @param skipRowGroups whether to skip reading row group metadata
    * @return a list of footers
    * @throws IOException if an exception is thrown while reading the footers
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static List<Footer> readAllFootersInParallel(
@@ -335,11 +333,11 @@ public class ParquetFileReader implements Closeable {
    * rowGroups are not skipped
    *
    * @param configuration the configuration to access the FS
-   * @param fileStatus    the root dir
+   * @param fileStatus the root dir
    * @return all the footers
    * @throws IOException if an exception is thrown while reading the footers
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static List<Footer> readAllFootersInParallel(Configuration configuration, FileStatus fileStatus)
@@ -349,11 +347,11 @@ public class ParquetFileReader implements Closeable {
 
   /**
    * @param configuration a configuration
-   * @param path          a file path
+   * @param path a file path
    * @return a list of footers
    * @throws IOException if an exception is thrown while reading the footers
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static List<Footer> readFooters(Configuration configuration, Path path) throws IOException {
@@ -368,11 +366,11 @@ public class ParquetFileReader implements Closeable {
    * this always returns the row groups
    *
    * @param configuration a configuration
-   * @param pathStatus    a file status to read footers from
+   * @param pathStatus a file status to read footers from
    * @return a list of footers
    * @throws IOException if an exception is thrown while reading the footers
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static List<Footer> readFooters(Configuration configuration, FileStatus pathStatus) throws IOException {
@@ -384,12 +382,12 @@ public class ParquetFileReader implements Closeable {
    * using summary files if possible
    *
    * @param configuration the configuration to access the FS
-   * @param pathStatus    the root dir
+   * @param pathStatus the root dir
    * @param skipRowGroups whether to skip reading row group metadata
    * @return all the footers
    * @throws IOException if an exception is thrown while reading the footers
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static List<Footer> readFooters(Configuration configuration, FileStatus pathStatus, boolean skipRowGroups)
@@ -479,11 +477,11 @@ public class ParquetFileReader implements Closeable {
    * Reads the meta data block in the footer of the file
    *
    * @param configuration a configuration
-   * @param file          the parquet File
+   * @param file the parquet File
    * @return the metadata blocks in the footer
    * @throws IOException if an error occurs while reading the file
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static final ParquetMetadata readFooter(Configuration configuration, Path file) throws IOException {
@@ -495,12 +493,12 @@ public class ParquetFileReader implements Closeable {
    * Skipping row groups (or not) based on the provided filter
    *
    * @param configuration a configuration
-   * @param file          the Parquet File
-   * @param filter        the filter to apply to row groups
+   * @param file the Parquet File
+   * @param filter the filter to apply to row groups
    * @return the metadata with row groups filtered.
-   * @throws IOException if an error occurs while reading the file
+   * @throws IOException  if an error occurs while reading the file
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static ParquetMetadata readFooter(Configuration configuration, Path file, MetadataFilter filter)
@@ -510,11 +508,11 @@ public class ParquetFileReader implements Closeable {
 
   /**
    * @param configuration a configuration
-   * @param file          the Parquet File
+   * @param file the Parquet File
    * @return the metadata with row groups.
-   * @throws IOException if an error occurs while reading the file
+   * @throws IOException  if an error occurs while reading the file
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static final ParquetMetadata readFooter(Configuration configuration, FileStatus file) throws IOException {
@@ -525,12 +523,12 @@ public class ParquetFileReader implements Closeable {
    * Reads the meta data block in the footer of the file
    *
    * @param configuration a configuration
-   * @param file          the parquet File
-   * @param filter        the filter to apply to row groups
+   * @param file the parquet File
+   * @param filter the filter to apply to row groups
    * @return the metadata blocks in the footer
    * @throws IOException if an error occurs while reading the file
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static final ParquetMetadata readFooter(Configuration configuration, FileStatus file, MetadataFilter filter)
@@ -541,12 +539,12 @@ public class ParquetFileReader implements Closeable {
   /**
    * Reads the meta data block in the footer of the file using provided input stream
    *
-   * @param file   a {@link InputFile} to read
+   * @param file a {@link InputFile} to read
    * @param filter the filter to apply to row groups
    * @return the metadata blocks in the footer
    * @throws IOException if an error occurs while reading the file
    * @deprecated will be removed in 2.0.0;
-   * use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
+   *             use {@link ParquetFileReader#open(InputFile, ParquetReadOptions)}
    */
   @Deprecated
   public static final ParquetMetadata readFooter(InputFile file, MetadataFilter filter) throws IOException {
@@ -660,12 +658,12 @@ public class ParquetFileReader implements Closeable {
   }
 
   /**
-   * @param conf   a configuration
-   * @param file   a file path to open
+   * @param conf a configuration
+   * @param file a file path to open
    * @param filter a metadata filter
    * @return a parquet file reader
    * @throws IOException if there is an error while opening the file
-   * @deprecated will be removed in 2.0.0; use {@link #open(InputFile, ParquetReadOptions)}
+   * @deprecated will be removed in 2.0.0; use {@link #open(InputFile,ParquetReadOptions)}
    */
   @Deprecated
   public static ParquetFileReader open(Configuration conf, Path file, MetadataFilter filter) throws IOException {
@@ -675,8 +673,8 @@ public class ParquetFileReader implements Closeable {
   }
 
   /**
-   * @param conf   a configuration
-   * @param file   a file path to open
+   * @param conf a configuration
+   * @param file a file path to open
    * @param footer a footer for the file if already loaded
    * @return a parquet file reader
    * @throws IOException if there is an error while opening the file
@@ -701,7 +699,7 @@ public class ParquetFileReader implements Closeable {
   /**
    * Open a {@link InputFile file} with {@link ParquetReadOptions options}.
    *
-   * @param file    an input file
+   * @param file an input file
    * @param options parquet read options
    * @return an open ParquetFileReader
    * @throws IOException if there is an error while opening the file
@@ -711,8 +709,11 @@ public class ParquetFileReader implements Closeable {
   }
 
   protected final SeekableInputStream f;
+  // input streams opened in the async mode
+  protected final List<SeekableInputStream> inputStreams = new ArrayList<>();
+  protected final List<ByteBufferInputStream> bufferInputStreams = new ArrayList<>();
   private final InputFile file;
-  private final ParquetReadOptions options;
+  final ParquetReadOptions options;
   private final Map<ColumnPath, ColumnDescriptor> paths = new HashMap<>();
   private final FileMetaData fileMetaData; // may be null
   private final List<BlockMetaData> blocks;
@@ -730,9 +731,9 @@ public class ParquetFileReader implements Closeable {
 
   /**
    * @param configuration the Hadoop conf
-   * @param filePath      Path for the parquet file
-   * @param blocks        the blocks to read
-   * @param columns       the columns to read (their path)
+   * @param filePath Path for the parquet file
+   * @param blocks the blocks to read
+   * @param columns the columns to read (their path)
    * @throws IOException if the file can not be opened
    * @deprecated will be removed in 2.0.0.
    */
@@ -745,10 +746,10 @@ public class ParquetFileReader implements Closeable {
 
   /**
    * @param configuration the Hadoop conf
-   * @param fileMetaData  fileMetaData for parquet file
-   * @param filePath      Path for the parquet file
-   * @param blocks        the blocks to read
-   * @param columns       the columns to read (their path)
+   * @param fileMetaData fileMetaData for parquet file
+   * @param filePath Path for the parquet file
+   * @param blocks the blocks to read
+   * @param columns the columns to read (their path)
    * @throws IOException if the file can not be opened
    * @deprecated will be removed in 2.0.0.
    */
@@ -796,8 +797,8 @@ public class ParquetFileReader implements Closeable {
   }
 
   /**
-   * @param conf   the Hadoop Configuration
-   * @param file   Path to a parquet file
+   * @param conf the Hadoop Configuration
+   * @param file Path to a parquet file
    * @param filter a {@link MetadataFilter} for selecting row groups
    * @throws IOException if the file can not be opened
    * @deprecated will be removed in 2.0.0.
@@ -810,8 +811,8 @@ public class ParquetFileReader implements Closeable {
   }
 
   /**
-   * @param conf   the Hadoop Configuration
-   * @param file   Path to a parquet file
+   * @param conf the Hadoop Configuration
+   * @param file Path to a parquet file
    * @param footer a {@link ParquetMetadata} footer already read from the file
    * @throws IOException if the file can not be opened
    * @deprecated will be removed in 2.0.0.
@@ -933,6 +934,30 @@ public class ParquetFileReader implements Closeable {
       this.crc = null;
       this.crcAllocator = null;
     }
+  }
+
+  private boolean isAsyncIOReaderEnabled() {
+    if (options.isAsyncIOReaderEnabled()) {
+      if (options.getIOThreadPool() != null) {
+        return true;
+      } else {
+        LOG.debug("Parquet async IO is configured but the IO thread pool has not been "
+            + "initialized. Configuration is being ignored");
+      }
+    }
+    return false;
+  }
+
+  boolean isParallelColumnReaderEnabled() {
+    if (options.isParallelColumnReaderEnabled()) {
+      if (options.getProcessThreadPool() != null) {
+        return true;
+      } else {
+        LOG.debug("Parallel column reading is configured but the process thread pool has "
+            + "not been initialized. Configuration is being ignored");
+      }
+    }
+    return false;
   }
 
   private static <T> List<T> listWithNulls(int size) {
@@ -1058,6 +1083,9 @@ public class ParquetFileReader implements Closeable {
     if (rowGroup == null) {
       return null;
     }
+    if (this.currentRowGroup != null) {
+      this.currentRowGroup.close();
+    }
     this.currentRowGroup = rowGroup;
     // avoid re-reading bytes the dictionary reader is used after this call
     if (nextDictionaryReader != null) {
@@ -1086,6 +1114,10 @@ public class ParquetFileReader implements Closeable {
       ColumnPath pathKey = mc.getPath();
       ColumnDescriptor columnDescriptor = paths.get(pathKey);
       if (columnDescriptor != null) {
+        // If async IO or parallel reader feature is enabled, we need a new stream for every column
+        if (isAsyncIOReaderEnabled() || isParallelColumnReaderEnabled()) {
+          currentParts = null;
+        }
         BenchmarkCounter.incrementTotalBytes(mc.getTotalSize());
         long startingPos = mc.getStartingPos();
         // first part or not consecutive => new list
@@ -1098,8 +1130,18 @@ public class ParquetFileReader implements Closeable {
     }
     // actually read all the chunks
     ChunkListBuilder builder = new ChunkListBuilder(block.getRowCount());
-    readAllPartsVectoredOrNormal(allParts, builder);
+    if (isAsyncIOReaderEnabled()) {
+      for (ConsecutivePartList consecutiveChunks : allParts) {
+
+        SeekableInputStream is = file.newStream();
+        consecutiveChunks.readAll(is, builder);
+        inputStreams.add(is);
+      }
+    } else {
+      readAllPartsVectoredOrNormal(allParts, builder);
+    }
     rowGroup.setReleaser(builder.releaser);
+
     for (Chunk chunk : builder.build()) {
       readChunkPages(chunk, block, rowGroup);
     }
@@ -1313,7 +1355,9 @@ public class ParquetFileReader implements Closeable {
       // All rows are matching -> fall back to the non-filtering path
       return readNextRowGroup();
     }
-
+    if (this.currentRowGroup != null) {
+      this.currentRowGroup.close();
+    }
     this.currentRowGroup = internalReadFilteredRowGroup(block, rowRanges, getColumnIndexStore(currentBlock));
 
     // avoid re-reading bytes the dictionary reader is used after this call
@@ -1337,6 +1381,10 @@ public class ParquetFileReader implements Closeable {
       ColumnPath pathKey = mc.getPath();
       ColumnDescriptor columnDescriptor = paths.get(pathKey);
       if (columnDescriptor != null) {
+        // If async IO or parallel reader feature is enabled, we need a new stream for every column
+        if (isAsyncIOReaderEnabled() || isParallelColumnReaderEnabled()) {
+          currentParts = null;
+        }
         OffsetIndex offsetIndex = ciStore.getOffsetIndex(mc.getPath());
 
         OffsetIndex filteredOffsetIndex = filterOffsetIndex(offsetIndex, rowRanges, block.getRowCount());
@@ -1355,7 +1403,16 @@ public class ParquetFileReader implements Closeable {
         }
       }
     }
-    readAllPartsVectoredOrNormal(allParts, builder);
+    // actually read all the chunks
+    if (isAsyncIOReaderEnabled()) {
+      for (ConsecutivePartList consecutiveChunks : allParts) {
+        SeekableInputStream is = file.newStream();
+        consecutiveChunks.readAll(is, builder);
+        inputStreams.add(is);
+      }
+    } else {
+      readAllPartsVectoredOrNormal(allParts, builder);
+    }
     rowGroup.setReleaser(builder.releaser);
     for (Chunk chunk : builder.build()) {
       readChunkPages(chunk, block, rowGroup);
@@ -1710,6 +1767,16 @@ public class ParquetFileReader implements Closeable {
       if (f != null) {
         f.close();
       }
+      if (this.currentRowGroup != null) {
+        this.currentRowGroup.close();
+        this.currentRowGroup = null;
+      }
+      for (SeekableInputStream is : inputStreams) {
+        is.close();
+      }
+      for (ByteBufferInputStream bufStr : bufferInputStreams) {
+        bufStr.close();
+      }
     } finally {
       AutoCloseables.uncheckedClose(nextDictionaryReader, crcAllocator);
       options.getCodecFactory().release();
@@ -1721,8 +1788,13 @@ public class ParquetFileReader implements Closeable {
    * result of the column-index based filtering when some pages might be skipped at reading.
    */
   private class ChunkListBuilder {
+    // ChunkData is backed by either a list of buffers or a list of streams
+    // It's a mistake to have both lists populated
     private class ChunkData {
+      // Used for synchronous reads
       final List<ByteBuffer> buffers = new ArrayList<>();
+      // Used for asynchronous reads
+      final List<ByteBufferInputStream> streams = new ArrayList<>();
       OffsetIndex offsetIndex;
     }
 
@@ -1734,6 +1806,12 @@ public class ParquetFileReader implements Closeable {
 
     public ChunkListBuilder(long rowCount) {
       this.rowCount = rowCount;
+    }
+
+    void add(ChunkDescriptor descriptor, ByteBufferInputStream stream, SeekableInputStream f) {
+      map.computeIfAbsent(descriptor, d -> new ChunkData()).streams.add(stream);
+      lastDescriptor = descriptor;
+      this.f = f;
     }
 
     void add(ChunkDescriptor descriptor, List<ByteBuffer> buffers, SeekableInputStream f) {
@@ -1756,11 +1834,21 @@ public class ParquetFileReader implements Closeable {
       for (Entry<ChunkDescriptor, ChunkData> entry : entries) {
         ChunkDescriptor descriptor = entry.getKey();
         ChunkData data = entry.getValue();
+        ByteBufferInputStream byteBufferInputStream;
+        if (isAsyncIOReaderEnabled()) {
+          // For async reads, we use a SequenceByeTeBufferInputStream instead of a ByteBufferInputStream
+          // because calling sliceBuffers in the latter blocks until all the buffers are read (effectively
+          // nullifying the async read) while the former blocks only if the next buffer is unavailable.
+          byteBufferInputStream = new SequenceByteBufferInputStream(data.streams);
+        } else {
+          byteBufferInputStream = ByteBufferInputStream.wrap(data.buffers);
+        }
         if (descriptor.equals(lastDescriptor)) {
           // because of a bug, the last chunk might be larger than descriptor.size
-          chunks.add(new WorkaroundChunk(lastDescriptor, data.buffers, f, data.offsetIndex, rowCount));
+          chunks.add(
+              new WorkaroundChunk(lastDescriptor, byteBufferInputStream, f, data.offsetIndex, rowCount));
         } else {
-          chunks.add(new Chunk(descriptor, data.buffers, data.offsetIndex, rowCount));
+          chunks.add(new Chunk(descriptor, byteBufferInputStream, data.offsetIndex, rowCount));
         }
       }
       return chunks;
@@ -1770,7 +1858,7 @@ public class ParquetFileReader implements Closeable {
   /**
    * The data for a column chunk
    */
-  private class Chunk {
+  class Chunk {
 
     protected final ChunkDescriptor descriptor;
     protected final ByteBufferInputStream stream;
@@ -1778,15 +1866,19 @@ public class ParquetFileReader implements Closeable {
     final long rowCount;
 
     /**
-     * @param descriptor  descriptor for the chunk
-     * @param buffers     ByteBuffers that contain the chunk
+     * @param descriptor descriptor for the chunk
+     * @param stream the input stream to read from
      * @param offsetIndex the offset index for this column; might be null
      */
-    public Chunk(ChunkDescriptor descriptor, List<ByteBuffer> buffers, OffsetIndex offsetIndex, long rowCount) {
+    public Chunk(ChunkDescriptor descriptor, ByteBufferInputStream stream, OffsetIndex offsetIndex, long rowCount) {
       this.descriptor = descriptor;
-      this.stream = ByteBufferInputStream.wrap(buffers);
+      this.stream = stream;
       this.offsetIndex = offsetIndex;
       this.rowCount = rowCount;
+    }
+
+    public ChunkDescriptor getDescriptor() {
+      return descriptor;
     }
 
     protected PageHeader readPageHeader() throws IOException {
@@ -1795,6 +1887,10 @@ public class ParquetFileReader implements Closeable {
 
     protected PageHeader readPageHeader(BlockCipher.Decryptor blockDecryptor, byte[] pageHeaderAAD)
         throws IOException {
+      if (LOG.isDebugEnabled()) {
+        String mode = (isAsyncIOReaderEnabled()) ? "ASYNC" : "SYNC";
+        LOG.debug("{} READ HEADER: stream {}", mode, stream);
+      }
       return Util.readPageHeader(stream, blockDecryptor, pageHeaderAAD);
     }
 
@@ -1802,7 +1898,7 @@ public class ParquetFileReader implements Closeable {
      * Calculate checksum of input bytes, throw decoding exception if it does not match the provided
      * reference crc
      */
-    private void verifyCrc(int referenceCrc, BytesInput bytes, String exceptionMsg) {
+    public void verifyCrc(int referenceCrc, BytesInput bytes, String exceptionMsg) {
       crc.reset();
       try (ByteBufferReleaser releaser = crcAllocator.getReleaser()) {
         crc.update(bytes.toByteBuffer(releaser));
@@ -1821,6 +1917,14 @@ public class ParquetFileReader implements Closeable {
       return readAllPages(null, null, null, -1, -1);
     }
 
+    /*
+     * If the async mode is enabled, this method will return immediately after reading the first page
+     * and for subsequent pages the caller will block on the queue of pages contained in the
+     * returned ColumnChunkPageReader object.
+     * If the read is synchronous, this method will return only after the queue is filled and the
+     * caller will not block on the queue.
+     * If there is only one page, the behaviour will be identical.
+     */
     public ColumnChunkPageReader readAllPages(
         BlockCipher.Decryptor headerBlockDecryptor,
         BlockCipher.Decryptor pageBlockDecryptor,
@@ -1828,163 +1932,50 @@ public class ParquetFileReader implements Closeable {
         int rowGroupOrdinal,
         int columnOrdinal)
         throws IOException {
-      List<DataPage> pagesInChunk = new ArrayList<>();
-      DictionaryPage dictionaryPage = null;
-      PrimitiveType type = getFileMetaData()
-          .getSchema()
-          .getType(descriptor.col.getPath())
-          .asPrimitiveType();
-      long valuesCountReadSoFar = 0L;
-      int dataPageCountReadSoFar = 0;
-      byte[] dataPageHeaderAAD = null;
-      if (null != headerBlockDecryptor) {
-        dataPageHeaderAAD = AesCipher.createModuleAAD(
-            aadPrefix,
-            ModuleType.DataPageHeader,
-            rowGroupOrdinal,
-            columnOrdinal,
-            getPageOrdinal(dataPageCountReadSoFar));
-      }
-      while (hasMorePages(valuesCountReadSoFar, dataPageCountReadSoFar)) {
-        byte[] pageHeaderAAD = dataPageHeaderAAD;
-        if (null != headerBlockDecryptor) {
-          // Important: this verifies file integrity (makes sure dictionary page had not been removed)
-          if (null == dictionaryPage && descriptor.metadata.hasDictionaryPage()) {
-            pageHeaderAAD = AesCipher.createModuleAAD(
-                aadPrefix, ModuleType.DictionaryPageHeader, rowGroupOrdinal, columnOrdinal, -1);
-          } else {
-            int pageOrdinal = getPageOrdinal(dataPageCountReadSoFar);
-            AesCipher.quickUpdatePageAAD(dataPageHeaderAAD, pageOrdinal);
-          }
-        }
-        PageHeader pageHeader = readPageHeader(headerBlockDecryptor, pageHeaderAAD);
-        int uncompressedPageSize = pageHeader.getUncompressed_page_size();
-        int compressedPageSize = pageHeader.getCompressed_page_size();
-        final BytesInput pageBytes;
-        switch (pageHeader.type) {
-          case DICTIONARY_PAGE:
-            // there is only one dictionary page per column chunk
-            if (dictionaryPage != null) {
-              throw new ParquetDecodingException(
-                  "more than one dictionary page in column " + descriptor.col);
-            }
-            pageBytes = this.readAsBytesInput(compressedPageSize);
-            if (options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
-              verifyCrc(
-                  pageHeader.getCrc(),
-                  pageBytes,
-                  "could not verify dictionary page integrity, CRC checksum verification failed");
-            }
-            DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
-            dictionaryPage = new DictionaryPage(
-                pageBytes,
-                uncompressedPageSize,
-                dicHeader.getNum_values(),
-                converter.getEncoding(dicHeader.getEncoding()));
-            // Copy crc to new page, used for testing
-            if (pageHeader.isSetCrc()) {
-              dictionaryPage.setCrc(pageHeader.getCrc());
-            }
-            break;
-          case DATA_PAGE:
-            DataPageHeader dataHeaderV1 = pageHeader.getData_page_header();
-            pageBytes = this.readAsBytesInput(compressedPageSize);
-            if (options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
-              verifyCrc(
-                  pageHeader.getCrc(),
-                  pageBytes,
-                  "could not verify page integrity, CRC checksum verification failed");
-            }
-            DataPageV1 dataPageV1 = new DataPageV1(
-                pageBytes,
-                dataHeaderV1.getNum_values(),
-                uncompressedPageSize,
-                converter.fromParquetStatistics(
-                    getFileMetaData().getCreatedBy(), dataHeaderV1.getStatistics(), type),
-                converter.getEncoding(dataHeaderV1.getRepetition_level_encoding()),
-                converter.getEncoding(dataHeaderV1.getDefinition_level_encoding()),
-                converter.getEncoding(dataHeaderV1.getEncoding()));
-            // Copy crc to new page, used for testing
-            if (pageHeader.isSetCrc()) {
-              dataPageV1.setCrc(pageHeader.getCrc());
-            }
-            pagesInChunk.add(dataPageV1);
-            valuesCountReadSoFar += dataHeaderV1.getNum_values();
-            ++dataPageCountReadSoFar;
-            break;
-          case DATA_PAGE_V2:
-            DataPageHeaderV2 dataHeaderV2 = pageHeader.getData_page_header_v2();
-            int dataSize = compressedPageSize
-                - dataHeaderV2.getRepetition_levels_byte_length()
-                - dataHeaderV2.getDefinition_levels_byte_length();
-            final BytesInput repetitionLevels =
-                this.readAsBytesInput(dataHeaderV2.getRepetition_levels_byte_length());
-            final BytesInput definitionLevels =
-                this.readAsBytesInput(dataHeaderV2.getDefinition_levels_byte_length());
-            final BytesInput values = this.readAsBytesInput(dataSize);
-            if (options.usePageChecksumVerification() && pageHeader.isSetCrc()) {
-              pageBytes = BytesInput.concat(repetitionLevels, definitionLevels, values);
-              verifyCrc(
-                  pageHeader.getCrc(),
-                  pageBytes,
-                  "could not verify page integrity, CRC checksum verification failed");
-            }
-            DataPageV2 dataPageV2 = new DataPageV2(
-                dataHeaderV2.getNum_rows(),
-                dataHeaderV2.getNum_nulls(),
-                dataHeaderV2.getNum_values(),
-                repetitionLevels,
-                definitionLevels,
-                converter.getEncoding(dataHeaderV2.getEncoding()),
-                values,
-                uncompressedPageSize,
-                converter.fromParquetStatistics(
-                    getFileMetaData().getCreatedBy(), dataHeaderV2.getStatistics(), type),
-                dataHeaderV2.isIs_compressed());
-            // Copy crc to new page, used for testing
-            if (pageHeader.isSetCrc()) {
-              dataPageV2.setCrc(pageHeader.getCrc());
-            }
-            pagesInChunk.add(dataPageV2);
-            valuesCountReadSoFar += dataHeaderV2.getNum_values();
-            ++dataPageCountReadSoFar;
-            break;
-          default:
-            LOG.debug("skipping page of type {} of size {}", pageHeader.getType(), compressedPageSize);
-            stream.skipFully(compressedPageSize);
-            break;
-        }
-      }
-      if (offsetIndex == null && valuesCountReadSoFar != descriptor.metadata.getValueCount()) {
-        // Would be nice to have a CorruptParquetFileException or something as a subclass?
-        throw new IOException(
-            "Expected " + descriptor.metadata.getValueCount() + " values in column chunk at " + getPath()
-                + " offset " + descriptor.metadata.getFirstDataPageOffset() + " but got "
-                + valuesCountReadSoFar + " values instead over " + pagesInChunk.size()
-                + " pages ending at file offset " + (descriptor.fileOffset + stream.position()));
-      }
       BytesInputDecompressor decompressor =
           options.getCodecFactory().getDecompressor(descriptor.metadata.getCodec());
+      DictionaryPage dictionaryPage;
+      LinkedBlockingDeque<Optional<DataPage>> pagesInChunk;
+
+      FilePageReader filePageReader = new FilePageReader(
+          ParquetFileReader.this,
+          this,
+          currentBlock,
+          headerBlockDecryptor,
+          pageBlockDecryptor,
+          aadPrefix,
+          rowGroupOrdinal,
+          columnOrdinal,
+          decompressor);
+
+      // Read the dictionary page;
+      filePageReader.readOnePage();
+      dictionaryPage = filePageReader.getDictionaryPage();
+      // if reading columns in parallel, we simply submit the read page task to the thread pool
+      // and continue (effectively to the next column).
+      if (isParallelColumnReaderEnabled()) {
+        filePageReader.readAllRemainingPagesAsync();
+      } else {
+        filePageReader.readAllRemainingPages();
+      }
+      pagesInChunk = filePageReader.getPagesInChunk();
+
       return new ColumnChunkPageReader(
           decompressor,
           pagesInChunk,
           dictionaryPage,
           offsetIndex,
+          this.descriptor.metadata.getValueCount(),
           rowCount,
           pageBlockDecryptor,
           aadPrefix,
           rowGroupOrdinal,
           columnOrdinal,
+          filePageReader,
           options);
     }
 
-    private boolean hasMorePages(long valuesCountReadSoFar, int dataPageCountReadSoFar) {
-      return offsetIndex == null
-          ? valuesCountReadSoFar < descriptor.metadata.getValueCount()
-          : dataPageCountReadSoFar < offsetIndex.getPageCount();
-    }
-
-    private int getPageOrdinal(int dataPageCountReadSoFar) {
+    int getPageOrdinal(int dataPageCountReadSoFar) {
       if (null == offsetIndex) {
         return dataPageCountReadSoFar;
       }
@@ -1998,7 +1989,16 @@ public class ParquetFileReader implements Closeable {
      * @throws IOException if there is an error while reading from the file stream
      */
     public BytesInput readAsBytesInput(int size) throws IOException {
+      if (LOG.isDebugEnabled()) {
+        String mode = (isAsyncIOReaderEnabled()) ? "ASYNC" : "SYNC";
+        LOG.debug("{} READ BYTES INPUT: stream {}", mode, stream);
+      }
       return BytesInput.from(stream.sliceBuffers(size));
+    }
+
+    @Override
+    public String toString() {
+      return "Chunk{" + "descriptor=" + descriptor + ", stream=" + stream + ", offsetIndex=" + offsetIndex + '}';
     }
   }
 
@@ -2011,15 +2011,15 @@ public class ParquetFileReader implements Closeable {
 
     /**
      * @param descriptor the descriptor of the chunk
-     * @param f          the file stream positioned at the end of this chunk
+     * @param f the file stream positioned at the end of this chunk
      */
     private WorkaroundChunk(
         ChunkDescriptor descriptor,
-        List<ByteBuffer> buffers,
+        ByteBufferInputStream stream,
         SeekableInputStream f,
         OffsetIndex offsetIndex,
         long rowCount) {
-      super(descriptor, buffers, offsetIndex, rowCount);
+      super(descriptor, stream, offsetIndex, rowCount);
       this.f = f;
     }
 
@@ -2054,6 +2054,10 @@ public class ParquetFileReader implements Closeable {
 
         List<ByteBuffer> streamBuffers = stream.sliceBuffers(available);
 
+        // do we make this async? If the async reader has completed reading its last
+        // buffer, the file stream will be positioned at the right place and this will work just
+        // fine. However this means that for some cases, the missing bytes of the last chunk will
+        // be read synchronously irrespective of the async read mode.
         ByteBuffer lastBuffer = ByteBuffer.allocate(missingBytes);
         f.readFully(lastBuffer);
 
@@ -2071,7 +2075,7 @@ public class ParquetFileReader implements Closeable {
   /**
    * Information needed to read a column chunk or a part of it.
    */
-  private static class ChunkDescriptor {
+  public static class ChunkDescriptor {
 
     private final ColumnDescriptor col;
     private final ColumnChunkMetaData metadata;
@@ -2079,10 +2083,10 @@ public class ParquetFileReader implements Closeable {
     private final long size;
 
     /**
-     * @param col        column this chunk is part of
-     * @param metadata   metadata for the column
+     * @param col column this chunk is part of
+     * @param metadata metadata for the column
      * @param fileOffset offset in the file where this chunk starts
-     * @param size       size of the chunk
+     * @param size size of the chunk
      */
     private ChunkDescriptor(ColumnDescriptor col, ColumnChunkMetaData metadata, long fileOffset, long size) {
       super();
@@ -2090,6 +2094,18 @@ public class ParquetFileReader implements Closeable {
       this.metadata = metadata;
       this.fileOffset = fileOffset;
       this.size = size;
+    }
+
+    public ColumnDescriptor getCol() {
+      return col;
+    }
+
+    public ColumnChunkMetaData getMetadata() {
+      return metadata;
+    }
+
+    public long getFileOffset() {
+      return fileOffset;
     }
 
     @Override
@@ -2106,6 +2122,15 @@ public class ParquetFileReader implements Closeable {
       } else {
         return false;
       }
+    }
+
+    @Override
+    public String toString() {
+      return "ChunkDescriptor{" + "col="
+          + col + ", metadata="
+          + metadata + ", fileOffset="
+          + fileOffset + ", size="
+          + size + '}';
     }
   }
 
@@ -2138,12 +2163,16 @@ public class ParquetFileReader implements Closeable {
     }
 
     /**
-     * @param f       file to read the chunks from
      * @param builder used to build chunk list to read the pages for the different columns
      * @throws IOException if there is an error while reading from the stream
      */
-    public void readAll(SeekableInputStream f, ChunkListBuilder builder) throws IOException {
-      f.seek(offset);
+    public void readAll(SeekableInputStream is, ChunkListBuilder builder) throws IOException {
+      // Use a new file input stream for every set of consecutive chunks.
+      // If we are reading synchronously, we don't want the input stream to seek back
+      // forth in the file for every set of chunks. Seeking backwards can cause a performance drop.
+      // If we read in async mode many such sets could be read in parallel, and we don't want the
+      // same input stream shared between threads.
+      is.seek(offset);
 
       int fullAllocations = Math.toIntExact(length / options.getMaxAllocationSize());
       int lastAllocationSize = Math.toIntExact(length % options.getMaxAllocationSize());
@@ -2161,17 +2190,39 @@ public class ParquetFileReader implements Closeable {
       builder.addBuffersToRelease(buffers);
 
       long readStart = System.nanoTime();
-      for (ByteBuffer buffer : buffers) {
-        f.readFully(buffer);
-        buffer.flip();
+
+      ByteBufferInputStream stream;
+      if (!isAsyncIOReaderEnabled()) {
+        // pre-read the files into the allocated buffers
+        for (ByteBuffer buffer : buffers) {
+          is.readFully(buffer);
+          buffer.flip();
+        }
+        long timeSpent = System.nanoTime() - readStart;
+        LOG.debug("SYNC Stream: READ - {}", timeSpent / 1000.0);
+        stream = ByteBufferInputStream.wrap(buffers);
+      } else {
+        // The underlying implementation will read the data from the input stream
+        // asynchronously.
+        stream = ByteBufferInputStream.wrapAsync(options.getIOThreadPool(), is, buffers);
       }
       setReadMetrics(readStart, length);
 
+      bufferInputStreams.add(stream);
       // report in a counter the data we just scanned
       BenchmarkCounter.incrementBytesRead(length);
-      ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffers);
       for (final ChunkDescriptor descriptor : chunks) {
-        builder.add(descriptor, stream.sliceBuffers(descriptor.size), f);
+        if (!isAsyncIOReaderEnabled()) {
+          // stream.sliceBuffers is a *blocking* call and assumes that all data has been read
+          builder.add(descriptor, stream.sliceBuffers(descriptor.size), is);
+          LOG.debug("SYNC: Added to builder -  chunk slice  {} ", descriptor);
+        } else {
+          // Preconditions:
+          //  1) The stream is an Async stream.
+          //  2) Each column chunk has an independent stream.
+          builder.add(descriptor, stream, is);
+          LOG.debug("ASYNC: Added to builder -  chunk slice  {} , stream {}", descriptor, stream);
+        }
       }
     }
 
@@ -2230,6 +2281,11 @@ public class ParquetFileReader implements Closeable {
      */
     public long endPos() {
       return offset + length;
+    }
+
+    @Override
+    public String toString() {
+      return "ConsecutivePartList{" + "offset=" + offset + ", length=" + length + ", chunks=" + chunks + '}';
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -148,6 +148,14 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   public static final String OFF_HEAP_DECRYPT_BUFFER_ENABLED = "parquet.decrypt.off-heap.buffer.enabled";
 
   /**
+   * key to configure whether parquet reader should use async file reads.
+   */
+  public static final String ENABLE_ASYNC_IO_READER = "parquet.read.async.io.enabled";
+  /**
+   * key to configure whether parquet reader should read all column data in parallel
+   */
+  public static final String ENABLE_PARALLEL_COLUMN_READER = "parquet.read.parallel.columnreader.enabled";
+  /**
    * key to turn on or off task side metadata loading (default true)
    * if true then metadata is read on the task side and some tasks may finish immediately.
    * if false metadata is read on the client which is slower if there is a lot of metadata but tasks will only be spawn if there is work to do.
@@ -283,7 +291,7 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
    * the read support property in their configuration.
    *
    * @param readSupportClass a ReadSupport subclass
-   * @param <S>              the Java read support type
+   * @param <S> the Java read support type
    */
   public <S extends ReadSupport<T>> ParquetInputFormat(Class<S> readSupportClass) {
     this.readSupportClass = readSupportClass;
@@ -326,7 +334,7 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
 
   /**
    * @param readSupportClass to instantiate
-   * @param <T>              the Java type of objects created by the ReadSupport
+   * @param <T> the Java type of objects created by the ReadSupport
    * @return the configured read support
    */
   @SuppressWarnings("unchecked")
@@ -368,7 +376,7 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
 
   /**
    * @param configuration the configuration to connect to the file system
-   * @param footers       the footers of the files to read
+   * @param footers the footers of the files to read
    * @return the splits for the footers
    * @throws IOException if there is an error while reading
    * @deprecated split planning using file footers will be removed
@@ -502,7 +510,7 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
    * the footers for the files
    *
    * @param configuration to connect to the file system
-   * @param statuses      the files to open
+   * @param statuses the files to open
    * @return the footers of the files
    * @throws IOException if there is an error while reading
    */

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetReader.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -60,7 +61,7 @@ public class ParquetReader<T> implements Closeable {
   private InternalParquetRecordReader<T> reader;
 
   /**
-   * @param file        the file to read
+   * @param file the file to read
    * @param readSupport to materialize records
    * @throws IOException if there is an error while reading
    * @deprecated use {@link #builder(ReadSupport, Path)}
@@ -71,8 +72,8 @@ public class ParquetReader<T> implements Closeable {
   }
 
   /**
-   * @param conf        the configuration
-   * @param file        the file to read
+   * @param conf the configuration
+   * @param file the file to read
    * @param readSupport to materialize records
    * @throws IOException if there is an error while reading
    * @deprecated use {@link #builder(ReadSupport, Path)}
@@ -83,8 +84,8 @@ public class ParquetReader<T> implements Closeable {
   }
 
   /**
-   * @param file                the file to read
-   * @param readSupport         to materialize records
+   * @param file the file to read
+   * @param readSupport to materialize records
    * @param unboundRecordFilter the filter to use to filter records
    * @throws IOException if there is an error while reading
    * @deprecated use {@link #builder(ReadSupport, Path)}
@@ -96,9 +97,9 @@ public class ParquetReader<T> implements Closeable {
   }
 
   /**
-   * @param conf                the configuration
-   * @param file                the file to read
-   * @param readSupport         to materialize records
+   * @param conf the configuration
+   * @param file the file to read
+   * @param readSupport to materialize records
    * @param unboundRecordFilter the filter to use to filter records
    * @throws IOException if there is an error while reading
    * @deprecated use {@link #builder(ReadSupport, Path)}
@@ -369,6 +370,16 @@ public class ParquetReader<T> implements Closeable {
 
     public Builder<T> withDecryption(FileDecryptionProperties fileDecryptionProperties) {
       optionsBuilder.withDecryption(fileDecryptionProperties);
+      return this;
+    }
+
+    public Builder<T> withIOThreadPool(ExecutorService threadPool) {
+      optionsBuilder.withIOThreadPool(threadPool);
+      return this;
+    }
+
+    public Builder<T> withProcessThreadPool(ExecutorService threadPool) {
+      optionsBuilder.withProcessThreadPool(threadPool);
       return this;
     }
 


### PR DESCRIPTION


### Jira

This PR addresses the following [PARQUET-2149](https://issues.apache.org/jira/browse/PARQUET-2149): Implement async IO for Parquet file reader

### Tests

This PR adds the following unit tests 
   AsyncMultiBufferInputStream.*
   TestMultipleWriteRead.testReadWriteAsync 
   TestColumnChunkPageWriteStore.testAsync
   
The PR is also tested by changing the default configuration to make all reads async and then ensuring all unit tests pass

