### PR TITLE
PARQUET-2153: SchemaParseException: Can't redefine: element for FixedSchema

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -304,6 +304,7 @@ public class AvroSchemaConverter {
   }
 
   private Schema convertField(final Type parquetType, Map<String, Integer> names) {
+    Integer nameCount = names.merge(parquetType.getName(), 1, (oldValue, value) -> oldValue + 1);
     if (parquetType.isPrimitive()) {
       final PrimitiveType asPrimitive = parquetType.asPrimitiveType();
       final PrimitiveTypeName parquetPrimitiveTypeName =
@@ -345,7 +346,7 @@ public class AvroSchemaConverter {
                 return Schema.create(Schema.Type.STRING);
               } else {
                 int size = parquetType.asPrimitiveType().getTypeLength();
-                return Schema.createFixed(parquetType.getName(), null, null, size);
+                return Schema.createFixed(parquetType.getName(), null, nameCount > 1 ? parquetType.getName() + nameCount : null, size);
               }
             }
             @Override


### PR DESCRIPTION
This extends the previous issue [PARQUET-1441](https://issues.apache.org/jira/browse/PARQUET-1441) where this issue was fixed for RecordSchema but not for FixedSchema. 

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

- I'm unsure on how to add unit tests for FixedSchema, maybe someone could help me on this?

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
