### PR TITLE
WiP: parquet to use openfile api and some other performance enhancements

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H1SeekableInputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H1SeekableInputStream.java
@@ -22,6 +22,7 @@ package org.apache.parquet.hadoop.util;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * SeekableInputStream implementation that implements read(ByteBuffer) for
@@ -44,6 +45,16 @@ class H1SeekableInputStream extends DelegatingSeekableInputStream {
   @Override
   public void seek(long newPos) throws IOException {
     stream.seek(newPos);
+  }
+
+
+  @Override
+  public void readFully(ByteBuffer buf) throws IOException {
+    if (buf.hasArray()) {
+      stream.readFully(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
+    } else {
+      super.readFully(buf);
+    }
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H2SeekableInputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/H2SeekableInputStream.java
@@ -73,7 +73,13 @@ class H2SeekableInputStream extends DelegatingSeekableInputStream {
 
   @Override
   public void readFully(ByteBuffer buf) throws IOException {
-    readFully(reader, buf);
+    // use ByteBufferPositionedReadable to read the entire buffer
+    // if the stream declares it supports it.
+    if (stream.hasCapability("in:preadbytebuffer")) {
+      stream.readFully(stream.getPos(), buf);
+    } else {
+      readFully(reader, buf);
+    }
   }
 
   private class H2Reader implements Reader {

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <jackson-databind.version>2.13.2.2</jackson-databind.version>
     <japicmp.version>0.14.2</japicmp.version>
     <shade.prefix>shaded.parquet</shade.prefix>
-    <hadoop.version>3.2.3</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <parquet.format.version>2.9.0</parquet.format.version>
     <previous.version>1.12.0</previous.version>
     <thrift.executable>thrift</thrift.executable>


### PR DESCRIPTION
This is me looking at what minimal changes could be made to
boost IO performance working with the cloud stores.

Compiles against hadoop 3.3.3; will need hadoop 3.3.5 for some
of the benefits

* not expecting any reviews here, just seeing how well it works for now *

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
