### PR TITLE
PARQUET-2205: Accelerate CI by commonizing thrift build and leveraging cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,31 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-  build:
+  build_thrift_compiler:
+    runs-on: ubuntu-latest
+    name: Build thrift compiler
+    env:
+      THRIFT_VERSION: 0.16.0
+    steps:
+      - name: Download thrift
+        run: curl -sLO https://archive.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz
+      - uses: actions/cache@v3
+        id: cache-thrift
+        with:
+          path: /usr/local/bin/thrift
+          key: thrift-${{ hashFiles('thrift-*.tar.gz') }}
+      - uses: actions/checkout@master
+        if: ${{ steps.cache-thrift.outputs.cache-hit != 'true' }}
+      - name: Build thrift compiler
+        if: ${{ steps.cache-thrift.outputs.cache-hit != 'true' }}
+        run: bash dev/ci-before_install.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: thrift-compiler
+          path: /usr/local/bin/thrift
 
+  build:
+    needs: build_thrift_compiler
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -29,18 +52,24 @@ jobs:
         java: [ '1.8', '11', '17' ]
         codes: [ 'uncompressed,brotli', 'gzip,snappy' ]
     name: Build Parquet with JDK ${{ matrix.java }} and ${{ matrix.codes }}
-
     steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: thrift-compiler
+      - name: Install thrift compiler
+        run: sudo install thrift /usr/local/bin
       - uses: actions/checkout@master
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
       - name: before_install
-        env:
-          CI_TARGET_BRANCH: $GITHUB_HEAD_REF
         run: |
-          bash dev/ci-before_install.sh
+          branch_specific_script="dev/ci-before_install-${GITHUB_HEAD_REF}.sh"
+          if [[ -e "$branch_specific_script" ]]
+          then
+            . "$branch_specific_script"
+          fi
       - name: install
         run: |
           EXTRA_JAVA_TEST_ARGS=$(mvn help:evaluate -Dexpression=extraJavaTestArgs -q -DforceStdout)
@@ -49,7 +78,6 @@ jobs:
       - name: verify
         env:
           TEST_CODECS: ${{ matrix.codes }}
-          JAVA_VERSION: ${{ matrix.java }}
         run: |
           EXTRA_JAVA_TEST_ARGS=$(mvn help:evaluate -Dexpression=extraJavaTestArgs -q -DforceStdout)
           export MAVEN_OPTS="$MAVEN_OPTS $EXTRA_JAVA_TEST_ARGS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ cache:
 before_install:
   - lscpu
   - bash dev/ci-before_install.sh
+  - if [ -f "dev/ci-before_install-${CI_TARGET_BRANCH}.sh" ]; then . "dev/ci-before_install-${CI_TARGET_BRANCH}.sh"; fi
   - export JAVA_HOME="/usr/lib/jvm/adoptopenjdk-11-hotspot-arm64"    # for maven-javadoc-plugin
     
 install: 

--- a/dev/ci-before_install.sh
+++ b/dev/ci-before_install.sh
@@ -20,7 +20,7 @@
 # This script gets invoked by the CI system in a "before install" step
 ################################################################################
 
-export THRIFT_VERSION=0.16.0
+THRIFT_VERSION="${THRIFT_VERSION:-0.16.0}"
 
 set -e
 date
@@ -30,15 +30,11 @@ sudo apt-get install -qq --no-install-recommends build-essential pv autoconf aut
    libevent-dev automake libtool flex bison pkg-config g++ libssl-dev xmlstarlet
 date
 pwd
-wget -qO- https://archive.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz | tar zxf -
+if [ ! -f thrift-$THRIFT_VERSION.tar.gz ]; then
+  curl -sLO https://archive.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz
+fi
+tar zxf thrift-$THRIFT_VERSION.tar.gz
 cd thrift-${THRIFT_VERSION}
 chmod +x ./configure
 ./configure --disable-libs
 sudo make install
-cd ..
-branch_specific_script="dev/ci-before_install-${CI_TARGET_BRANCH}.sh"
-if [[ -e "$branch_specific_script" ]]
-then
-  . "$branch_specific_script"
-fi
-date


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-2205
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

This fix changes only CI-related files, so it's enough to make sure that CI jobs are improved.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
