### PR TITLE
PARQUET-2258: Storing toString fields in FilterPredicate instances can lead to memory pressure

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java
@@ -121,7 +121,6 @@ public final class Operators {
   static abstract class ColumnFilterPredicate<T extends Comparable<T>> implements FilterPredicate, Serializable  {
     private final Column<T> column;
     private final T value;
-    private final String toString;
 
     protected ColumnFilterPredicate(Column<T> column, T value) {
       this.column = Objects.requireNonNull(column, "column cannot be null");
@@ -129,9 +128,6 @@ public final class Operators {
       // Eq and NotEq allow value to be null, Lt, Gt, LtEq, GtEq however do not, so they guard against
       // null in their own constructors.
       this.value = value;
-
-      String name = getClass().getSimpleName().toLowerCase(Locale.ENGLISH);
-      this.toString = name + "(" + column.getColumnPath().toDotString() + ", " + value + ")";
     }
 
     public Column<T> getColumn() {
@@ -144,7 +140,8 @@ public final class Operators {
 
     @Override
     public String toString() {
-      return toString;
+      return getClass().getSimpleName().toLowerCase(Locale.ENGLISH) + "(" + column.getColumnPath().toDotString() + ", "
+          + value + ")";
     }
 
     @Override
@@ -330,13 +327,10 @@ public final class Operators {
   private static abstract class BinaryLogicalFilterPredicate implements FilterPredicate, Serializable {
     private final FilterPredicate left;
     private final FilterPredicate right;
-    private final String toString;
 
     protected BinaryLogicalFilterPredicate(FilterPredicate left, FilterPredicate right) {
       this.left = Objects.requireNonNull(left, "left cannot be null");
       this.right = Objects.requireNonNull(right, "right cannot be null");
-      String name = getClass().getSimpleName().toLowerCase(Locale.ENGLISH);
-      this.toString = name + "(" + left + ", " + right + ")";
     }
 
     public FilterPredicate getLeft() {
@@ -349,7 +343,7 @@ public final class Operators {
 
     @Override
     public String toString() {
-      return toString;
+      return getClass().getSimpleName().toLowerCase(Locale.ENGLISH) + "(" + left + ", " + right + ")";
     }
 
     @Override
@@ -400,11 +394,9 @@ public final class Operators {
 
   public static class Not implements FilterPredicate, Serializable {
     private final FilterPredicate predicate;
-    private final String toString;
 
     Not(FilterPredicate predicate) {
       this.predicate = Objects.requireNonNull(predicate, "predicate cannot be null");
-      this.toString = "not(" + predicate + ")";
     }
 
     public FilterPredicate getPredicate() {
@@ -413,7 +405,7 @@ public final class Operators {
 
     @Override
     public String toString() {
-      return toString;
+      return "not(" + predicate + ")";
     }
 
     @Override
@@ -456,15 +448,12 @@ public final class Operators {
     
   public static final class UserDefinedByClass<T extends Comparable<T>, U extends UserDefinedPredicate<T>> extends UserDefined<T, U> {
     private final Class<U> udpClass;
-    private final String toString;
     private static final String INSTANTIATION_ERROR_MESSAGE =
         "Could not instantiate custom filter: %s. User defined predicates must be static classes with a default constructor.";
 
     UserDefinedByClass(Column<T> column, Class<U> udpClass) {
       super(column);
       this.udpClass = Objects.requireNonNull(udpClass, "udpClass cannot be null");
-      String name = getClass().getSimpleName().toLowerCase(Locale.ENGLISH);
-      this.toString = name + "(" + column.getColumnPath().toDotString() + ", " + udpClass.getName() + ")";
 
       // defensively try to instantiate the class early to make sure that it's possible
       getUserDefinedPredicate();
@@ -485,7 +474,8 @@ public final class Operators {
 
     @Override
     public String toString() {
-      return toString;
+      return getClass().getSimpleName().toLowerCase(Locale.ENGLISH) + "(" + column.getColumnPath().toDotString() + ", "
+          + udpClass.getName() + ")";
     }
 
     @Override
@@ -511,14 +501,11 @@ public final class Operators {
   }
   
   public static final class UserDefinedByInstance<T extends Comparable<T>, U extends UserDefinedPredicate<T> & Serializable> extends UserDefined<T, U> {
-    private final String toString;
     private final U udpInstance;
 
     UserDefinedByInstance(Column<T> column, U udpInstance) {
       super(column);
       this.udpInstance = Objects.requireNonNull(udpInstance, "udpInstance cannot be null");
-      String name = getClass().getSimpleName().toLowerCase(Locale.ENGLISH);
-      this.toString = name + "(" + column.getColumnPath().toDotString() + ", " + udpInstance + ")";
     }
 
     @Override
@@ -528,7 +515,8 @@ public final class Operators {
 
     @Override
     public String toString() {
-      return toString;
+      return getClass().getSimpleName().toLowerCase(Locale.ENGLISH) + "(" + column.getColumnPath().toDotString() + ", "
+          + udpInstance + ")";
     }
 
     @Override
@@ -557,11 +545,9 @@ public final class Operators {
   // of the not() operator
   public static final class LogicalNotUserDefined <T extends Comparable<T>, U extends UserDefinedPredicate<T>> implements FilterPredicate, Serializable {
     private final UserDefined<T, U> udp;
-    private final String toString;
 
     LogicalNotUserDefined(UserDefined<T, U> userDefined) {
       this.udp = Objects.requireNonNull(userDefined, "userDefined cannot be null");
-      this.toString = "inverted(" + udp + ")";
     }
 
     public UserDefined<T, U> getUserDefined() {
@@ -575,7 +561,7 @@ public final class Operators {
 
     @Override
     public String toString() {
-      return toString;
+      return "inverted(" + udp + ")";
     }
 
     @Override


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
The existence of preallocated toString fields in FilterPredicate instances vs. toString() method should not be subject to any expectations regarding these classes, so testing whether there is a toString field or not doesn't make sense to me.

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
