### PR TITLE
Uniformizing booleans naming in ParquetWriter

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroParquetWriter.java
@@ -84,7 +84,7 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
                            int pageSize, boolean enableDictionary) throws IOException {
     super(file, AvroParquetWriter.<T>writeSupport(avroSchema, SpecificData.get()),
         compressionCodecName, blockSize, pageSize, enableDictionary,
-        DEFAULT_IS_VALIDATING_ENABLED);
+      DEFAULT_VALIDATING_ENABLED);
   }
 
   /** Create a new {@link AvroParquetWriter}. The default block size is 128 MB. The default
@@ -119,7 +119,7 @@ public class AvroParquetWriter<T> extends ParquetWriter<T> {
     this(file,
         AvroParquetWriter.<T>writeSupport(conf, avroSchema, SpecificData.get()),
         compressionCodecName, blockSize, pageSize,
-        enableDictionary, DEFAULT_IS_VALIDATING_ENABLED, DEFAULT_WRITER_VERSION,
+        enableDictionary, DEFAULT_VALIDATING_ENABLED, DEFAULT_WRITER_VERSION,
         conf);
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -47,8 +47,8 @@ public class ParquetProperties {
 
   public static final int DEFAULT_PAGE_SIZE = 1024 * 1024;
   public static final int DEFAULT_DICTIONARY_PAGE_SIZE = DEFAULT_PAGE_SIZE;
-  public static final boolean DEFAULT_IS_DICTIONARY_ENABLED = true;
-  public static final boolean DEFAULT_IS_BYTE_STREAM_SPLIT_ENABLED = false;
+  public static final boolean DEFAULT_DICTIONARY_ENABLED = true;
+  public static final boolean DEFAULT_BYTE_STREAM_SPLIT_ENABLED = false;
   public static final WriterVersion DEFAULT_WRITER_VERSION = WriterVersion.PARQUET_1_0;
   public static final boolean DEFAULT_ESTIMATE_ROW_COUNT_FOR_PAGE_SIZE_CHECK = true;
   public static final int DEFAULT_MINIMUM_RECORD_COUNT_FOR_CHECK = 100;
@@ -107,7 +107,7 @@ public class ParquetProperties {
   private final ColumnProperty<Boolean> bloomFilterEnabled;
   private final int pageRowCountLimit;
   private final boolean pageWriteChecksumEnabled;
-  private final boolean enableByteStreamSplit;
+  private final boolean byteStreamSplitEnabled;
 
   private ParquetProperties(Builder builder) {
     this.pageSizeThreshold = builder.pageSize;
@@ -130,7 +130,7 @@ public class ParquetProperties {
     this.maxBloomFilterBytes = builder.maxBloomFilterBytes;
     this.pageRowCountLimit = builder.pageRowCountLimit;
     this.pageWriteChecksumEnabled = builder.pageWriteChecksumEnabled;
-    this.enableByteStreamSplit = builder.enableByteStreamSplit;
+    this.byteStreamSplitEnabled = builder.enableByteStreamSplit;
   }
 
   public ValuesWriter newRepetitionLevelWriter(ColumnDescriptor path) {
@@ -193,7 +193,7 @@ public class ParquetProperties {
   }
 
   public boolean isByteStreamSplitEnabled() {
-      return enableByteStreamSplit;
+      return byteStreamSplitEnabled;
   }
 
   public ByteBufferAllocator getAllocator() {
@@ -320,10 +320,10 @@ public class ParquetProperties {
     private final ColumnProperty.Builder<Boolean> bloomFilterEnabled;
     private int pageRowCountLimit = DEFAULT_PAGE_ROW_COUNT_LIMIT;
     private boolean pageWriteChecksumEnabled = DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED;
-    private boolean enableByteStreamSplit = DEFAULT_IS_BYTE_STREAM_SPLIT_ENABLED;
+    private boolean enableByteStreamSplit = DEFAULT_BYTE_STREAM_SPLIT_ENABLED;
 
     private Builder() {
-      enableDict = ColumnProperty.<Boolean>builder().withDefaultValue(DEFAULT_IS_DICTIONARY_ENABLED);
+      enableDict = ColumnProperty.<Boolean>builder().withDefaultValue(DEFAULT_DICTIONARY_ENABLED);
       bloomFilterEnabled = ColumnProperty.<Boolean>builder().withDefaultValue(DEFAULT_BLOOM_FILTER_ENABLED);
       bloomFilterNDVs = ColumnProperty.<Long>builder().withDefaultValue(null);
       bloomFilterFPPs = ColumnProperty.<Double>builder().withDefaultValue(DEFAULT_BLOOM_FILTER_FPP);
@@ -345,7 +345,7 @@ public class ParquetProperties {
       this.bloomFilterFPPs = ColumnProperty.<Double>builder(toCopy.bloomFilterFPPs);
       this.bloomFilterEnabled = ColumnProperty.<Boolean>builder(toCopy.bloomFilterEnabled);
       this.maxBloomFilterBytes = toCopy.maxBloomFilterBytes;
-      this.enableByteStreamSplit = toCopy.enableByteStreamSplit;
+      this.enableByteStreamSplit = toCopy.byteStreamSplitEnabled;
     }
 
     /**

--- a/parquet-common/src/main/java/org/apache/parquet/io/DelegatingSeekableInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/DelegatingSeekableInputStream.java
@@ -32,7 +32,7 @@ import java.nio.ByteBuffer;
  */
 public abstract class DelegatingSeekableInputStream extends SeekableInputStream {
 
-  private final int COPY_BUFFER_SIZE = 8192;
+  private static final int COPY_BUFFER_SIZE = 8192;
   private final byte[] temp = new byte[COPY_BUFFER_SIZE];
 
   private final InputStream stream;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -258,7 +258,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
 
   public static boolean getEnableDictionary(Configuration configuration) {
     return configuration.getBoolean(
-        ENABLE_DICTIONARY, ParquetProperties.DEFAULT_IS_DICTIONARY_ENABLED);
+        ENABLE_DICTIONARY, ParquetProperties.DEFAULT_DICTIONARY_ENABLED);
   }
 
   public static int getMinRowCountForPageSizeCheck(Configuration configuration) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordWriter.java
@@ -48,7 +48,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
 
   /**
    *
-   * @param w the file to write to
+   * @param parquetFileWriter the file to write to
    * @param writeSupport the class to convert incoming records
    * @param schema the schema of the records
    * @param extraMetaData extra meta data to write in the footer of the file
@@ -62,7 +62,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
    */
   @Deprecated
   public ParquetRecordWriter(
-      ParquetFileWriter w,
+      ParquetFileWriter parquetFileWriter,
       WriteSupport<T> writeSupport,
       MessageType schema,
       Map<String, String> extraMetaData,
@@ -78,7 +78,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
         .withDictionaryEncoding(enableDictionary)
         .withWriterVersion(writerVersion)
         .build();
-    internalWriter = new InternalParquetRecordWriter<T>(w, writeSupport, schema,
+    internalWriter = new InternalParquetRecordWriter<T>(parquetFileWriter, writeSupport, schema,
         extraMetaData, blockSize, compressor, validating, props);
     this.memoryManager = null;
     this.codecFactory = null;
@@ -86,7 +86,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
 
   /**
    *
-   * @param w the file to write to
+   * @param parquetFileWriter the file to write to
    * @param writeSupport the class to convert incoming records
    * @param schema the schema of the records
    * @param extraMetaData extra meta data to write in the footer of the file
@@ -101,7 +101,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
    */
   @Deprecated
   public ParquetRecordWriter(
-      ParquetFileWriter w,
+      ParquetFileWriter parquetFileWriter,
       WriteSupport<T> writeSupport,
       MessageType schema,
       Map<String, String> extraMetaData,
@@ -118,7 +118,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
         .withDictionaryEncoding(enableDictionary)
         .withWriterVersion(writerVersion)
         .build();
-    internalWriter = new InternalParquetRecordWriter<T>(w, writeSupport, schema,
+    internalWriter = new InternalParquetRecordWriter<T>(parquetFileWriter, writeSupport, schema,
         extraMetaData, blockSize, compressor, validating, props);
     this.memoryManager = Objects.requireNonNull(memoryManager, "memoryManager cannot be null");
     memoryManager.addWriter(internalWriter, blockSize);
@@ -127,7 +127,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
 
   /**
    *
-   * @param w the file to write to
+   * @param parquetFileWriter the file to write to
    * @param writeSupport the class to convert incoming records
    * @param schema the schema of the records
    * @param extraMetaData extra meta data to write in the footer of the file
@@ -137,7 +137,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
    * @param props parquet encoding properties
    */
   ParquetRecordWriter(
-      ParquetFileWriter w,
+      ParquetFileWriter parquetFileWriter,
       WriteSupport<T> writeSupport,
       MessageType schema,
       Map<String, String> extraMetaData,
@@ -148,7 +148,7 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
       MemoryManager memoryManager,
       Configuration conf) {
     this.codecFactory = new CodecFactory(conf, props.getPageSizeThreshold());
-    internalWriter = new InternalParquetRecordWriter<T>(w, writeSupport, schema,
+    internalWriter = new InternalParquetRecordWriter<T>(parquetFileWriter, writeSupport, schema,
         extraMetaData, blockSize, codecFactory.getCompressor(codec), validating,
         props);
     this.memoryManager = Objects.requireNonNull(memoryManager, "memoryManager cannot be null");

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -44,9 +44,9 @@ public class ParquetWriter<T> implements Closeable {
       ParquetProperties.DEFAULT_PAGE_SIZE;
   public static final CompressionCodecName DEFAULT_COMPRESSION_CODEC_NAME =
       CompressionCodecName.UNCOMPRESSED;
-  public static final boolean DEFAULT_IS_DICTIONARY_ENABLED =
-      ParquetProperties.DEFAULT_IS_DICTIONARY_ENABLED;
-  public static final boolean DEFAULT_IS_VALIDATING_ENABLED = false;
+  public static final boolean DEFAULT_DICTIONARY_ENABLED =
+      ParquetProperties.DEFAULT_DICTIONARY_ENABLED;
+  public static final boolean DEFAULT_VALIDATING_ENABLED = false;
   public static final WriterVersion DEFAULT_WRITER_VERSION =
       ParquetProperties.DEFAULT_WRITER_VERSION;
 
@@ -73,7 +73,7 @@ public class ParquetWriter<T> implements Closeable {
   @Deprecated
   public ParquetWriter(Path file, WriteSupport<T> writeSupport, CompressionCodecName compressionCodecName, int blockSize, int pageSize) throws IOException {
     this(file, writeSupport, compressionCodecName, blockSize, pageSize,
-        DEFAULT_IS_DICTIONARY_ENABLED, DEFAULT_IS_VALIDATING_ENABLED);
+      DEFAULT_DICTIONARY_ENABLED, DEFAULT_VALIDATING_ENABLED);
   }
 
   /**
@@ -258,8 +258,8 @@ public class ParquetWriter<T> implements Closeable {
         DEFAULT_BLOCK_SIZE,
         DEFAULT_PAGE_SIZE,
         DEFAULT_PAGE_SIZE,
-        DEFAULT_IS_DICTIONARY_ENABLED,
-        DEFAULT_IS_VALIDATING_ENABLED,
+      DEFAULT_DICTIONARY_ENABLED,
+      DEFAULT_VALIDATING_ENABLED,
         DEFAULT_WRITER_VERSION,
         conf);
   }
@@ -357,7 +357,7 @@ public class ParquetWriter<T> implements Closeable {
     private CompressionCodecName codecName = DEFAULT_COMPRESSION_CODEC_NAME;
     private long rowGroupSize = DEFAULT_BLOCK_SIZE;
     private int maxPaddingSize = MAX_PADDING_SIZE_DEFAULT;
-    private boolean enableValidation = DEFAULT_IS_VALIDATING_ENABLED;
+    private boolean enableValidation = DEFAULT_VALIDATING_ENABLED;
     private ParquetProperties.Builder encodingPropsBuilder =
         ParquetProperties.builder();
 


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references them in the PR title. For example, "PARQUET-1234: My Parquet PR"
  - https://issues.apache.org/jira/browse/PARQUET-XXX
  - In case you are adding a dependency, check if the license complies with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR does not need testing for this extremely good reason: Only variable renaming

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - All the public functions and the classes in the PR contain Javadoc that explain what it does
