### PR TITLE
PARQUET-2412: Reduce excessive synchronization in MemoryManager

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/MemoryManager.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/MemoryManager.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +47,7 @@ public class MemoryManager {
 
   private final long totalMemoryPool;
   private final long minMemoryAllocation;
-  private final Map<InternalParquetRecordWriter<?>, Long> writerList = new HashMap<>();
+  private final Map<InternalParquetRecordWriter<?>, Long> writerList = new ConcurrentHashMap<>();
   private final Map<String, Runnable> callBacks = new HashMap<String, Runnable>();
   private double scale = 1.0;
 
@@ -74,7 +75,7 @@ public class MemoryManager {
    * @param writer     the new created writer
    * @param allocation the requested buffer size
    */
-  synchronized void addWriter(InternalParquetRecordWriter<?> writer, Long allocation) {
+  void addWriter(InternalParquetRecordWriter<?> writer, Long allocation) {
     Long oldValue = writerList.get(writer);
     if (oldValue == null) {
       writerList.put(writer, allocation);
@@ -92,7 +93,7 @@ public class MemoryManager {
    *
    * @param writer the writer that has been closed
    */
-  synchronized void removeWriter(InternalParquetRecordWriter<?> writer) {
+  void removeWriter(InternalParquetRecordWriter<?> writer) {
     writerList.remove(writer);
     if (!writerList.isEmpty()) {
       updateAllocation();


### PR DESCRIPTION
The surface of the synchronized methods is unnecessarily large which in case of large number of concurrent writers may be suboptimal, threads may starve each other for access to the writerList (if writers are being dynamically closed and created). Please see the profile reports in the Jira issue. The fix in this PR is to use `ConcurrentHashMap` for `MemoryManager`'s `writerList` instead of sync methods.

### Jira

- [x] My PR addresses the following https://issues.apache.org/jira/browse/PARQUET-2412 issues and references
  them in the PR title.

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason: there are already tests for `MemoryManager`.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.