### PR TITLE
PARQUET-2415: Reuse hadoop file status and footer in ParquetRecordReader

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowFooterCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ShowFooterCommand.java
@@ -24,6 +24,7 @@ import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -64,6 +65,11 @@ public class ShowFooterCommand extends BaseCommand {
     return 0;
   }
 
+  abstract class MixIn {
+    @JsonIgnore
+    abstract int getInputFile();
+  }
+
   private String readFooter(InputFile inputFile) throws JsonProcessingException, IOException {
     String json;
     try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
@@ -71,6 +77,7 @@ public class ShowFooterCommand extends BaseCommand {
       ObjectMapper mapper = RawUtils.createObjectMapper();
       mapper.setVisibility(PropertyAccessor.ALL, Visibility.NONE);
       mapper.setVisibility(PropertyAccessor.FIELD, Visibility.ANY);
+      mapper.addMixIn(ParquetMetadata.class, MixIn.class);
       json = mapper.writerWithDefaultPrettyPrinter().writeValueAsString(footer);
     }
     return json;

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -96,6 +96,11 @@
       <version>${jackson-databind.version}</version>
     </dependency>
     <dependency>
+      <groupId>${jackson.groupId}</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>${jackson-databind.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.xerial.snappy</groupId>
       <artifactId>snappy-java</artifactId>
       <version>1.1.10.5</version>

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -613,8 +613,10 @@ public class ParquetFileReader implements Closeable {
 
     // Regular file, or encrypted file with plaintext footer
     if (!encryptedFooterMode) {
-      return converter.readParquetMetadata(
+      ParquetMetadata parquetMetadata = converter.readParquetMetadata(
           footerBytesStream, options.getMetadataFilter(), fileDecryptor, false, fileMetadataLength);
+      parquetMetadata.setInputFile(file);
+      return parquetMetadata;
     }
 
     // Encrypted file with encrypted footer
@@ -625,7 +627,9 @@ public class ParquetFileReader implements Closeable {
     fileDecryptor.setFileCryptoMetaData(
         fileCryptoMetaData.getEncryption_algorithm(), true, fileCryptoMetaData.getKey_metadata());
     // footer length is required only for signed plaintext footers
-    return converter.readParquetMetadata(footerBytesStream, options.getMetadataFilter(), fileDecryptor, true, 0);
+    ParquetMetadata parquetMetadata =converter.readParquetMetadata(footerBytesStream, options.getMetadataFilter(), fileDecryptor, true, 0);
+    parquetMetadata.setInputFile(file);
+    return parquetMetadata;
   }
 
   /**
@@ -824,12 +828,20 @@ public class ParquetFileReader implements Closeable {
   }
 
   public ParquetFileReader(InputFile file, ParquetReadOptions options) throws IOException {
+    this(file, options, null);
+  }
+
+  public ParquetFileReader(InputFile file, ParquetReadOptions options, ParquetMetadata footer) throws IOException {
     this.converter = new ParquetMetadataConverter(options);
     this.file = file;
     this.f = file.newStream();
     this.options = options;
     try {
-      this.footer = readFooter(file, options, f, converter);
+      if (footer == null) {
+        this.footer = readFooter(file, options, f, converter);
+      } else {
+        this.footer = footer;
+      }
     } catch (Exception e) {
       // In case that reading footer throws an exception in the constructor, the new stream
       // should be closed. Otherwise, there's no way to close this outside.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -839,10 +839,9 @@ public class ParquetFileReader implements Closeable {
     this.options = options;
     try {
       if (footer == null) {
-        this.footer = readFooter(file, options, f, converter);
-      } else {
-        this.footer = footer;
+        footer = readFooter(file, options, f, converter);
       }
+      this.footer = footer;
     } catch (Exception e) {
       // In case that reading footer throws an exception in the constructor, the new stream
       // should be closed. Otherwise, there's no way to close this outside.

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -627,7 +627,8 @@ public class ParquetFileReader implements Closeable {
     fileDecryptor.setFileCryptoMetaData(
         fileCryptoMetaData.getEncryption_algorithm(), true, fileCryptoMetaData.getKey_metadata());
     // footer length is required only for signed plaintext footers
-    ParquetMetadata parquetMetadata =converter.readParquetMetadata(footerBytesStream, options.getMetadataFilter(), fileDecryptor, true, 0);
+    ParquetMetadata parquetMetadata =
+        converter.readParquetMetadata(footerBytesStream, options.getMetadataFilter(), fileDecryptor, true, 0);
     parquetMetadata.setInputFile(file);
     return parquetMetadata;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputSplit.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputSplit.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
@@ -30,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Writable;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputSplit.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputSplit.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 
@@ -54,6 +55,7 @@ public class ParquetInputSplit extends FileSplit implements Writable {
 
   private long end;
   private long[] rowGroupOffsets;
+  private volatile ParquetMetadata footer;
 
   /**
    * Writables must have a parameterless constructor
@@ -220,6 +222,14 @@ public class ParquetInputSplit extends FileSplit implements Writable {
    */
   public long[] getRowGroupOffsets() {
     return rowGroupOffsets;
+  }
+
+  public ParquetMetadata getFooter() {
+    return footer;
+  }
+
+  public void setFooter(ParquetMetadata footer) {
+    this.footer = footer;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputSplit.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputSplit.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.Writable;
@@ -55,6 +56,8 @@ public class ParquetInputSplit extends FileSplit implements Writable {
 
   private long end;
   private long[] rowGroupOffsets;
+
+  @JsonIgnore
   private volatile ParquetMetadata footer;
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
@@ -156,8 +156,9 @@ public class ParquetRecordReader<T> extends RecordReader<Void, T> {
 
     // open a reader with the metadata filter
     HadoopInputFile inputFile;
-    if (split.getFooter() != null && split.getFooter().getInputFile() != null
-      && split.getFooter().getInputFile() instanceof HadoopInputFile) {
+    if (split.getFooter() != null
+        && split.getFooter().getInputFile() != null
+        && split.getFooter().getInputFile() instanceof HadoopInputFile) {
       inputFile = (HadoopInputFile) split.getFooter().getInputFile();
     } else {
       inputFile = HadoopInputFile.fromPath(path, configuration);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
@@ -155,8 +155,14 @@ public class ParquetRecordReader<T> extends RecordReader<Void, T> {
     }
 
     // open a reader with the metadata filter
-    ParquetFileReader reader =
-        ParquetFileReader.open(HadoopInputFile.fromPath(path, configuration), optionsBuilder.build());
+    HadoopInputFile inputFile;
+    if (split.getFooter() != null && split.getFooter().getInputFile() != null
+      && split.getFooter().getInputFile() instanceof HadoopInputFile) {
+      inputFile = (HadoopInputFile) split.getFooter().getInputFile();
+    } else {
+      inputFile = HadoopInputFile.fromPath(path, configuration);
+    }
+    ParquetFileReader reader = new ParquetFileReader(inputFile, optionsBuilder.build(), split.getFooter());
 
     if (rowGroupOffsets != null) {
       // verify a row group was found for each offset

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordReader.java
@@ -46,6 +46,7 @@ import org.apache.parquet.hadoop.metadata.FileMetaData;
 import org.apache.parquet.hadoop.util.ContextUtil;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.hadoop.util.counters.BenchmarkCounter;
+import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -155,11 +156,9 @@ public class ParquetRecordReader<T> extends RecordReader<Void, T> {
     }
 
     // open a reader with the metadata filter
-    HadoopInputFile inputFile;
-    if (split.getFooter() != null
-        && split.getFooter().getInputFile() != null
-        && split.getFooter().getInputFile() instanceof HadoopInputFile) {
-      inputFile = (HadoopInputFile) split.getFooter().getInputFile();
+    InputFile inputFile;
+    if (split.getFooter() != null && split.getFooter().getInputFile() != null) {
+      inputFile = split.getFooter().getInputFile();
     } else {
       inputFile = HadoopInputFile.fromPath(path, configuration);
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.hadoop.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.parquet.io.InputFile;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -84,6 +85,8 @@ public class ParquetMetadata {
   private final FileMetaData fileMetaData;
   private final List<BlockMetaData> blocks;
 
+  private volatile InputFile inputFile;
+
   /**
    * @param fileMetaData file level metadata
    * @param blocks       block level metadata
@@ -105,6 +108,14 @@ public class ParquetMetadata {
    */
   public FileMetaData getFileMetaData() {
     return fileMetaData;
+  }
+
+  public InputFile getInputFile() {
+    return inputFile;
+  }
+
+  public void setInputFile(InputFile inputFile) {
+    this.inputFile = inputFile;
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
@@ -19,11 +19,11 @@
 package org.apache.parquet.hadoop.metadata;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.parquet.io.InputFile;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.List;
+import org.apache.parquet.io.InputFile;
 
 /**
  * Meta Data block stored in the footer of the file

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop.metadata;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.StringReader;
@@ -85,6 +86,7 @@ public class ParquetMetadata {
   private final FileMetaData fileMetaData;
   private final List<BlockMetaData> blocks;
 
+  @JsonIgnore
   private volatile InputFile inputFile;
 
   /**

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ParquetMetadata.java
@@ -112,10 +112,18 @@ public class ParquetMetadata {
     return fileMetaData;
   }
 
+  /**
+   * Reuse the inputFile in ParquetFileReader if it is not null
+   * @return
+   */
   public InputFile getInputFile() {
     return inputFile;
   }
 
+  /**
+   *
+   * @param inputFile Cache the inputFile in readFooter method and reuse it in ParquetFileReader
+   */
   public void setInputFile(InputFile inputFile) {
     this.inputFile = inputFile;
   }


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-2415: Reuse hadoop file status and footer in ParquetRecordReader"
    - https://issues.apache.org/jira/browse/PARQUET-2415

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [ ] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - Call `ParquetInputSplit.setFooter(footer)` before creating a ParquetRecordReader from this split, then the reader will  reuse the Hadoop file status and skip the  getfileinfo Hadoop RPC and skip reading the footer again.
