### PR TITLE
PARQUET-2477: close readers opened by ParquetFileWriter

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -124,6 +124,9 @@ public class ParquetFileWriter implements AutoCloseable {
   private final AlignmentStrategy alignment;
   private final int columnIndexTruncateLength;
 
+  // file reader
+  private final List<ParquetFileReader> readers = new ArrayList<>();
+
   // file data
   private final List<BlockMetaData> blocks = new ArrayList<BlockMetaData>();
 
@@ -1433,12 +1436,14 @@ public class ParquetFileWriter implements AutoCloseable {
   public void appendFile(Configuration conf, Path file) throws IOException {
     try (ParquetFileReader reader = ParquetFileReader.open(conf, file)) {
       reader.appendTo(this);
+      readers.add(reader);
     }
   }
 
   public void appendFile(InputFile file) throws IOException {
     try (ParquetFileReader reader = ParquetFileReader.open(file)) {
       reader.appendTo(this);
+      readers.add(reader);
     }
   }
 
@@ -1662,6 +1667,9 @@ public class ParquetFileWriter implements AutoCloseable {
       temp.flush();
       if (crcAllocator != null) {
         crcAllocator.close();
+      }
+      for (ParquetFileReader reader : readers) {
+        reader.close();
       }
     }
   }


### PR DESCRIPTION
Files opened by `appendFile` method of `ParquetFileWriter` should be closed correctly.


Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-2477
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [x] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
