### PR TITLE
PARQUET-781. Direct support for PathOutputCommitter

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -66,6 +66,8 @@ public class ParquetProperties {
 
   public static final boolean DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED = true;
 
+  public static final boolean DEFAULT_PAGE_PATH_OUTPUT_COMMITTER_ENABLED = false;
+
   public static final ValuesWriterFactory DEFAULT_VALUES_WRITER_FACTORY = new DefaultValuesWriterFactory();
 
   private static final int MIN_SLAB_SIZE = 64;


### PR DESCRIPTION

If `parquet.path.outputcommitter.enabled` is true
then it uses the `PathOutputCommitterFactory` mechanism to dynamically
choose a committer for the output path.
Such committers do not generate summary files; a warning
about this is printed when appropriate
 
This significantly simplifies writing to s3/azure/gcs
though committers which commit correctly and efficiently
to the target stores.

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:


No tests yet

### Commits

- [X] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [X] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
