### PR TITLE
PARQUET-2139: fix file_offset field in ColumnChunk metadata

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -534,8 +534,9 @@ public class ParquetMetadataConverter {
     int columnOrdinal = -1;
     ByteArrayOutputStream tempOutStream = null;
     for (ColumnChunkMetaData columnMetaData : columns) {
-      ColumnChunk columnChunk =
-          new ColumnChunk(columnMetaData.getFirstDataPageOffset()); // verify this is the right offset
+      // There is no ColumnMetaData written after the chunk data, so set the ColumnChunk
+      // file_offset to 0
+      ColumnChunk columnChunk = new ColumnChunk(0);
       columnChunk.file_path = block.getPath(); // they are in the same file for now
       InternalColumnEncryptionSetup columnSetup = null;
       boolean writeCryptoMetadata = false;


### PR DESCRIPTION
Fixes the referenced issue wherein the `file_offset` field of the `ColumnChunk` object is improperly set to the offset of the first page in the column chunk. Because parquet-java does not write a copy of `ColumnMetaData` after the column chunk, this PR simply sets the value of `file_offset` to 0 (per [apache/parquet-format/#440](https://github.com/apache/parquet-format/pull/440)).

Closes #2678.

Make sure you have checked _all_ steps below.

### Jira

- [x] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-2139
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
The footer metadata lacks the `file_offset` field, so unit testing is difficult. Manual inspection of generated files confirms the desired output.

### Commits

- [x] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [x] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
