### PR TITLE
PARQUET-2498: Vector IO to handle empty range list

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/wrapped/io/VectorIoBridge.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/wrapped/io/VectorIoBridge.java
@@ -362,7 +362,12 @@ public final class VectorIoBridge {
   private static List<ParquetFileRange> validateAndSortRanges(final List<ParquetFileRange> input) {
 
     requireNonNull(input, "Null input list");
-    checkArgument(!input.isEmpty(), "Empty input list");
+    if (input.isEmpty()) {
+      // this may seem a pathological case, but it
+      // has surfaced during testing.
+      LOG.debug("Empty input list");
+      return input;
+    }
     final List<ParquetFileRange> sortedRanges;
 
     if (input.size() == 1) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/wrapped/io/TestVectorIoBridge.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/wrapped/io/TestVectorIoBridge.java
@@ -305,6 +305,17 @@ public class TestVectorIoBridge {
     verifyExceptionalVectoredRead(null, NullPointerException.class);
   }
 
+  /**
+   * An empty range list is permitted.
+   */
+  @Test
+  public void testEmptyRangeList() throws Exception {
+    List<ParquetFileRange> fileRanges = new ArrayList<>();
+    try (FSDataInputStream in = openTestFile()) {
+      readVectored(in, fileRanges);
+    }
+  }
+
   @Test
   public void testSomeRandomNonOverlappingRanges() throws Exception {
     List<ParquetFileRange> fileRanges = ranges(


### PR DESCRIPTION

Empty range lists currently trigger IllegalArgumentException,
however some (integration test) codepaths attempt to do this.

Downgrading the empty list case to a no-op resolves this.

Change-Id: Ia0f94422415aeeacb15d3c3a909d4de6f1563268

Make sure you have checked _all_ steps below.

### Jira

- [X] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [X] My PR adds the following unit tests 

```
TestVectorIoBridge.testEmptyRangeList()
```


### Commits

- [X ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [X] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
