### PR TITLE
PARQUET-2471: Add support for geometry logical type

### DIFF
--- a/parquet-column/pom.xml
+++ b/parquet-column/pom.xml
@@ -75,6 +75,11 @@
       <artifactId>slf4j-api</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>${jts.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>com.carrotsearch</groupId>

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.column.statistics;
 
+import org.apache.parquet.column.statistics.geometry.GeometryStatistics;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/BinaryStatistics.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.column.statistics;
 
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
 
@@ -30,6 +31,7 @@ public class BinaryStatistics extends Statistics<Binary> {
 
   private Binary max;
   private Binary min;
+  private GeometryStatistics geometryStatistics = null;
 
   /**
    * @deprecated will be removed in 2.0.0. Use {@link Statistics#createStats(org.apache.parquet.schema.Type)} instead
@@ -41,6 +43,10 @@ public class BinaryStatistics extends Statistics<Binary> {
 
   BinaryStatistics(PrimitiveType type) {
     super(type);
+    LogicalTypeAnnotation logicalType = type.getLogicalTypeAnnotation();
+    if (logicalType instanceof LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) {
+      geometryStatistics = new GeometryStatistics();
+    }
   }
 
   private BinaryStatistics(BinaryStatistics other) {
@@ -49,6 +55,9 @@ public class BinaryStatistics extends Statistics<Binary> {
       initializeStats(other.min, other.max);
     }
     setNumNulls(other.getNumNulls());
+    if (other.geometryStatistics != null) {
+      geometryStatistics = other.geometryStatistics.copy();
+    }
   }
 
   @Override
@@ -62,6 +71,9 @@ public class BinaryStatistics extends Statistics<Binary> {
     } else if (comparator().compare(max, value) < 0) {
       max = value.copy();
     }
+    if (geometryStatistics != null) {
+      geometryStatistics.update(value);
+    }
   }
 
   @Override
@@ -71,6 +83,9 @@ public class BinaryStatistics extends Statistics<Binary> {
       initializeStats(binaryStats.getMin(), binaryStats.getMax());
     } else {
       updateStats(binaryStats.getMin(), binaryStats.getMax());
+    }
+    if (geometryStatistics != null) {
+      geometryStatistics.merge(binaryStats.geometryStatistics);
     }
   }
 
@@ -189,5 +204,13 @@ public class BinaryStatistics extends Statistics<Binary> {
   @Override
   public BinaryStatistics copy() {
     return new BinaryStatistics(this);
+  }
+
+  public void setGeometryStatistics(GeometryStatistics geometryStatistics) {
+    this.geometryStatistics = geometryStatistics;
+  }
+
+  public GeometryStatistics getGeometryStatistics() {
+    return geometryStatistics;
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/GeometryStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/GeometryStatistics.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.statistics;
+
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.column.statistics.geometry.BoundingBox;
+import org.apache.parquet.column.statistics.geometry.Covering;
+import org.apache.parquet.column.statistics.geometry.EnvelopeCovering;
+import org.apache.parquet.column.statistics.geometry.GeometryTypes;
+import org.apache.parquet.io.api.Binary;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
+
+public class GeometryStatistics {
+
+  private final BoundingBox boundingBox;
+  private final Covering covering;
+  private final GeometryTypes geometryTypes;
+  private final WKBReader reader = new WKBReader();
+
+  public GeometryStatistics(BoundingBox boundingBox, Covering covering, GeometryTypes geometryTypes) {
+    this.boundingBox = boundingBox;
+    this.covering = covering;
+    this.geometryTypes = geometryTypes;
+  }
+
+  public GeometryStatistics() {
+    this(new BoundingBox(), new EnvelopeCovering(), new GeometryTypes());
+  }
+
+  public BoundingBox getBoundingBox() {
+    return boundingBox;
+  }
+
+  public Covering getCovering() {
+    return covering;
+  }
+
+  public GeometryTypes getGeometryTypes() {
+    return geometryTypes;
+  }
+
+  public void update(Binary value) {
+    if (value == null) {
+      return;
+    }
+    try {
+      Geometry geom = reader.read(value.getBytes());
+      update(geom);
+    } catch (ParseException e) {
+      abort();
+    }
+  }
+
+  public void update(Geometry geom) {
+    boundingBox.update(geom);
+    covering.update(geom);
+    geometryTypes.update(geom);
+  }
+
+  public void merge(GeometryStatistics other) {
+    Preconditions.checkArgument(other != null, "Cannot merge with null GeometryStatistics");
+    boundingBox.merge(other.boundingBox);
+    covering.merge(other.covering);
+    geometryTypes.merge(other.geometryTypes);
+  }
+
+  public void reset() {
+    boundingBox.reset();
+    covering.reset();
+    geometryTypes.reset();
+  }
+
+  public void abort() {
+    boundingBox.abort();
+    covering.abort();
+    geometryTypes.abort();
+  }
+
+  public GeometryStatistics copy() {
+    return new GeometryStatistics(boundingBox.copy(), covering.copy(), geometryTypes.copy());
+  }
+
+  @Override
+  public String toString() {
+    return "GeometryStatistics{" + "boundingBox="
+        + boundingBox + ", covering="
+        + covering + ", geometryTypes="
+        + geometryTypes + '}';
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/Statistics.java
@@ -20,6 +20,7 @@ package org.apache.parquet.column.statistics;
 
 import java.util.Arrays;
 import org.apache.parquet.column.UnknownColumnTypeException;
+import org.apache.parquet.column.statistics.geometry.GeometryStatistics;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.Float16;
 import org.apache.parquet.schema.LogicalTypeAnnotation;

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/BoundingBox.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/BoundingBox.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.statistics.geometry;
+
+import org.apache.parquet.Preconditions;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+
+public class BoundingBox {
+
+  private double xMin = Double.MAX_VALUE;
+  private double xMax = Double.MIN_VALUE;
+  private double yMin = Double.MAX_VALUE;
+  private double yMax = Double.MIN_VALUE;
+  private double zMin = Double.MAX_VALUE;
+  private double zMax = Double.MIN_VALUE;
+  private double mMin = Double.MAX_VALUE;
+  private double mMax = Double.MIN_VALUE;
+
+  public BoundingBox(
+      double xMin, double xMax, double yMin, double yMax, double zMin, double zMax, double mMin, double mMax) {
+    this.xMin = xMin;
+    this.xMax = xMax;
+    this.yMin = yMin;
+    this.yMax = yMax;
+    this.zMin = zMin;
+    this.zMax = zMax;
+    this.mMin = mMin;
+    this.mMax = mMax;
+  }
+
+  public BoundingBox() {}
+
+  public double getXMin() {
+    return xMin;
+  }
+
+  public double getXMax() {
+    return xMax;
+  }
+
+  public double getYMin() {
+    return yMin;
+  }
+
+  public double getYMax() {
+    return yMax;
+  }
+
+  public double getZMin() {
+    return zMin;
+  }
+
+  public double getZMax() {
+    return zMax;
+  }
+
+  public double getMMin() {
+    return mMin;
+  }
+
+  public double getMMax() {
+    return mMax;
+  }
+
+  public void update(Geometry geom) {
+    if (geom == null || geom.isEmpty()) {
+      return;
+    }
+    Coordinate[] coordinates = geom.getCoordinates();
+    for (Coordinate coordinate : coordinates) {
+      update(coordinate.getX(), coordinate.getY(), coordinate.getZ(), coordinate.getM());
+    }
+  }
+
+  public void update(double x, double y, double z, double m) {
+    xMin = Math.min(xMin, x);
+    xMax = Math.max(xMax, x);
+    yMin = Math.min(yMin, y);
+    yMax = Math.max(yMax, y);
+    zMin = Math.min(zMin, z);
+    zMax = Math.max(zMax, z);
+    mMin = Math.min(mMin, m);
+    mMax = Math.max(mMax, m);
+  }
+
+  public void merge(BoundingBox other) {
+    Preconditions.checkArgument(other != null, "Cannot merge with null bounding box");
+    xMin = Math.min(xMin, other.xMin);
+    xMax = Math.max(xMax, other.xMax);
+    yMin = Math.min(yMin, other.yMin);
+    yMax = Math.max(yMax, other.yMax);
+    zMin = Math.min(zMin, other.zMin);
+    zMax = Math.max(zMax, other.zMax);
+    mMin = Math.min(mMin, other.mMin);
+    mMax = Math.max(mMax, other.mMax);
+  }
+
+  public void reset() {
+    xMin = Double.MAX_VALUE;
+    xMax = Double.MIN_VALUE;
+    yMin = Double.MAX_VALUE;
+    yMax = Double.MIN_VALUE;
+    zMin = Double.MAX_VALUE;
+    zMax = Double.MIN_VALUE;
+    mMin = Double.MAX_VALUE;
+    mMax = Double.MIN_VALUE;
+  }
+
+  public void abort() {
+    xMin = Double.NaN;
+    xMax = Double.NaN;
+    yMin = Double.NaN;
+    yMax = Double.NaN;
+    zMin = Double.NaN;
+    zMax = Double.NaN;
+    mMin = Double.NaN;
+    mMax = Double.NaN;
+  }
+
+  public BoundingBox copy() {
+    return new BoundingBox(xMin, xMax, yMin, yMax, zMin, zMax, mMin, mMax);
+  }
+
+  @Override
+  public String toString() {
+    return "BoundingBox{" + "xMin="
+        + xMin + ", xMax="
+        + xMax + ", yMin="
+        + yMin + ", yMax="
+        + yMax + ", zMin="
+        + zMin + ", zMax="
+        + zMax + ", mMin="
+        + mMin + ", mMax="
+        + mMax + '}';
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/BoundingBox.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/BoundingBox.java
@@ -79,7 +79,7 @@ public class BoundingBox {
     return mMax;
   }
 
-  public void update(Geometry geom) {
+  void update(Geometry geom) {
     if (geom == null || geom.isEmpty()) {
       return;
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/Covering.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/Covering.java
@@ -24,7 +24,6 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKBReader;
-import org.locationtech.jts.io.WKBWriter;
 
 public class Covering {
 
@@ -47,7 +46,8 @@ public class Covering {
   }
 
   void update(Geometry geom) {
-    geometry = ByteBuffer.wrap(new WKBWriter().write(geom));
+    throw new UnsupportedOperationException(
+        "Update is not supported for " + this.getClass().getSimpleName());
   }
 
   public void merge(Covering other) {
@@ -66,8 +66,7 @@ public class Covering {
   }
 
   public Covering copy() {
-    throw new UnsupportedOperationException(
-        "Copy is not supported for " + this.getClass().getSimpleName());
+    return new Covering(geometry.duplicate(), edges);
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/Covering.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/Covering.java
@@ -46,7 +46,7 @@ public class Covering {
     return edges;
   }
 
-  public void update(Geometry geom) {
+  void update(Geometry geom) {
     geometry = ByteBuffer.wrap(new WKBWriter().write(geom));
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/Covering.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/Covering.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.statistics.geometry;
+
+import java.nio.ByteBuffer;
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
+import org.locationtech.jts.io.WKBWriter;
+
+public class Covering {
+
+  protected final LogicalTypeAnnotation.Edges edges;
+  protected ByteBuffer geometry;
+
+  public Covering(ByteBuffer geometry, LogicalTypeAnnotation.Edges edges) {
+    Preconditions.checkArgument(geometry != null, "Geometry cannot be null");
+    Preconditions.checkArgument(edges != null, "Edges cannot be null");
+    this.geometry = geometry;
+    this.edges = edges;
+  }
+
+  public ByteBuffer getGeometry() {
+    return geometry;
+  }
+
+  public LogicalTypeAnnotation.Edges getEdges() {
+    return edges;
+  }
+
+  public void update(Geometry geom) {
+    geometry = ByteBuffer.wrap(new WKBWriter().write(geom));
+  }
+
+  public void merge(Covering other) {
+    throw new UnsupportedOperationException(
+        "Merge is not supported for " + this.getClass().getSimpleName());
+  }
+
+  public void reset() {
+    throw new UnsupportedOperationException(
+        "Reset is not supported for " + this.getClass().getSimpleName());
+  }
+
+  public void abort() {
+    throw new UnsupportedOperationException(
+        "Abort is not supported for " + this.getClass().getSimpleName());
+  }
+
+  public Covering copy() {
+    throw new UnsupportedOperationException(
+        "Copy is not supported for " + this.getClass().getSimpleName());
+  }
+
+  @Override
+  public String toString() {
+    String geomText;
+    try {
+      geomText = new WKBReader().read(geometry.array()).toText();
+    } catch (ParseException e) {
+      geomText = "Invalid Geometry";
+    }
+
+    return "Covering{" + "geometry=" + geomText + ", edges=" + edges + '}';
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/EnvelopeCovering.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/EnvelopeCovering.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.statistics.geometry;
+
+import java.nio.ByteBuffer;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
+import org.locationtech.jts.io.WKBWriter;
+
+public class EnvelopeCovering extends Covering {
+
+  private static final ByteBuffer EMPTY = ByteBuffer.wrap(new byte[0]);
+  private final WKBReader reader = new WKBReader();
+  private final WKBWriter writer = new WKBWriter();
+
+  public EnvelopeCovering() {
+    super(EMPTY, LogicalTypeAnnotation.Edges.PLANAR);
+  }
+
+  @Override
+  public void update(Geometry geom) {
+    if (geometry == null) {
+      return;
+    }
+    try {
+      if (geometry != EMPTY) {
+        Geometry envelope = reader.read(geometry.array());
+        geometry = ByteBuffer.wrap(writer.write(envelope.union(geom).getEnvelope()));
+      } else {
+        geometry = ByteBuffer.wrap(writer.write(geom.getEnvelope()));
+      }
+    } catch (ParseException e) {
+      geometry = null;
+    }
+  }
+
+  @Override
+  public void merge(Covering other) {
+    if (other instanceof EnvelopeCovering) {
+      try {
+        update(reader.read(other.geometry.array()));
+      } catch (ParseException e) {
+        geometry = null;
+      }
+    } else {
+      throw new UnsupportedOperationException("Cannot merge " + this.getClass() + " with "
+          + other.getClass().getSimpleName());
+    }
+  }
+
+  @Override
+  public void reset() {
+    geometry = EMPTY;
+  }
+
+  @Override
+  public void abort() {
+    geometry = null;
+  }
+
+  @Override
+  public EnvelopeCovering copy() {
+    EnvelopeCovering copy = new EnvelopeCovering();
+    copy.geometry = geometry == null ? null : ByteBuffer.wrap(geometry.array());
+    return copy;
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/EnvelopeCovering.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/EnvelopeCovering.java
@@ -36,7 +36,7 @@ public class EnvelopeCovering extends Covering {
   }
 
   @Override
-  public void update(Geometry geom) {
+  void update(Geometry geom) {
     if (geometry == null) {
       return;
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/GeometryStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/GeometryStatistics.java
@@ -16,13 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.parquet.column.statistics;
+package org.apache.parquet.column.statistics.geometry;
 
 import org.apache.parquet.Preconditions;
-import org.apache.parquet.column.statistics.geometry.BoundingBox;
-import org.apache.parquet.column.statistics.geometry.Covering;
-import org.apache.parquet.column.statistics.geometry.EnvelopeCovering;
-import org.apache.parquet.column.statistics.geometry.GeometryTypes;
 import org.apache.parquet.io.api.Binary;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
@@ -69,7 +65,7 @@ public class GeometryStatistics {
     }
   }
 
-  public void update(Geometry geom) {
+  private void update(Geometry geom) {
     boundingBox.update(geom);
     covering.update(geom);
     geometryTypes.update(geom);

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/GeometryTypes.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/GeometryTypes.java
@@ -40,7 +40,7 @@ public class GeometryTypes {
     return types;
   }
 
-  public void update(Geometry geometry) {
+  void update(Geometry geometry) {
     if (!valid) {
       return;
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/GeometryTypes.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geometry/GeometryTypes.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.statistics.geometry;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.parquet.Preconditions;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+
+public class GeometryTypes {
+
+  private static final int UNKNOWN_TYPE_ID = -1;
+  private Set<Integer> types = new HashSet<>();
+  private boolean valid = true;
+
+  public GeometryTypes(Set<Integer> types) {
+    this.types = types;
+  }
+
+  public GeometryTypes() {}
+
+  public Set<Integer> getTypes() {
+    return types;
+  }
+
+  public void update(Geometry geometry) {
+    if (!valid) {
+      return;
+    }
+    int code = getGeometryTypeCode(geometry);
+    if (code != UNKNOWN_TYPE_ID) {
+      types.add(code);
+    } else {
+      valid = false;
+      types.clear();
+    }
+  }
+
+  public void merge(GeometryTypes other) {
+    Preconditions.checkArgument(other != null, "Cannot merge with null GeometryTypes");
+    if (!valid) {
+      return;
+    }
+    if (!other.valid) {
+      valid = false;
+      types.clear();
+      return;
+    }
+    types.addAll(other.types);
+  }
+
+  public void reset() {
+    types.clear();
+    valid = true;
+  }
+
+  public void abort() {
+    valid = false;
+    types.clear();
+  }
+
+  public GeometryTypes copy() {
+    return new GeometryTypes(new HashSet<>(types));
+  }
+
+  @Override
+  public String toString() {
+    // TODO: Print the geometry types as strings
+    return "GeometryTypes{" + "types=" + types + '}';
+  }
+
+  private int getGeometryTypeId(Geometry geometry) {
+    switch (geometry.getGeometryType()) {
+      case Geometry.TYPENAME_POINT:
+        return 1;
+      case Geometry.TYPENAME_LINESTRING:
+        return 2;
+      case Geometry.TYPENAME_POLYGON:
+        return 3;
+      case Geometry.TYPENAME_MULTIPOINT:
+        return 4;
+      case Geometry.TYPENAME_MULTILINESTRING:
+        return 5;
+      case Geometry.TYPENAME_MULTIPOLYGON:
+        return 6;
+      case Geometry.TYPENAME_GEOMETRYCOLLECTION:
+        return 7;
+      default:
+        return UNKNOWN_TYPE_ID;
+    }
+  }
+
+  private int getGeometryTypeCode(Geometry geometry) {
+    int typeId = getGeometryTypeId(geometry);
+    if (typeId == UNKNOWN_TYPE_ID) {
+      return UNKNOWN_TYPE_ID;
+    }
+    Coordinate coordinate = geometry.getCoordinate();
+    if (!Double.isNaN(coordinate.getZ())) {
+      typeId += 1000;
+    }
+    if (!Double.isNaN(coordinate.getM())) {
+      typeId += 2000;
+    }
+    return typeId;
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndex.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndex.java
@@ -21,6 +21,7 @@ package org.apache.parquet.internal.column.columnindex;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.PrimitiveIterator;
+import org.apache.parquet.column.statistics.geometry.GeometryStatistics;
 import org.apache.parquet.filter2.predicate.FilterPredicate.Visitor;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexFilter;
 
@@ -70,5 +71,13 @@ public interface ColumnIndex extends Visitor<PrimitiveIterator.OfInt> {
    */
   default List<Long> getDefinitionLevelHistogram() {
     throw new UnsupportedOperationException("Definition level histogram is not implemented");
+  }
+
+  /**
+   * @return the unmodifiable list of the geometry statistics for each page;
+   * used for converting to the related thrift object
+   */
+  default List<GeometryStatistics> getGeometryStatistics() {
+    throw new UnsupportedOperationException("Geometry statistics is not implemented");
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java
@@ -35,6 +35,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 import javax.naming.OperationNotSupportedException;
 import org.apache.parquet.io.api.Binary;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
 
 /**
  * Class that provides string representations for the primitive values. These string values are to be used for
@@ -447,6 +450,22 @@ public abstract class PrimitiveStringifier {
     @Override
     String stringifyNotNull(Binary value) {
       return Float16.toFloatString(value);
+    }
+  };
+
+  static final PrimitiveStringifier WKB_STRINGIFIER = new BinaryStringifierBase("WKB_STRINGIFIER") {
+
+    @Override
+    String stringifyNotNull(Binary value) {
+
+      Geometry geometry;
+      try {
+        WKBReader reader = new WKBReader();
+        geometry = reader.read(value.getBytesUnsafe());
+        return geometry.toText();
+      } catch (ParseException e) {
+        return BINARY_INVALID;
+      }
     }
   };
 }

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
@@ -275,7 +275,8 @@ public final class PrimitiveType extends Type {
               @Override
               public Optional<PrimitiveComparator> visit(
                   LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
-                // TODO: implement a custom comparator for geometries
+                // ColumnOrder is undefined for GEOMETRY logical type. Use the default comparator for
+                // now.
                 return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
               }
             })

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
@@ -271,6 +271,13 @@ public final class PrimitiveType extends Type {
                   LogicalTypeAnnotation.BsonLogicalTypeAnnotation bsonLogicalType) {
                 return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
               }
+
+              @Override
+              public Optional<PrimitiveComparator> visit(
+                  LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+                // TODO: implement a custom comparator for geometries
+                return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
+              }
             })
             .orElseThrow(() -> new ShouldNeverHappenException(
                 "No comparator logic implemented for BINARY logical type: " + logicalType));

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
@@ -571,6 +571,15 @@ public class Types {
                 return checkBinaryPrimitiveType(enumLogicalType);
               }
 
+              @Override
+              public Optional<Boolean> visit(
+                  LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+                if (geometryLogicalType.getEncoding() != LogicalTypeAnnotation.GeometryEncoding.WKB) {
+                  throw new RuntimeException("Only WKB geometry encoding is supported for now");
+                }
+                return checkBinaryPrimitiveType(geometryLogicalType);
+              }
+
               private Optional<Boolean> checkFixedPrimitiveType(
                   int l, LogicalTypeAnnotation logicalTypeAnnotation) {
                 Preconditions.checkState(

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -822,7 +822,7 @@ public class ParquetMetadataConverter {
   }
 
   private static GeometryStatistics toParquetStatistics(
-      org.apache.parquet.column.statistics.GeometryStatistics stats) {
+      org.apache.parquet.column.statistics.geometry.GeometryStatistics stats) {
     GeometryStatistics formatStats = new GeometryStatistics();
 
     formatStats.setBbox(toParquetBoundingBox(stats.getBoundingBox()));
@@ -978,8 +978,9 @@ public class ParquetMetadataConverter {
         if (formatGeomStats.isSetGeometry_types()) {
           geometryTypes = new GeometryTypes(new HashSet<>(formatGeomStats.getGeometry_types()));
         }
-        org.apache.parquet.column.statistics.GeometryStatistics geomStats =
-            new org.apache.parquet.column.statistics.GeometryStatistics(bbox, covering, geometryTypes);
+        org.apache.parquet.column.statistics.geometry.GeometryStatistics geomStats =
+            new org.apache.parquet.column.statistics.geometry.GeometryStatistics(
+                bbox, covering, geometryTypes);
         statsBuilder.withGeometryStatistics(geomStats);
       }
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -834,8 +834,9 @@ public class ParquetMetadataConverter {
       formatStats.setCovering(formatCovering);
     }
 
-    formatStats.setGeometry_types(
-        new ArrayList<Integer>(stats.getGeometryTypes().getTypes()));
+    List<Integer> geometryTypes = new ArrayList<>(stats.getGeometryTypes().getTypes());
+    Collections.sort(geometryTypes);
+    formatStats.setGeometry_types(geometryTypes);
 
     return formatStats;
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -31,6 +31,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -50,6 +51,7 @@ import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.geometry.GeometryTypes;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.crypto.AesCipher;
 import org.apache.parquet.crypto.AesGcmEncryptor;
@@ -65,6 +67,7 @@ import org.apache.parquet.format.BloomFilterCompression;
 import org.apache.parquet.format.BloomFilterHash;
 import org.apache.parquet.format.BloomFilterHeader;
 import org.apache.parquet.format.BoundaryOrder;
+import org.apache.parquet.format.BoundingBox;
 import org.apache.parquet.format.BsonType;
 import org.apache.parquet.format.ColumnChunk;
 import org.apache.parquet.format.ColumnCryptoMetaData;
@@ -73,17 +76,22 @@ import org.apache.parquet.format.ColumnMetaData;
 import org.apache.parquet.format.ColumnOrder;
 import org.apache.parquet.format.CompressionCodec;
 import org.apache.parquet.format.ConvertedType;
+import org.apache.parquet.format.Covering;
 import org.apache.parquet.format.DataPageHeader;
 import org.apache.parquet.format.DataPageHeaderV2;
 import org.apache.parquet.format.DateType;
 import org.apache.parquet.format.DecimalType;
 import org.apache.parquet.format.DictionaryPageHeader;
+import org.apache.parquet.format.Edges;
 import org.apache.parquet.format.Encoding;
 import org.apache.parquet.format.EncryptionWithColumnKey;
 import org.apache.parquet.format.EnumType;
 import org.apache.parquet.format.FieldRepetitionType;
 import org.apache.parquet.format.FileMetaData;
 import org.apache.parquet.format.Float16Type;
+import org.apache.parquet.format.GeometryEncoding;
+import org.apache.parquet.format.GeometryStatistics;
+import org.apache.parquet.format.GeometryType;
 import org.apache.parquet.format.IntType;
 import org.apache.parquet.format.JsonType;
 import org.apache.parquet.format.KeyValue;
@@ -346,6 +354,27 @@ public class ParquetMetadataConverter {
     }
   }
 
+  static org.apache.parquet.format.GeometryEncoding convertGeometryEncoding(
+      LogicalTypeAnnotation.GeometryEncoding encoding) {
+    switch (encoding) {
+      case WKB:
+        return org.apache.parquet.format.GeometryEncoding.WKB;
+      default:
+        throw new RuntimeException("Unknown geometry encoding " + encoding);
+    }
+  }
+
+  static org.apache.parquet.format.Edges convertEdges(LogicalTypeAnnotation.Edges edges) {
+    switch (edges) {
+      case PLANAR:
+        return org.apache.parquet.format.Edges.PLANAR;
+      case SPHERICAL:
+        return org.apache.parquet.format.Edges.SPHERICAL;
+      default:
+        throw new RuntimeException("Unknown edges " + edges);
+    }
+  }
+
   private static class ConvertedTypeConverterVisitor
       implements LogicalTypeAnnotation.LogicalTypeAnnotationVisitor<ConvertedType> {
     @Override
@@ -518,6 +547,24 @@ public class ParquetMetadataConverter {
     @Override
     public Optional<LogicalType> visit(LogicalTypeAnnotation.IntervalLogicalTypeAnnotation intervalLogicalType) {
       return of(LogicalType.UNKNOWN(new NullType()));
+    }
+
+    @Override
+    public Optional<LogicalType> visit(LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+      GeometryType geometryType = new GeometryType();
+      if (geometryLogicalType.getEncoding() != null) {
+        geometryType.setEncoding(convertGeometryEncoding(geometryLogicalType.getEncoding()));
+      }
+      if (geometryLogicalType.getCrs() != null) {
+        geometryType.setCrs(geometryLogicalType.getCrs());
+      }
+      if (geometryLogicalType.getEdges() != null) {
+        geometryType.setEdges(convertEdges(geometryLogicalType.getEdges()));
+      }
+      if (geometryLogicalType.getMetadata() != null) {
+        geometryType.setMetadata(geometryLogicalType.getMetadata());
+      }
+      return of(LogicalType.GEOMETRY(geometryType));
     }
   }
 
@@ -765,7 +812,49 @@ public class ParquetMetadataConverter {
         }
       }
     }
+    if (stats instanceof BinaryStatistics) {
+      BinaryStatistics binaryStats = (BinaryStatistics) stats;
+      if (binaryStats.getGeometryStatistics() != null) {
+        formatStats.setGeometry_stats(toParquetStatistics(binaryStats.getGeometryStatistics()));
+      }
+    }
     return formatStats;
+  }
+
+  private static GeometryStatistics toParquetStatistics(
+      org.apache.parquet.column.statistics.GeometryStatistics stats) {
+    GeometryStatistics formatStats = new GeometryStatistics();
+
+    formatStats.setBbox(toParquetBoundingBox(stats.getBoundingBox()));
+
+    if (stats.getCovering().getGeometry() != null) {
+      Covering formatCovering = new Covering();
+      formatCovering.setGeometry(stats.getCovering().getGeometry());
+      formatCovering.setEdges(convertEdges(stats.getCovering().getEdges()));
+      formatStats.setCovering(formatCovering);
+    }
+
+    formatStats.setGeometry_types(
+        new ArrayList<Integer>(stats.getGeometryTypes().getTypes()));
+
+    return formatStats;
+  }
+
+  private static BoundingBox toParquetBoundingBox(org.apache.parquet.column.statistics.geometry.BoundingBox bbox) {
+    BoundingBox formatBbox = new BoundingBox();
+    formatBbox.setXmin(bbox.getXMin());
+    formatBbox.setXmax(bbox.getXMax());
+    formatBbox.setYmin(bbox.getYMin());
+    formatBbox.setYmax(bbox.getYMax());
+    if (bbox.getZMin() <= bbox.getZMax()) {
+      formatBbox.setZmin(bbox.getZMin());
+      formatBbox.setZmax(bbox.getZMax());
+    }
+    if (bbox.getMMin() <= bbox.getMMax()) {
+      formatBbox.setMmin(bbox.getMMin());
+      formatBbox.setMmax(bbox.getMMax());
+    }
+    return formatBbox;
   }
 
   private static boolean withinLimit(org.apache.parquet.column.statistics.Statistics stats, int truncateLength) {
@@ -862,6 +951,36 @@ public class ParquetMetadataConverter {
 
       if (formatStats.isSetNull_count()) {
         statsBuilder.withNumNulls(formatStats.null_count);
+      }
+
+      if (formatStats.isSetGeometry_stats()) {
+        GeometryStatistics formatGeomStats = formatStats.getGeometry_stats();
+        org.apache.parquet.column.statistics.geometry.BoundingBox bbox = null;
+        if (formatGeomStats.isSetBbox()) {
+          BoundingBox formatBbox = formatGeomStats.getBbox();
+          bbox = new org.apache.parquet.column.statistics.geometry.BoundingBox(
+              formatBbox.getXmin(),
+              formatBbox.getXmax(),
+              formatBbox.getYmin(),
+              formatBbox.getYmax(),
+              formatBbox.isSetZmin() ? formatBbox.getZmin() : Double.NaN,
+              formatBbox.isSetZmax() ? formatBbox.getZmax() : Double.NaN,
+              formatBbox.isSetMmin() ? formatBbox.getMmin() : Double.NaN,
+              formatBbox.isSetMmax() ? formatBbox.getMmax() : Double.NaN);
+        }
+        org.apache.parquet.column.statistics.geometry.Covering covering = null;
+        if (formatGeomStats.isSetCovering()) {
+          Covering formatCovering = formatGeomStats.getCovering();
+          covering = new org.apache.parquet.column.statistics.geometry.Covering(
+              ByteBuffer.wrap(formatCovering.getGeometry()), convertEdges(formatCovering.getEdges()));
+        }
+        org.apache.parquet.column.statistics.geometry.GeometryTypes geometryTypes = null;
+        if (formatGeomStats.isSetGeometry_types()) {
+          geometryTypes = new GeometryTypes(new HashSet<>(formatGeomStats.getGeometry_types()));
+        }
+        org.apache.parquet.column.statistics.GeometryStatistics geomStats =
+            new org.apache.parquet.column.statistics.GeometryStatistics(bbox, covering, geometryTypes);
+        statsBuilder.withGeometryStatistics(geomStats);
       }
     }
     return statsBuilder.build();
@@ -1030,6 +1149,12 @@ public class ParquetMetadataConverter {
                 LogicalTypeAnnotation.TimestampLogicalTypeAnnotation timestampLogicalType) {
               return of(SortOrder.SIGNED);
             }
+
+            @Override
+            public Optional<SortOrder> visit(
+                LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+              return of(SortOrder.UNKNOWN);
+            }
           })
           .orElse(defaultSortOrder(primitive.getPrimitiveTypeName()));
     }
@@ -1173,6 +1298,13 @@ public class ParquetMetadataConverter {
         return LogicalTypeAnnotation.uuidType();
       case FLOAT16:
         return LogicalTypeAnnotation.float16Type();
+      case GEOMETRY:
+        GeometryType geometry = type.getGEOMETRY();
+        return LogicalTypeAnnotation.geometryType(
+            convertGeometryEncoding(geometry.getEncoding()),
+            convertEdges(geometry.getEdges()),
+            geometry.getCrs(),
+            geometry.getMetadata() != null ? ByteBuffer.wrap(geometry.getMetadata()) : null);
       default:
         throw new RuntimeException("Unknown logical type " + type);
     }
@@ -1188,6 +1320,32 @@ public class ParquetMetadataConverter {
         return LogicalTypeAnnotation.TimeUnit.NANOS;
       default:
         throw new RuntimeException("Unknown time unit " + unit);
+    }
+  }
+
+  private LogicalTypeAnnotation.GeometryEncoding convertGeometryEncoding(GeometryEncoding encoding) {
+    if (encoding == null) {
+      return null;
+    }
+    switch (encoding) {
+      case WKB:
+        return LogicalTypeAnnotation.GeometryEncoding.WKB;
+      default:
+        throw new RuntimeException("Unknown geometry encoding " + encoding);
+    }
+  }
+
+  private static LogicalTypeAnnotation.Edges convertEdges(Edges edge) {
+    if (edge == null) {
+      return null;
+    }
+    switch (edge) {
+      case PLANAR:
+        return LogicalTypeAnnotation.Edges.PLANAR;
+      case SPHERICAL:
+        return LogicalTypeAnnotation.Edges.SPHERICAL;
+      default:
+        throw new RuntimeException("Unknown geometry edge " + edge);
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestGeometryTypeRoundTrip.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestGeometryTypeRoundTrip.java
@@ -24,6 +24,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.statistics.BinaryStatistics;
@@ -36,6 +37,7 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.io.LocalInputFile;
 import org.apache.parquet.io.LocalOutputFile;
 import org.apache.parquet.io.api.Binary;
@@ -109,6 +111,15 @@ public class TestGeometryTypeRoundTrip {
       System.out.println("GeometryStatistics");
       System.out.println(geometryStatistics);
       System.out.println();
+
+      ColumnIndex columnIndex = reader.readColumnIndex(columnChunkMetaData);
+      System.out.println("ColumnIndex");
+      System.out.println(columnIndex);
+
+      List<GeometryStatistics> pageGeometryStatistics = columnIndex.getGeometryStatistics();
+      Assert.assertNotNull(pageGeometryStatistics);
+      System.out.println("Page GeometryStatistics");
+      System.out.println(pageGeometryStatistics);
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestGeometryTypeRoundTrip.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestGeometryTypeRoundTrip.java
@@ -1,0 +1,114 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.parquet.statistics;
+
+import static org.apache.parquet.schema.LogicalTypeAnnotation.geometryType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.Preconditions;
+import org.apache.parquet.column.statistics.BinaryStatistics;
+import org.apache.parquet.column.statistics.GeometryStatistics;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.GroupFactory;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.io.LocalInputFile;
+import org.apache.parquet.io.LocalOutputFile;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation.Edges;
+import org.apache.parquet.schema.LogicalTypeAnnotation.GeometryEncoding;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.io.WKBWriter;
+
+public class TestGeometryTypeRoundTrip {
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
+  private Path newTempPath() throws IOException {
+    File file = temp.newFile();
+    Preconditions.checkArgument(file.delete(), "Could not remove temp file");
+    return file.toPath();
+  }
+
+  @Test
+  public void testBasicReadWriteGeometryValue() throws IOException {
+    GeometryFactory geomFactory = new GeometryFactory();
+    WKBWriter wkbWriter = new WKBWriter();
+    Binary[] points = {
+      Binary.fromConstantByteArray(wkbWriter.write(geomFactory.createPoint(new Coordinate(1.0, 1.0)))),
+      Binary.fromConstantByteArray(wkbWriter.write(geomFactory.createPoint(new Coordinate(2.0, 2.0))))
+    };
+
+    MessageType schema = Types.buildMessage()
+        .required(BINARY)
+        .as(geometryType(GeometryEncoding.WKB, Edges.PLANAR, "EPSG:4326", null))
+        .named("col_geom")
+        .named("msg");
+
+    Configuration conf = new Configuration();
+    GroupWriteSupport.setSchema(schema, conf);
+    GroupFactory factory = new SimpleGroupFactory(schema);
+    Path path = newTempPath();
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(new LocalOutputFile(path))
+        .withConf(conf)
+        .withDictionaryEncoding(false)
+        .build()) {
+      for (Binary value : points) {
+        writer.write(factory.newGroup().append("col_geom", value));
+      }
+    }
+
+    try (ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(path))) {
+      Assert.assertEquals(2, reader.getRecordCount());
+
+      System.out.println("Footer");
+      System.out.println(reader.getFooter().toString());
+      System.out.println();
+
+      ColumnChunkMetaData columnChunkMetaData =
+          reader.getRowGroups().get(0).getColumns().get(0);
+      System.out.println("Statistics");
+      System.out.println(columnChunkMetaData.getStatistics().toString());
+      System.out.println();
+
+      GeometryStatistics geometryStatistics =
+          ((BinaryStatistics) columnChunkMetaData.getStatistics()).getGeometryStatistics();
+      Assert.assertNotNull(geometryStatistics);
+      System.out.println("GeometryStatistics");
+      System.out.println(geometryStatistics);
+      System.out.println();
+    }
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestGeometryTypeRoundTrip.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestGeometryTypeRoundTrip.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.statistics.BinaryStatistics;
-import org.apache.parquet.column.statistics.GeometryStatistics;
+import org.apache.parquet.column.statistics.geometry.GeometryStatistics;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.GroupFactory;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <spotless.version>2.30.0</spotless.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <hadoop.version>3.3.6</hadoop.version>
-    <parquet.format.version>2.10.0</parquet.format.version>
+    <parquet.format.version>2.11.0-SNAPSHOT</parquet.format.version>
     <previous.version>1.13.1</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>${thrift.executable}</format.thrift.executable>
@@ -98,6 +98,7 @@
     <powermock.version>2.0.9</powermock.version>
     <net.openhft.version>0.16</net.openhft.version>
     <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+    <jts.version>1.19.0</jts.version>
 
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
This is the PoC of https://github.com/apache/parquet-format/pull/240

### Jira

- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-XXX
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including Jira issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [ ] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
