### PR TITLE
GH-2930: Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -33,8 +33,8 @@ body:
       label: Component(s)
       multiple: true
       options:
-        - Release
-        - Continuous Integration
+        - Core
+        - Build
         - Arrow
         - Avro
         - Pig
@@ -43,6 +43,5 @@ body:
         - Thrift
         - CLI
         - Benchmarking
-        - Other
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -42,6 +42,6 @@ body:
         - Scala
         - Thrift
         - CLI
-        - Benchmarking
+        - Benchmark
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Bug Report
+description: File a bug report
+labels: ["Type: bug"]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug, including details regarding any error messages, version, and platform.
+      description: Please include what you expected.
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component(s)
+      multiple: true
+      options:
+        - Java
+        - Release
+        - Benchmarking
+        - Documentation
+        - Continuous Integration
+        - Packaging
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -33,12 +33,16 @@ body:
       label: Component(s)
       multiple: true
       options:
-        - Java
         - Release
-        - Benchmarking
-        - Documentation
         - Continuous Integration
-        - Packaging
+        - Arrow
+        - Avro
+        - Pig
+        - Protobuf
+        - Scala
+        - Thrift
+        - CLI
+        - Benchmarking
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -36,12 +36,16 @@ body:
       label: Component(s)
       multiple: true
       options:
-        - Java
         - Release
-        - Benchmarking
-        - Documentation
         - Continuous Integration
-        - Packaging
+        - Arrow
+        - Avro
+        - Pig
+        - Protobuf
+        - Scala
+        - Thrift
+        - CLI
+        - Benchmarking
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -45,6 +45,6 @@ body:
         - Scala
         - Thrift
         - CLI
-        - Benchmarking
+        - Benchmark
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -36,8 +36,8 @@ body:
       label: Component(s)
       multiple: true
       options:
-        - Release
-        - Continuous Integration
+        - Core
+        - Build
         - Arrow
         - Avro
         - Pig
@@ -46,6 +46,5 @@ body:
         - Thrift
         - CLI
         - Benchmarking
-        - Other
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Enhancement Request
+description: Request an enhancement to the project
+labels: ["Type: enhancement"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to share your feedback on ways Apache Parquet can be improved!
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the enhancement requested
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component(s)
+      multiple: true
+      options:
+        - Java
+        - Release
+        - Benchmarking
+        - Documentation
+        - Continuous Integration
+        - Packaging
+        - Other
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/usage_question.yaml
+++ b/.github/ISSUE_TEMPLATE/usage_question.yaml
@@ -56,8 +56,8 @@ body:
       label: Component(s)
       multiple: true
       options:
-        - Release
-        - Continuous Integration
+        - Core
+        - Build
         - Arrow
         - Avro
         - Pig
@@ -66,6 +66,5 @@ body:
         - Thrift
         - CLI
         - Benchmarking
-        - Other
     validations:
-      required: true
+      required: false

--- a/.github/ISSUE_TEMPLATE/usage_question.yaml
+++ b/.github/ISSUE_TEMPLATE/usage_question.yaml
@@ -56,12 +56,16 @@ body:
       label: Component(s)
       multiple: true
       options:
-        - Java
         - Release
-        - Benchmarking
-        - Documentation
         - Continuous Integration
-        - Packaging
+        - Arrow
+        - Avro
+        - Pig
+        - Protobuf
+        - Scala
+        - Thrift
+        - CLI
+        - Benchmarking
         - Other
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/usage_question.yaml
+++ b/.github/ISSUE_TEMPLATE/usage_question.yaml
@@ -65,6 +65,6 @@ body:
         - Scala
         - Thrift
         - CLI
-        - Benchmarking
+        - Benchmark
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/usage_question.yaml
+++ b/.github/ISSUE_TEMPLATE/usage_question.yaml
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Usage Question
+description: Ask a question
+labels: ["Type: usage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: >
+        While we enable issues as a mechanism for new contributors and passers-by who 
+        are unfamiliar with Apache Software Foundation projects to ask questions and 
+        interact with the project, we encourage users to ask such questions on public 
+        mailing lists:
+        
+        * Development discussions: dev@parquet.apache.org (first subscribe by sending an 
+        e-mail to dev-subscribe@parquet.apache.org).
+        
+        * User discussions: user@parquet.apache.org (first subscribe by sending an e-mail 
+        to user-subscribe@parquet.apache.org).
+        
+        * Mailing list archives: https://parquet.apache.org/community/
+        
+        
+        Do not be surprised by responses to issues raised here directing you to those 
+        mailing lists, or to report a bug or feature request here.
+
+
+        Thank you!
+  - type: textarea
+    id: description
+    attributes:
+      label: >
+        Describe the usage question you have. Please include as many useful details as 
+        possible.
+    validations:
+      required: true
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component(s)
+      multiple: true
+      options:
+        - Java
+        - Release
+        - Benchmarking
+        - Documentation
+        - Continuous Integration
+        - Packaging
+        - Other
+    validations:
+      required: true


### PR DESCRIPTION
This introduces [Arrow-like issue templates](https://github.com/apache/arrow/tree/main/.github/ISSUE_TEMPLATE) to structure and categorize issues somewhat as they are reported.

See #2930 