### PR TITLE
GH-2932: Adjust PR template to reference GitHub issue tracker

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 Make sure you have checked _all_ steps below.
 
-### Jira
+### Issue
 
-- [ ] My PR addresses the following [Parquet Jira](https://issues.apache.org/jira/browse/PARQUET/) issues and references
-  them in the PR title. For example, "PARQUET-1234: My Parquet PR"
-    - https://issues.apache.org/jira/browse/PARQUET-XXX
+- [ ] My PR addresses the following [GitHub issues](https://github.com/apache/parquet-java/issues) and references
+  them in the PR title. For example, "GH-1234: My Parquet PR"
+    - https://github.com/apache/parquet-java/issues/1234
     - In case you are adding a dependency, check if the license complies with
       the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
 
@@ -14,10 +14,10 @@ Make sure you have checked _all_ steps below.
 
 ### Commits
 
-- [ ] My commits all reference Jira issues in their subject lines. In addition, my commits follow the guidelines
+- [ ] My commits all reference GitHub issues in their subject lines. In addition, my commits follow the guidelines
   from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
     1. Subject is separated from body by a blank line
-    1. Subject is limited to 50 characters (not including Jira issue reference)
+    1. Subject is limited to 50 characters (not including GitHub issue reference)
     1. Subject does not end with a period
     1. Subject uses the imperative mood ("add", not "adding")
     1. Body wraps at 72 characters


### PR DESCRIPTION
This adjusts language of the PR templates to reference GitHub instead of Jira.

See #2932 