### PR TITLE
PARQUET-34: implement not() for Contains predicate

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/LogicalInverter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/LogicalInverter.java
@@ -95,7 +95,7 @@ public final class LogicalInverter implements Visitor<FilterPredicate> {
 
   @Override
   public <T extends Comparable<T>> FilterPredicate visit(Contains<T> contains) {
-    throw new UnsupportedOperationException("Contains not supported yet");
+    return contains.not();
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java
+++ b/parquet-column/src/main/java/org/apache/parquet/filter2/predicate/Operators.java
@@ -324,16 +324,12 @@ public final class Operators {
     }
   }
 
-  static class DoesNotContain<T extends Comparable<T>> extends Contains<T> {
+  private static class DoesNotContain<T extends Comparable<T>> extends Contains<T> {
     Contains<T> underlying;
 
     protected DoesNotContain(Contains<T> underlying) {
       super(underlying.getColumn());
       this.underlying = underlying;
-    }
-
-    public Contains<T> getUnderlying() {
-      return underlying;
     }
 
     @Override

--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/ColumnIndexBuilder.java
@@ -371,7 +371,11 @@ public abstract class ColumnIndexBuilder {
 
     @Override
     public <T extends Comparable<T>> PrimitiveIterator.OfInt visit(Contains<T> contains) {
-      return contains.filter(this, IndexIterator::intersection, IndexIterator::union);
+      return contains.filter(
+          this,
+          IndexIterator::intersection,
+          IndexIterator::union,
+          indices -> IndexIterator.all(getPageCount()));
     }
 
     @Override

--- a/parquet-column/src/main/java/org/apache/parquet/internal/filter2/columnindex/ColumnIndexFilter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/filter2/columnindex/ColumnIndexFilter.java
@@ -158,7 +158,7 @@ public class ColumnIndexFilter implements Visitor<RowRanges> {
 
   @Override
   public <T extends Comparable<T>> RowRanges visit(Contains<T> contains) {
-    return contains.filter(this, RowRanges::intersection, RowRanges::union);
+    return contains.filter(this, RowRanges::intersection, RowRanges::union, ranges -> allRows());
   }
 
   @Override

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestFilterApiMethods.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestFilterApiMethods.java
@@ -116,6 +116,8 @@ public class TestFilterApiMethods {
             contains(eq(binaryColumn("b.c.d"), Binary.fromString("baz"))))));
     assertTrue(rewritten instanceof Or);
 
+    // Assert that the predicates for column b.c.d have been combined into a single Contains predicate,
+    // while the predicate for column a.b.c is separate
     final Or or = (Or) rewritten;
     assertEquals(binaryColumn("a.b.c"), ((Operators.Contains) or.getLeft()).getColumn());
     assertEquals(binaryColumn("b.c.d"), ((Operators.Contains) or.getRight()).getColumn());
@@ -133,9 +135,9 @@ public class TestFilterApiMethods {
         contains(eq(binColumn, Binary.fromString("foo"))),
         and(
             contains(eq(binColumn, Binary.fromString("bar"))),
-            contains(eq(binColumn, Binary.fromString("baz"))))));
+            not(contains(eq(binColumn, Binary.fromString("baz")))))));
     assertEquals(
-        "or(contains(eq(a.string.column, Binary{\"foo\"})), and(contains(eq(a.string.column, Binary{\"bar\"})), contains(eq(a.string.column, Binary{\"baz\"}))))",
+        "or(contains(eq(a.string.column, Binary{\"foo\"})), and(contains(eq(a.string.column, Binary{\"bar\"})), not(contains(eq(a.string.column, Binary{\"baz\"})))))",
         pred.toString());
   }
 

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestFilterApiMethods.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestFilterApiMethods.java
@@ -94,20 +94,31 @@ public class TestFilterApiMethods {
   }
 
   @Test
-  public void testInvalidContainsCreation() {
+  public void testContainsCreation() {
     assertThrows(
         "Contains predicate does not support null element value",
         IllegalArgumentException.class,
         () -> contains(eq(binColumn, null)));
 
+    // Assert that a single Contains predicate referencing multiple columns throws an error
     assertThrows(
         "Composed Contains predicates must reference the same column name; found [a.b.c, b.c.d]",
         IllegalArgumentException.class,
-        () -> ContainsRewriter.rewrite(or(
-            contains(eq(binaryColumn("a.b.c"), Binary.fromString("foo"))),
-            and(
-                contains(eq(binaryColumn("b.c.d"), Binary.fromString("bar"))),
-                contains(eq(binaryColumn("b.c.d"), Binary.fromString("bar")))))));
+        () -> contains(eq(binaryColumn("a.b.c"), Binary.fromString("foo")))
+            .and(contains(eq(binaryColumn("b.c.d"), Binary.fromString("bar"))))
+            .and(contains(eq(binaryColumn("b.c.d"), Binary.fromString("bar")))));
+
+    // Assert that a Contains predicate referencing multiple columns is allowed when composed with and() or or()
+    final FilterPredicate rewritten = ContainsRewriter.rewrite(or(
+        contains(eq(binaryColumn("a.b.c"), Binary.fromString("foo"))),
+        and(
+            contains(eq(binaryColumn("b.c.d"), Binary.fromString("bar"))),
+            contains(eq(binaryColumn("b.c.d"), Binary.fromString("baz"))))));
+    assertTrue(rewritten instanceof Or);
+
+    final Or or = (Or) rewritten;
+    assertEquals(binaryColumn("a.b.c"), ((Operators.Contains) or.getLeft()).getColumn());
+    assertEquals(binaryColumn("b.c.d"), ((Operators.Contains) or.getRight()).getColumn());
   }
 
   @Test

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/bloomfilterlevel/BloomFilterImpl.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/bloomfilterlevel/BloomFilterImpl.java
@@ -121,7 +121,7 @@ public class BloomFilterImpl implements FilterPredicate.Visitor<Boolean> {
 
   @Override
   public <T extends Comparable<T>> Boolean visit(Operators.Contains<T> contains) {
-    return contains.filter(this, (l, r) -> l || r, (l, r) -> l && r);
+    return contains.filter(this, (l, r) -> l || r, (l, r) -> l && r, v -> BLOCK_MIGHT_MATCH);
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java
@@ -490,7 +490,7 @@ public class DictionaryFilter implements FilterPredicate.Visitor<Boolean> {
 
   @Override
   public <T extends Comparable<T>> Boolean visit(Contains<T> contains) {
-    return contains.filter(this, (l, r) -> l || r, (l, r) -> l && r);
+    return contains.filter(this, (l, r) -> l || r, (l, r) -> l && r, v -> BLOCK_MIGHT_MATCH);
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -214,7 +214,7 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
 
   @Override
   public <T extends Comparable<T>> Boolean visit(Contains<T> contains) {
-    return contains.filter(this, (l, r) -> l || r, (l, r) -> l && r);
+    return contains.filter(this, (l, r) -> l || r, (l, r) -> l && r, b -> BLOCK_MIGHT_MATCH);
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/statisticslevel/StatisticsFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/statisticslevel/StatisticsFilter.java
@@ -214,7 +214,7 @@ public class StatisticsFilter implements FilterPredicate.Visitor<Boolean> {
 
   @Override
   public <T extends Comparable<T>> Boolean visit(Contains<T> contains) {
-    return contains.filter(this, (l, r) -> l || r, (l, r) -> l && r, b -> BLOCK_MIGHT_MATCH);
+    return contains.filter(this, (l, r) -> l || r, (l, r) -> l && r, v -> BLOCK_MIGHT_MATCH);
   }
 
   @Override

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/TestRecordLevelFilters.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/TestRecordLevelFilters.java
@@ -402,6 +402,15 @@ public class TestRecordLevelFilters {
   }
 
   @Test
+  public void testArrayContainsMixedColumns() throws Exception {
+    assertPredicate(
+        and(
+            contains(eq(binaryColumn("phoneNumbers.phone.kind"), Binary.fromString("home"))),
+            not(contains(eq(longColumn("phoneNumbers.phone.number"), 2222222222L)))),
+        30L);
+  }
+
+  @Test
   public void testNameNotNull() throws Exception {
     BinaryColumn name = binaryColumn("name");
 


### PR DESCRIPTION
This should be the final subtask for the Contains() predicate work. It adds support for logical inversion -- `not(contains(...))`.

Also, it fixes a small bug with the composition of mixed Contains predicates.

Make sure you have checked _all_ steps below.

### Issue

- [x] My PR addresses the following [GitHub issues](https://github.com/apache/parquet-java/issues) and references
  them in the PR title. For example, "GH-1234: My Parquet PR"
    - https://issues.apache.org/jira/browse/PARQUET-34 (should I make a new Github issue for this?)
    - In case you are adding a dependency, check if the license complies with
      the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).

### Tests

- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [x] My commits all reference GitHub issues in their subject lines. In addition, my commits follow the guidelines
  from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    1. Subject is limited to 50 characters (not including GitHub issue reference)
    1. Subject does not end with a period
    1. Subject uses the imperative mood ("add", not "adding")
    1. Body wraps at 72 characters
    1. Body explains "what" and "why", not "how"

### Style
- [ ] My contribution adheres to the code style guidelines and Spotless passes.
    - To apply the necessary changes, run `mvn spotless:apply -Pvector-plugins`

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
    - All the public functions and the classes in the PR contain Javadoc that explain what it does
