### PR TITLE
HadoopInputFile to pass down FileStatus when opening file

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -160,7 +160,11 @@
       <artifactId>zstd-jni</artifactId>
       <version>${zstd-jni.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>${jsr305.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/HadoopFSKeyMaterialStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/keytools/HadoopFSKeyMaterialStore.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
+import org.apache.parquet.hadoop.util.HadoopFileIO;
 
 public class HadoopFSKeyMaterialStore implements FileKeyMaterialStore {
   public static final String KEY_MATERIAL_FILE_PREFIX = "_KEY_MATERIAL_FOR_";
@@ -73,7 +74,7 @@ public class HadoopFSKeyMaterialStore implements FileKeyMaterialStore {
   }
 
   private void loadKeyMaterialMap() {
-    try (FSDataInputStream keyMaterialStream = hadoopFileSystem.open(keyMaterialFile)) {
+    try (FSDataInputStream keyMaterialStream = HadoopFileIO.openFile(hadoopFileSystem, keyMaterialFile, false)) {
       JsonNode keyMaterialJson = objectMapper.readTree(keyMaterialStream);
       keyMaterialMap =
           objectMapper.readValue(keyMaterialJson.traverse(), new TypeReference<Map<String, String>>() {});

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopFileIO.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopFileIO.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.parquet.hadoop.util;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.util.wrapped.io.DynamicWrappedIO;
+
+/**
+ * Class for enhanced FileIO, calling {@link DynamicWrappedIO} as appropriate.
+ * If/when Parquet sets a baseline release with the relevant methods directly
+ * invocable, this class is where changes would need to be made.
+ */
+public class HadoopFileIO {
+
+  /**
+   * Get the status of file; if the file is not found downgrade to null.
+   * @param fileSystem FileSystem to use
+   * @param filePath file to load
+   * @return the status or null
+   * @throws IOException IO failure other than FileNotFoundException
+   */
+  public static FileStatus getFileStatusOrNull(final FileSystem fileSystem, final Path filePath) throws IOException {
+    final FileStatus commonFileStatus;
+    try {
+      commonFileStatus = fileSystem.getFileStatus(filePath);
+    } catch (FileNotFoundException e) {
+      // file does not exist
+      return null;
+    }
+    return commonFileStatus;
+  }
+
+  /**
+   * Open a file for reading using a read policy appropriate for the purpose,
+   * passing in a status object containing filename, length and possibly more
+   * <p>
+   * Note that for filesystems with lazy IO, existence checks may be delayed until
+   * the first read() operation.
+   *
+   * @param fileSystem FileSystem to use
+   * @param status file status
+   * @param randomIO is the file parquet file to be read with random IO?
+   *
+   * @return an input stream.
+   *
+   * @throws IOException failure to open the file.
+   */
+  public static FSDataInputStream openFile(
+      final FileSystem fileSystem, final FileStatus status, final boolean randomIO) throws IOException {
+    return DynamicWrappedIO.openFile(fileSystem, status.getPath(), status, readPolicies(randomIO));
+  }
+
+  /**
+   * Open a file for reading using a read policy appropriate for the purpose.
+   * <p>
+   * Note that for filesystems with lazy IO, existence checks may be delayed until
+   * the first read() operation.
+   *
+   * @param fileSystem FileSystem to use
+   * @param path path to file
+   * @param randomIO is the file parquet file to be read with random IO?
+   *
+   * @return an input stream.
+   *
+   * @throws IOException failure to open the file.
+   */
+  public static FSDataInputStream openFile(final FileSystem fileSystem, final Path path, final boolean randomIO)
+      throws IOException {
+    return DynamicWrappedIO.openFile(fileSystem, path, null, readPolicies(randomIO));
+  }
+
+  /**
+   * Choose the read policies for the desired purpose.
+   * @param randomIO is the file parquet file to be read with random IO?
+   * @return appropriate policy string
+   */
+  private static String readPolicies(final boolean randomIO) {
+    return randomIO ? DynamicWrappedIO.PARQUET_READ_POLICIES : DynamicWrappedIO.SEQUENTIAL_READ_POLICIES;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopFileIO.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopFileIO.java
@@ -98,4 +98,20 @@ public class HadoopFileIO {
   private static String readPolicies(final boolean randomIO) {
     return randomIO ? DynamicWrappedIO.PARQUET_READ_POLICIES : DynamicWrappedIO.SEQUENTIAL_READ_POLICIES;
   }
+
+  /**
+   * Does a path have a given capability?
+   * Calls {@code PathCapabilities#hasPathCapability(Path, String)},
+   * mapping IOExceptions to false.
+   * @param fs filesystem
+   * @param path path to query the capability of.
+   * @param capability non-null, non-empty string to query the path for support.
+   * @return true if the capability is supported
+   * under that part of the FS
+   * false if the method is not loaded or the path lacks the capability.
+   * @throws IllegalArgumentException invalid arguments
+   */
+  public boolean hasPathCapability(Object fs, Path path, String capability) {
+    return DynamicWrappedIO.instance().pathCapabilities_hasPathCapability(fs, path, capability);
+  }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -73,7 +73,7 @@ public class HadoopInputFile implements InputFile {
 
   @Override
   public SeekableInputStream newStream() throws IOException {
-    return HadoopStreams.wrap(DynamicWrappedIO.openFile(fs, stat));
+    return HadoopStreams.wrap(DynamicWrappedIO.openFile(fs, stat, DynamicWrappedIO.PARQUET_READ_POLICIES));
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.hadoop.util.wrapped.io.DynamicWrappedIO;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.SeekableInputStream;
 
@@ -72,7 +73,7 @@ public class HadoopInputFile implements InputFile {
 
   @Override
   public SeekableInputStream newStream() throws IOException {
-    return HadoopStreams.wrap(fs.open(stat.getPath()));
+    return HadoopStreams.wrap(DynamicWrappedIO.openFile(fs, stat));
   }
 
   @Override

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/wrapped/io/DynamicWrappedIO.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/wrapped/io/DynamicWrappedIO.java
@@ -374,15 +374,16 @@ public final class DynamicWrappedIO {
    * <p>
    * If the WrappedIO class is found, uses
    * {@link #fileSystem_openFile(FileSystem, Path, String, FileStatus, Long, Map)} with
-   * {@link #PARQUET_READ_POLICIES} as the list of read policies and passing down
+   * the supplied list of read policies and passing down
    * the file status.
    * <p>
    * If not, falls back to the classic {@code fs.open(Path)} call.
    * @param fs filesystem
    * @param status file status
+   * @param policy  read policy
    * @throws IOException any IO failure.
    */
-  public static FSDataInputStream openFile(FileSystem fs, FileStatus status) throws IOException {
+  public static FSDataInputStream openFile(FileSystem fs, FileStatus status, String policy) throws IOException {
     final DynamicWrappedIO instance = DynamicWrappedIO.instance();
     FSDataInputStream stream;
     if (instance.fileSystem_openFile_available()) {
@@ -392,8 +393,8 @@ public final class DynamicWrappedIO {
       // in open and choosing the range for GET requests.
       // For other stores, it ultimately invokes the classic open(Path)
       // call so is no more expensive than before.
-      LOG.debug("Opening file {} through fileSystem_openFile", status);
-      stream = instance.fileSystem_openFile(fs, status.getPath(), PARQUET_READ_POLICIES, status, null, null);
+      LOG.debug("Opening file {} through fileSystem_openFile() with policy {}", status, policy);
+      stream = instance.fileSystem_openFile(fs, status.getPath(), policy, status, null, null);
     } else {
       LOG.debug("Opening file {} through open()", status);
       stream = fs.open(status.getPath());

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/wrapped/io/DynamicWrappedIO.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/wrapped/io/DynamicWrappedIO.java
@@ -1,0 +1,403 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.parquet.hadoop.util.wrapped.io;
+
+import static org.apache.parquet.hadoop.util.wrapped.io.BindingUtils.available;
+import static org.apache.parquet.hadoop.util.wrapped.io.BindingUtils.checkAvailable;
+import static org.apache.parquet.hadoop.util.wrapped.io.BindingUtils.loadClass;
+import static org.apache.parquet.hadoop.util.wrapped.io.BindingUtils.loadStaticMethod;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.util.DynMethods;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The wrapped IO methods in {@code org.apache.hadoop.io.wrappedio.WrappedIO},
+ * dynamically loaded.
+ * <p>
+ * This class is derived from {@code org.apache.hadoop.io.wrappedio.impl.DynamicWrappedIO}.
+ * If a bug is found here, check to see if it has been fixed in hadoop trunk branch.
+ * If not: please provide a patch for that project alongside one here.
+ */
+public final class DynamicWrappedIO {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DynamicWrappedIO.class);
+
+  /**
+   * Classname of the wrapped IO class: {@value}.
+   */
+  public static final String WRAPPED_IO_CLASSNAME = "org.apache.hadoop.io.wrappedio.WrappedIO";
+
+  /**
+   * Method name for openFile: {@value}
+   */
+  public static final String FILESYSTEM_OPEN_FILE = "fileSystem_openFile";
+
+  /**
+   * Method name for bulk delete: {@value}
+   */
+  public static final String BULKDELETE_DELETE = "bulkDelete_delete";
+
+  /**
+   * Method name for bulk delete: {@value}
+   */
+  public static final String BULKDELETE_PAGESIZE = "bulkDelete_pageSize";
+
+  /**
+   * Method name for {@code byteBufferPositionedReadable}: {@value}.
+   */
+  public static final String BYTE_BUFFER_POSITIONED_READABLE_READ_FULLY_AVAILABLE =
+      "byteBufferPositionedReadable_readFullyAvailable";
+
+  /**
+   * Method name for {@code byteBufferPositionedReadable}: {@value}.
+   */
+  public static final String BYTE_BUFFER_POSITIONED_READABLE_READ_FULLY = "byteBufferPositionedReadable_readFully";
+
+  /**
+   * Method name for {@code PathCapabilities.hasPathCapability()}.
+   * {@value}
+   */
+  public static final String PATH_CAPABILITIES_HAS_PATH_CAPABILITY = "pathCapabilities_hasPathCapability";
+
+  /**
+   * Method name for {@code StreamCapabilities.hasCapability()}.
+   * {@value}
+   */
+  public static final String STREAM_CAPABILITIES_HAS_CAPABILITY = "streamCapabilities_hasCapability";
+
+  /**
+   * A singleton instance of the wrapper.
+   */
+  private static final DynamicWrappedIO INSTANCE = new DynamicWrappedIO();
+
+  /**
+   * Read policy for parquet files: {@value}.
+   */
+  public static final String PARQUET_READ_POLICIES = "parquet, columnar, vector, random";
+
+  /**
+   * Was wrapped IO loaded?
+   * In the hadoop codebase, this is true.
+   * But in other libraries it may not always be true...this
+   * field is used to assist copy-and-paste adoption.
+   */
+  private final boolean loaded;
+
+  /**
+   * Method binding.
+   * {@code WrappedIO.bulkDelete_delete(FileSystem, Path, Collection)}.
+   */
+  private final DynMethods.UnboundMethod bulkDeleteDeleteMethod;
+
+  /**
+   * Method binding.
+   * {@code WrappedIO.bulkDelete_pageSize(FileSystem, Path)}.
+   */
+  private final DynMethods.UnboundMethod bulkDeletePageSizeMethod;
+
+  /**
+   * Dynamic openFile() method.
+   * {@code WrappedIO.fileSystem_openFile(FileSystem, Path, String, FileStatus, Long, Map)}.
+   */
+  private final DynMethods.UnboundMethod fileSystemOpenFileMethod;
+
+  private final DynMethods.UnboundMethod pathCapabilitiesHasPathCapabilityMethod;
+
+  private final DynMethods.UnboundMethod streamCapabilitiesHasCapabilityMethod;
+
+  private final DynMethods.UnboundMethod byteBufferPositionedReadableReadFullyAvailableMethod;
+
+  private final DynMethods.UnboundMethod byteBufferPositionedReadableReadFullyMethod;
+
+  public DynamicWrappedIO() {
+    this(WRAPPED_IO_CLASSNAME);
+  }
+
+  public DynamicWrappedIO(String classname) {
+
+    // Wrapped IO class.
+    Class<?> wrappedClass = loadClass(classname);
+
+    loaded = wrappedClass != null;
+
+    // bulk delete APIs
+    bulkDeleteDeleteMethod = loadStaticMethod(
+        wrappedClass, List.class, BULKDELETE_DELETE, FileSystem.class, Path.class, Collection.class);
+
+    bulkDeletePageSizeMethod =
+        loadStaticMethod(wrappedClass, Integer.class, BULKDELETE_PAGESIZE, FileSystem.class, Path.class);
+
+    // load the openFile method
+    fileSystemOpenFileMethod = loadStaticMethod(
+        wrappedClass,
+        FSDataInputStream.class,
+        FILESYSTEM_OPEN_FILE,
+        FileSystem.class,
+        Path.class,
+        String.class,
+        FileStatus.class,
+        Long.class,
+        Map.class);
+
+    // path and stream capabilities
+    pathCapabilitiesHasPathCapabilityMethod = loadStaticMethod(
+        wrappedClass,
+        Boolean.class,
+        PATH_CAPABILITIES_HAS_PATH_CAPABILITY,
+        FileSystem.class,
+        Path.class,
+        String.class);
+
+    streamCapabilitiesHasCapabilityMethod = loadStaticMethod(
+        wrappedClass, Boolean.class, STREAM_CAPABILITIES_HAS_CAPABILITY, Object.class, String.class);
+
+    // ByteBufferPositionedReadable
+    byteBufferPositionedReadableReadFullyAvailableMethod = loadStaticMethod(
+        wrappedClass, Void.class, BYTE_BUFFER_POSITIONED_READABLE_READ_FULLY_AVAILABLE, InputStream.class);
+
+    byteBufferPositionedReadableReadFullyMethod = loadStaticMethod(
+        wrappedClass,
+        Void.class,
+        BYTE_BUFFER_POSITIONED_READABLE_READ_FULLY,
+        InputStream.class,
+        long.class,
+        ByteBuffer.class);
+  }
+
+  /**
+   * Is the wrapped IO class loaded?
+   * @return true if the wrappedIO class was found and loaded.
+   */
+  public boolean loaded() {
+    return loaded;
+  }
+
+  /**
+   * Are the bulk delete methods available?
+   * @return true if the methods were found.
+   */
+  public boolean bulkDelete_available() {
+    return available(bulkDeleteDeleteMethod);
+  }
+
+  /**
+   * Get the maximum number of objects/files to delete in a single request.
+   * @param fileSystem filesystem
+   * @param path path to delete under.
+   * @return a number greater than or equal to zero.
+   * @throws UnsupportedOperationException bulk delete under that path is not supported.
+   * @throws IllegalArgumentException path not valid.
+   * @throws RuntimeException invocation failure.
+   */
+  public int bulkDelete_pageSize(final FileSystem fileSystem, final Path path) {
+    checkAvailable(bulkDeletePageSizeMethod);
+    return bulkDeletePageSizeMethod.invoke(null, fileSystem, path);
+  }
+
+  /**
+   * Delete a list of files/objects.
+   * <ul>
+   *   <li>Files must be under the path provided in {@code base}.</li>
+   *   <li>The size of the list must be equal to or less than the page size.</li>
+   *   <li>Directories are not supported; the outcome of attempting to delete
+   *       directories is undefined (ignored; undetected, listed as failures...).</li>
+   *   <li>The operation is not atomic.</li>
+   *   <li>The operation is treated as idempotent: network failures may
+   *        trigger resubmission of the request -any new objects created under a
+   *        path in the list may then be deleted.</li>
+   *    <li>There is no guarantee that any parent directories exist after this call.
+   *    </li>
+   * </ul>
+   * @param fs filesystem
+   * @param base path to delete under.
+   * @param paths list of paths which must be absolute and under the base path.
+   * @return a list of all the paths which couldn't be deleted for a reason other than "not found" and any associated error message.
+   * @throws UnsupportedOperationException bulk delete under that path is not supported.
+   * @throws IllegalArgumentException if a path argument is invalid.
+   * @throws RuntimeException for any failure.
+   */
+  public List<Map.Entry<Path, String>> bulkDelete_delete(FileSystem fs, Path base, Collection<Path> paths) {
+    checkAvailable(bulkDeleteDeleteMethod);
+    return bulkDeleteDeleteMethod.invoke(null, fs, base, paths);
+  }
+
+  /**
+   * Is the {@link #fileSystem_openFile(FileSystem, Path, String, FileStatus, Long, Map)}
+   * method available.
+   * @return true if the optimized open file method can be invoked.
+   */
+  public boolean fileSystem_openFile_available() {
+    return available(fileSystemOpenFileMethod);
+  }
+
+  /**
+   * OpenFile assistant, easy reflection-based access to
+   * {@code FileSystem#openFile(Path)} and blocks
+   * awaiting the operation completion.
+   * @param fs filesystem
+   * @param path path
+   * @param policy read policy
+   * @param status optional file status
+   * @param length optional file length
+   * @param options nullable map of other options
+   * @return stream of the opened file
+   * @throws RuntimeException for any failure.
+   */
+  public FSDataInputStream fileSystem_openFile(
+      final FileSystem fs,
+      final Path path,
+      final String policy,
+      @Nullable final FileStatus status,
+      @Nullable final Long length,
+      @Nullable final Map<String, String> options) {
+    checkAvailable(fileSystemOpenFileMethod);
+    return fileSystemOpenFileMethod.invoke(null, fs, path, policy, status, length, options);
+  }
+
+  /**
+   * Does a path have a given capability?
+   * Calls {@code PathCapabilities#hasPathCapability(Path, String)},
+   * mapping IOExceptions to false.
+   * @param fs filesystem
+   * @param path path to query the capability of.
+   * @param capability non-null, non-empty string to query the path for support.
+   * @return true if the capability is supported
+   * under that part of the FS
+   * false if the method is not loaded or the path lacks the capability.
+   * @throws IllegalArgumentException invalid arguments
+   */
+  public boolean pathCapabilities_hasPathCapability(Object fs, Path path, String capability) {
+    if (!available(pathCapabilitiesHasPathCapabilityMethod)) {
+      return false;
+    }
+    return pathCapabilitiesHasPathCapabilityMethod.invoke(null, fs, path, capability);
+  }
+
+  /**
+   * Does an object implement {@code StreamCapabilities} and, if so,
+   * what is the result of the probe for the capability?
+   * Calls {@code StreamCapabilities#hasCapability(String)},
+   * @param object object to probe
+   * @param capability capability string
+   * @return true iff the object implements StreamCapabilities and the capability is
+   * declared available.
+   */
+  public boolean streamCapabilities_hasCapability(Object object, String capability) {
+    if (!available(streamCapabilitiesHasCapabilityMethod)) {
+      return false;
+    }
+    return streamCapabilitiesHasCapabilityMethod.invoke(null, object, capability);
+  }
+
+  /**
+   * Are the ByteBufferPositionedReadable methods loaded?
+   * This does not check that a specific stream implements the API;
+   * use {@link #byteBufferPositionedReadable_readFullyAvailable(InputStream)}.
+   * @return true if the hadoop libraries have the method.
+   */
+  public boolean byteBufferPositionedReadable_available() {
+    return available(byteBufferPositionedReadableReadFullyAvailableMethod);
+  }
+
+  /**
+   * Probe to see if the input stream is an instance of ByteBufferPositionedReadable.
+   * If the stream is an FSDataInputStream, the wrapped stream is checked.
+   * @param in input stream
+   * @return true if the API is available, the stream implements the interface
+   * (including the innermost wrapped stream) and that it declares the stream capability.
+   */
+  public boolean byteBufferPositionedReadable_readFullyAvailable(InputStream in) {
+    return available(byteBufferPositionedReadableReadFullyAvailableMethod)
+        && (boolean) byteBufferPositionedReadableReadFullyAvailableMethod.invoke(null, in);
+  }
+
+  /**
+   * Delegate to {@code ByteBufferPositionedReadable#read(long, ByteBuffer)}.
+   * @param in input stream
+   * @param position position within file
+   * @param buf the ByteBuffer to receive the results of the read operation.
+   * @throws UnsupportedOperationException if the input doesn't implement
+   * the interface or, if when invoked, it is raised.
+   * Note: that is the default behaviour of {@code FSDataInputStream#readFully(long, ByteBuffer)}.
+   */
+  public void byteBufferPositionedReadable_readFully(InputStream in, long position, ByteBuffer buf) {
+    checkAvailable(byteBufferPositionedReadableReadFullyMethod);
+    byteBufferPositionedReadableReadFullyMethod.invoke(null, in, position, buf);
+  }
+
+  /**
+   * Get the singleton instance.
+   * @return the instance
+   */
+  public static DynamicWrappedIO instance() {
+    return INSTANCE;
+  }
+
+  /**
+   * Is the wrapped IO class loaded?
+   * @return true if the instance is loaded.
+   */
+  public static boolean isAvailable() {
+    return instance().loaded();
+  }
+
+  /**
+   * Open a parquet file.
+   * <p>
+   * If the WrappedIO class is found, uses
+   * {@link #fileSystem_openFile(FileSystem, Path, String, FileStatus, Long, Map)} with
+   * {@link #PARQUET_READ_POLICIES} as the list of read policies and passing down
+   * the file status.
+   * <p>
+   * If not, falls back to the classic {@code fs.open(Path)} call.
+   * @param fs filesystem
+   * @param status file status
+   * @throws IOException any IO failure.
+   */
+  public static FSDataInputStream openFile(FileSystem fs, FileStatus status) throws IOException {
+    final DynamicWrappedIO instance = DynamicWrappedIO.instance();
+    FSDataInputStream stream;
+    if (instance.fileSystem_openFile_available()) {
+      // use openfile for a higher performance read
+      // and the ability to set a read policy.
+      // This optimizes for cloud storage by saving on IO
+      // in open and choosing the range for GET requests.
+      // For other stores, it ultimately invokes the classic open(Path)
+      // call so is no more expensive than before.
+      LOG.debug("Opening file {} through fileSystem_openFile", status);
+      stream = instance.fileSystem_openFile(fs, status.getPath(), PARQUET_READ_POLICIES, status, null, null);
+    } else {
+      LOG.debug("Opening file {} through open()", status);
+      stream = fs.open(status.getPath());
+    }
+    return stream;
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/wrapped/io/DynamicWrappedIO.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/wrapped/io/DynamicWrappedIO.java
@@ -175,9 +175,9 @@ public final class DynamicWrappedIO {
     // path and stream capabilities
     pathCapabilitiesHasPathCapabilityMethod = loadStaticMethod(
         wrappedClass,
-        Boolean.class,
+        boolean.class,
         PATH_CAPABILITIES_HAS_PATH_CAPABILITY,
-        FileSystem.class,
+        Object.class,
         Path.class,
         String.class);
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -98,6 +98,7 @@ import org.apache.parquet.hadoop.util.ContextUtil;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.apache.parquet.hadoop.util.HiddenFileFilter;
+import org.apache.parquet.hadoop.util.wrapped.io.DynamicWrappedIO;
 import org.apache.parquet.internal.column.columnindex.BinaryTruncator;
 import org.apache.parquet.internal.column.columnindex.BoundaryOrder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
@@ -647,10 +648,11 @@ public class TestParquetFileWriter {
     w.end(new HashMap<String, String>());
 
     FileSystem fs = path.getFileSystem(conf);
-    long fileLen = fs.getFileStatus(path).getLen();
+    final FileStatus stat = fs.getFileStatus(path);
+    long fileLen = stat.getLen();
 
     long footerLen;
-    try (FSDataInputStream data = fs.open(path)) {
+    try (FSDataInputStream data = DynamicWrappedIO.openFile(fs, stat)) {
       data.seek(fileLen - 8); // 4-byte offset + "PAR1"
       footerLen = BytesUtils.readIntLittleEndian(data);
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -29,6 +29,7 @@ import static org.apache.parquet.hadoop.ParquetInputFormat.READ_SUPPORT_CLASS;
 import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE;
 import static org.apache.parquet.hadoop.ParquetWriter.MAX_PADDING_SIZE_DEFAULT;
 import static org.apache.parquet.hadoop.TestUtils.enforceEmptyDir;
+import static org.apache.parquet.hadoop.util.HadoopFileIO.openFile;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
@@ -98,7 +99,6 @@ import org.apache.parquet.hadoop.util.ContextUtil;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.apache.parquet.hadoop.util.HiddenFileFilter;
-import org.apache.parquet.hadoop.util.wrapped.io.DynamicWrappedIO;
 import org.apache.parquet.internal.column.columnindex.BinaryTruncator;
 import org.apache.parquet.internal.column.columnindex.BoundaryOrder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
@@ -652,7 +652,7 @@ public class TestParquetFileWriter {
     long fileLen = stat.getLen();
 
     long footerLen;
-    try (FSDataInputStream data = DynamicWrappedIO.openFile(fs, stat, DynamicWrappedIO.PARQUET_READ_POLICIES)) {
+    try (FSDataInputStream data = openFile(fs, stat, true)) {
       data.seek(fileLen - 8); // 4-byte offset + "PAR1"
       footerLen = BytesUtils.readIntLittleEndian(data);
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -652,7 +652,7 @@ public class TestParquetFileWriter {
     long fileLen = stat.getLen();
 
     long footerLen;
-    try (FSDataInputStream data = DynamicWrappedIO.openFile(fs, stat)) {
+    try (FSDataInputStream data = DynamicWrappedIO.openFile(fs, stat, DynamicWrappedIO.PARQUET_READ_POLICIES)) {
       data.seek(fileLen - 8); // 4-byte offset + "PAR1"
       footerLen = BytesUtils.readIntLittleEndian(data);
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/wrapped/io/TestVectorIoBridge.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/wrapped/io/TestVectorIoBridge.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.hadoop.util.HadoopFileIO;
 import org.apache.parquet.io.ParquetFileRange;
 import org.junit.After;
 import org.junit.Before;
@@ -176,7 +177,7 @@ public class TestVectorIoBridge {
    * @throws IOException failure to open
    */
   private FSDataInputStream openTestFile() throws IOException {
-    return getFileSystem().open(testFilePath);
+    return HadoopFileIO.openFile(getFileSystem(), testFilePath, true);
   }
 
   /**


### PR DESCRIPTION
### Rationale for this change

* Saves overhead of HTTP head request when opening a file
* tells the hadoop FS client that the file being opened is parquet, and should use the first recognized policy of "parquet, columnar, vector, random". These can disable prefetch and limit ranges requested to those optimal for columns.

### What changes are included in this PR?

1,. Uses reflection to load reflection-friendly bindings to the enhanced openFile method of https://github.com/apache/hadoop/pull/6686 . Although openFile() has been present since Hadoop 3.3.0, because parquet still builds against hadoop 2.x reflection is required.

### Are these changes tested?

Existing tests have been modified.
https://github.com/apache/hadoop/pull/6686https://github.com/apache/hadoop/pull/6686


### Are there any user-facing changes?

no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #${#2915}
