### PR TITLE
GH-1701: fix double close of ParquetFileWriter

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -175,6 +175,9 @@ public class ParquetFileWriter implements AutoCloseable {
   private final ReusingByteBufferAllocator crcAllocator;
   private final boolean pageWriteChecksumEnabled;
 
+  // set when PositionOutputStream is closed
+  private boolean closed;
+
   /**
    * Captures the order in which methods should be called
    */
@@ -1658,11 +1661,17 @@ public class ParquetFileWriter implements AutoCloseable {
 
   @Override
   public void close() throws IOException {
+    if (closed) {
+      return;
+    }
+
     try (PositionOutputStream temp = out) {
       temp.flush();
       if (crcAllocator != null) {
         crcAllocator.close();
       }
+    } finally {
+      closed = true;
     }
   }
 


### PR DESCRIPTION
### Rationale for this change
ParquetFileWriter::close can be called multiple times (end -> close and InternalParquetRecordWriter::close via AutoCloseables.uncheckedClose). this causes an exception to be generated on the 2nd close.

### What changes are included in this PR?
Make ParquetFileWriter::close safe to be called multiple times. 

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.

Closes #1701