### PR TITLE
GH-2976: Parqurt CLI compression commands should accept lowercase compression name

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/RewriteCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/RewriteCommand.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.cli.BaseCommand;
+import org.apache.parquet.cli.util.Codecs;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.rewrite.MaskMode;
 import org.apache.parquet.hadoop.rewrite.ParquetRewriter;
@@ -114,7 +115,7 @@ public class RewriteCommand extends BaseCommand {
     }
 
     if (codec != null) {
-      CompressionCodecName codecName = CompressionCodecName.valueOf(codec);
+      CompressionCodecName codecName = Codecs.parquetCodec(codec);
       builder.transform(codecName);
     }
 

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/TransCompressionCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/TransCompressionCommand.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.HadoopReadOptions;
 import org.apache.parquet.cli.BaseCommand;
+import org.apache.parquet.cli.util.Codecs;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -76,7 +77,7 @@ public class TransCompressionCommand extends BaseCommand {
 
     Path inPath = new Path(input);
     Path outPath = new Path(output);
-    CompressionCodecName codecName = CompressionCodecName.valueOf(codec);
+    CompressionCodecName codecName = Codecs.parquetCodec(codec);
 
     ParquetMetadata metaData = ParquetFileReader.readFooter(getConf(), inPath, NO_FILTER);
     MessageType schema = metaData.getFileMetaData().getSchema();

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
@@ -67,4 +67,32 @@ public class RewriteCommandTest extends ParquetFileTest {
     Assert.assertEquals(0, command.run());
     Assert.assertTrue(output.exists());
   }
+
+  @Test
+  public void testRewriteCommandWithCompression_GZIP() throws IOException {
+    File file = parquetFile();
+    RewriteCommand command = new RewriteCommand(createLogger());
+    command.inputs = Arrays.asList(file.getAbsolutePath());
+    File output = new File(getTempFolder(), "converted-1.GZIP.parquet");
+    command.output = output.getAbsolutePath();
+    command.codec = "GZIP";
+    command.setConf(new Configuration());
+
+    Assert.assertEquals(0, command.run());
+    Assert.assertTrue(output.exists());
+  }
+
+  @Test
+  public void testRewriteCommandWithCompression_gzip() throws IOException {
+    File file = parquetFile();
+    RewriteCommand command = new RewriteCommand(createLogger());
+    command.inputs = Arrays.asList(file.getAbsolutePath());
+    File output = new File(getTempFolder(), "converted-2.gzip.parquet");
+    command.output = output.getAbsolutePath();
+    command.codec = "gzip";
+    command.setConf(new Configuration());
+
+    Assert.assertEquals(0, command.run());
+    Assert.assertTrue(output.exists());
+  }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/TransCompressionCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/TransCompressionCommandTest.java
@@ -27,14 +27,29 @@ import org.junit.Test;
 public class TransCompressionCommandTest extends ParquetFileTest {
 
   @Test
-  public void testTransCompressionCommand() throws IOException {
+  public void testTransCompressionCommand_ZSTD() throws IOException {
     TransCompressionCommand command = new TransCompressionCommand(createLogger());
 
     command.input = parquetFile().getAbsolutePath();
 
-    File output = new File(getTempFolder(), getClass().getSimpleName() + ".converted.parquet");
+    File output = new File(getTempFolder(), getClass().getSimpleName() + ".converted-1.ZSTD.parquet");
     command.output = output.getAbsolutePath();
     command.codec = "ZSTD";
+    command.setConf(new Configuration());
+
+    Assert.assertEquals(0, command.run());
+    Assert.assertTrue(output.exists());
+  }
+
+  @Test
+  public void testTransCompressionCommand_zstd() throws IOException {
+    TransCompressionCommand command = new TransCompressionCommand(createLogger());
+
+    command.input = parquetFile().getAbsolutePath();
+
+    File output = new File(getTempFolder(), getClass().getSimpleName() + ".converted-2.zstd.parquet");
+    command.output = output.getAbsolutePath();
+    command.codec = "zstd";
     command.setConf(new Configuration());
 
     Assert.assertEquals(0, command.run());


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Currently, there is inconsistent in different commands.
```
$ parquet convert c000.snappy.parquet -o c000.zstd.parquet --compression-codec zstd
```
```
$ parquet rewrite -i c000.snappy.parquet -o c000.zstd.parquet --compression-codec zstd
Argument error: No enum constant org.apache.parquet.hadoop.metadata.CompressionCodecName.zstd
```

For consistent user experience of Parquet CLI, we should allow lowercase codecs in all commands.

### What changes are included in this PR?

Change Parquet CLI's `trans-compression` and `rewrite` commands to accept lowercase compression codec.

### Are these changes tested?

Yes, new UTs are added.

### Are there any user-facing changes?

Yes.

Close #2976
