### PR TITLE
GH-2990: Only call hsync() and hflush() on supported filesystems

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopPositionOutputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopPositionOutputStream.java
@@ -50,8 +50,9 @@ public class HadoopPositionOutputStream extends PositionOutputStream {
     wrapped.write(b, off, len);
   }
 
+  @Deprecated
   public void sync() throws IOException {
-    wrapped.hsync();
+    // sync is not necessary for Parquet use cases.
   }
 
   @Override
@@ -61,8 +62,6 @@ public class HadoopPositionOutputStream extends PositionOutputStream {
 
   @Override
   public void close() throws IOException {
-    try (FSDataOutputStream fdos = wrapped) {
-      fdos.hflush();
-    }
+    wrapped.close();
   }
 }


### PR DESCRIPTION
Instead of log the unsupported call check capabilities and call only on supported filesystems - e.g. S3A does not.

### Rationale for this change
When stream into an HadoopOutputFile on S3A a waring gets logged: Application invoked the Syncable API against stream writing to XXX. This is Unsupported
https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/troubleshooting_s3a.html#UnsupportedOperationException_.E2.80.9CS3A_streams_are_not_Syncable._See_HADOOP-17597..E2.80.9D

### What changes are included in this PR?
Instead of log the unsupported call (hflush() and hsync()) check capabilities and call only on supported filesystems - whereas S3A is not.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No

Closes: #2990