### PR TITLE
GH-2994: Optimize string to binary conversion in AvroWriteSupport

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -408,7 +408,7 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     } else if (value instanceof CharSequence) {
       return Binary.fromCharSequence((CharSequence) value);
     }
-    return Binary.fromCharSequence(value.toString());
+    return Binary.fromString(value.toString());
   }
 
   private static GenericData getDataModel(ParquetConfiguration conf, Schema schema) {

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroWriteSupport.java
@@ -403,6 +403,8 @@ public class AvroWriteSupport<T> extends WriteSupport<T> {
     if (value instanceof Utf8) {
       Utf8 utf8 = (Utf8) value;
       return Binary.fromReusedByteArray(utf8.getBytes(), 0, utf8.getByteLength());
+    } else if (value instanceof String) {
+      return Binary.fromString((String) value);
     } else if (value instanceof CharSequence) {
       return Binary.fromCharSequence((CharSequence) value);
     }


### PR DESCRIPTION
### Rationale for this change
`Binary.fromCharSequence` is an order of magnitud slower than `Binary.fromString` when input is a `String`:

```
Benchmarks.fromCharSequence  thrpt   25   5885347.328 ±  186669.738  ops/s
Benchmarks.fromString        thrpt   25  71335979.492 ± 8800704.044  ops/s
```

Here is the code for the benchmarks:
```java
public class Benchmarks {
    private static final String string = RandomStringUtils.randomAlphanumeric(100);

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void fromCharSequence(Blackhole blackhole) {
        blackhole.consume(Binary.fromCharSequence(string));
    }

    @Benchmark
    @BenchmarkMode(Mode.Throughput)
    public void fromString(Blackhole blackhole) {
        blackhole.consume(Binary.fromString(string));
    }
}
```

### What changes are included in this PR?
Change `AvroWriteSupport.fromAvroString()` to use `Binary.fromString` when operating with string inputs.

### Are these changes tested?
Current tests should cover the change

### Are there any user-facing changes?
No

Closes #2994
