### PR TITLE
MINOR: Don't run all the tests on a release

### DIFF
--- a/dev/prepare-release.sh
+++ b/dev/prepare-release.sh
@@ -39,6 +39,6 @@ new_development_version="$release_version-SNAPSHOT"
 tag="apache-parquet-$release_version-rc$2"
 
 mvn release:clean
-mvn release:prepare -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
+mvn release:prepare -DskipTests -Darguments=-DskipTests -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
 
 echo "Finish staging binary artifacts by running: mvn release:perform"


### PR DESCRIPTION
### Rationale for this change

We don't want to rerun all the tests during a release since it takes a lot of time. We can rely on the CI instead.

### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
