### PR TITLE
GH-3007: Ensure version specific Jackson classes are shaded 

### DIFF
--- a/parquet-jackson/pom.xml
+++ b/parquet-jackson/pom.xml
@@ -97,6 +97,18 @@
                   <pattern>${jackson.package}</pattern>
                   <shadedPattern>${shade.prefix}.${jackson.package}</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.11.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.11.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.17.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.17.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.21.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.21.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>


### PR DESCRIPTION
### Rationale for this change
The current jar contains version specific classes under META-INF/versions/... with unshaded package names. This leads to clashes with jackson and thus classpath duplicates. This is a major problem in many big projects right now (e.g. Spark).

### What changes are included in this PR?
Ensure these classes are shaded.

### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #3007
