### PR TITLE
GH-2962: Set dictionary_page_offset even when encoding_stats are missing

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -557,8 +557,9 @@ public class ParquetMetadataConverter {
           columnMetaData.getTotalUncompressedSize(),
           columnMetaData.getTotalSize(),
           columnMetaData.getFirstDataPageOffset());
-      if (columnMetaData.getEncodingStats() != null
-          && columnMetaData.getEncodingStats().hasDictionaryPages()) {
+      if ((columnMetaData.getEncodingStats() != null
+              && columnMetaData.getEncodingStats().hasDictionaryPages())
+          || columnMetaData.hasDictionaryPage()) {
         metaData.setDictionary_page_offset(columnMetaData.getDictionaryPageOffset());
       }
       long bloomFilterOffset = columnMetaData.getBloomFilterOffset();


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Currently dictionary page offset is not being set when there are no encoding statistics. This is creating problem while creating parquet files using the addRowGroup method in ParquetMetadataConverter

### What changes are included in this PR?
Set dictionary_page_offset value when column has any dictionary pages.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #2962 
