### PR TITLE
GH-3016: Do not use dependency-reduced pom for attached shaded artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Parquet-Java uses Maven to build and depends on the thrift compiler (protoc is n
 To build and install the thrift compiler, run:
 
 ```
-wget -nv http://archive.apache.org/dist/thrift/0.20.0/thrift-0.20.0.tar.gz
+wget -nv https://archive.apache.org/dist/thrift/0.20.0/thrift-0.20.0.tar.gz
 tar xzf thrift-0.20.0.tar.gz
 cd thrift-0.20.0
 chmod +x ./configure

--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -239,6 +239,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
               <shadedArtifactAttached>true</shadedArtifactAttached>
               <shadedClassifierName>runtime</shadedClassifierName>
               <minimizeJar>false</minimizeJar>


### PR DESCRIPTION
Since 0.14.0, `parquet-cli` does not contain transitive compile scope dependencies. Check [0.14.0](https://central.sonatype.com/artifact/org.apache.parquet/parquet-cli/1.14.0/dependencies) vs [0.13.1](https://central.sonatype.com/artifact/org.apache.parquet/parquet-cli/1.13.1/dependencies).

this is an issue from the `maven-shade-plugin`. When `shadedArtifactAttached` is set, `createDependencyReducedPom` should be `false`.

See https://issues.apache.org/jira/projects/MSHADE/issues/MSHADE-419

fix: #3016
