### PR TITLE
GH-3007: Ensure version specific Jackson classes are shaded

### DIFF
--- a/parquet-jackson/pom.xml
+++ b/parquet-jackson/pom.xml
@@ -34,6 +34,7 @@
 
   <dependencies>
     <dependency>
+      <!-- Shade jackson package names to prevent classpath duplicates  -->
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>

--- a/parquet-jackson/pom.xml
+++ b/parquet-jackson/pom.xml
@@ -34,7 +34,6 @@
 
   <dependencies>
     <dependency>
-      <!-- Shade jackson package names to prevent classpath duplicates  -->
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
       <version>${jackson.version}</version>

--- a/parquet-jackson/pom.xml
+++ b/parquet-jackson/pom.xml
@@ -97,6 +97,26 @@
                   <pattern>${jackson.package}</pattern>
                   <shadedPattern>${shade.prefix}.${jackson.package}</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.9.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.9.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.11.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.11.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.17.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.17.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.19.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.19.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.21.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.21.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
     <jackson.groupId>com.fasterxml.jackson.core</jackson.groupId>
     <jackson.datatype.groupId>com.fasterxml.jackson.datatype</jackson.datatype.groupId>
     <jackson.package>com.fasterxml.jackson</jackson.package>
+    <!-- To upgrade jackson, check the jdk versions inside the jar and include any new versions in the shading in parquet-jackson. -->
     <jackson.version>2.17.2</jackson.version>
     <jackson-databind.version>2.17.2</jackson-databind.version>
     <japicmp.version>0.21.0</japicmp.version>


### PR DESCRIPTION
Rationale for this change
The current jar contains version specific classes under META-INF/versions/... with unshaded package names. This leads to clashes with jackson and thus classpath duplicates. This is a major problem in many big projects right now (e.g. Spark).

What changes are included in this PR?
Ensure these classes are shaded.

Are these changes tested?
Are there any user-facing changes?
Closes https://github.com/apache/parquet-java/issues/3007