### PR TITLE
PARQUET-3031: Support to transfer input stream when building ParquetFileReader

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -922,7 +922,7 @@ public class ParquetFileReader implements Closeable {
   }
 
   public ParquetFileReader(InputFile file, ParquetReadOptions options) throws IOException {
-    this(file, options, null);
+    this(file, options, file.newStream());
   }
 
   public ParquetFileReader(InputFile file, ParquetReadOptions options, SeekableInputStream f) throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -710,6 +710,19 @@ public class ParquetFileReader implements Closeable {
     return new ParquetFileReader(file, options);
   }
 
+  /**
+   * Open a {@link InputFile file} with {@link ParquetReadOptions options}.
+   *
+   * @param file    an input file
+   * @param options parquet read options
+   * @param f       the input stream for the file
+   * @return an open ParquetFileReader
+   * @throws IOException if there is an error while opening the file
+   */
+  public static ParquetFileReader open(InputFile file, ParquetReadOptions options, SeekableInputStream f) throws IOException {
+    return new ParquetFileReader(file, options, f);
+  }
+
   protected final SeekableInputStream f;
   private final InputFile file;
   private final ParquetReadOptions options;
@@ -908,9 +921,13 @@ public class ParquetFileReader implements Closeable {
   }
 
   public ParquetFileReader(InputFile file, ParquetReadOptions options) throws IOException {
+    this(file, options, null);
+  }
+
+  public ParquetFileReader(InputFile file, ParquetReadOptions options, SeekableInputStream f) throws IOException {
     this.converter = new ParquetMetadataConverter(options);
     this.file = file;
-    this.f = file.newStream();
+    this.f = (null != f ? f : file.newStream());
     this.options = options;
     try {
       this.footer = readFooter(file, options, f, converter);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -877,7 +877,7 @@ public class ParquetFileReader implements Closeable {
    */
   public ParquetFileReader(Configuration conf, Path file, ParquetMetadata footer, ParquetReadOptions options)
       throws IOException {
-    this(conf, file, footer, options, null);
+    this(conf, file, footer, options, HadoopInputFile.fromPath(file, conf).newStream());
   }
 
   /**
@@ -893,7 +893,7 @@ public class ParquetFileReader implements Closeable {
       throws IOException {
     this.converter = new ParquetMetadataConverter(conf);
     this.file = HadoopInputFile.fromPath(file, conf);
-    this.f = (null != f ? f : this.file.newStream());
+    this.f = f;
     this.fileMetaData = footer.getFileMetaData();
     this.fileDecryptor = fileMetaData.getFileDecryptor();
     this.options = options;
@@ -928,7 +928,7 @@ public class ParquetFileReader implements Closeable {
   public ParquetFileReader(InputFile file, ParquetReadOptions options, SeekableInputStream f) throws IOException {
     this.converter = new ParquetMetadataConverter(options);
     this.file = file;
-    this.f = (null != f ? f : file.newStream());
+    this.f = f;
     this.options = options;
     try {
       this.footer = readFooter(file, options, f, converter);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -877,19 +877,19 @@ public class ParquetFileReader implements Closeable {
    */
   public ParquetFileReader(Configuration conf, Path file, ParquetMetadata footer, ParquetReadOptions options)
       throws IOException {
-    this(conf, file, footer, null, options);
+    this(conf, file, footer, options, null);
   }
 
   /**
    * @param conf   the Hadoop Configuration
    * @param file   Path to a parquet file
    * @param footer a {@link ParquetMetadata} footer already read from the file
-   * @param f      a {@link SeekableInputStream} for the parquet file
    * @param options {@link ParquetReadOptions}
+   * @param f      a {@link SeekableInputStream} for the parquet file
    * @throws IOException if the file can not be opened
    */
   public ParquetFileReader(
-      Configuration conf, Path file, ParquetMetadata footer, SeekableInputStream f, ParquetReadOptions options)
+      Configuration conf, Path file, ParquetMetadata footer, ParquetReadOptions options, SeekableInputStream f)
       throws IOException {
     this.converter = new ParquetMetadataConverter(conf);
     this.file = HadoopInputFile.fromPath(file, conf);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -719,7 +719,8 @@ public class ParquetFileReader implements Closeable {
    * @return an open ParquetFileReader
    * @throws IOException if there is an error while opening the file
    */
-  public static ParquetFileReader open(InputFile file, ParquetReadOptions options, SeekableInputStream f) throws IOException {
+  public static ParquetFileReader open(InputFile file, ParquetReadOptions options, SeekableInputStream f)
+      throws IOException {
     return new ParquetFileReader(file, options, f);
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -863,9 +863,23 @@ public class ParquetFileReader implements Closeable {
    */
   public ParquetFileReader(Configuration conf, Path file, ParquetMetadata footer, ParquetReadOptions options)
       throws IOException {
+    this(conf, file, footer, null, options);
+  }
+
+  /**
+   * @param conf   the Hadoop Configuration
+   * @param file   Path to a parquet file
+   * @param footer a {@link ParquetMetadata} footer already read from the file
+   * @param f      a {@link SeekableInputStream} for the parquet file
+   * @param options {@link ParquetReadOptions}
+   * @throws IOException if the file can not be opened
+   */
+  public ParquetFileReader(
+      Configuration conf, Path file, ParquetMetadata footer, SeekableInputStream f, ParquetReadOptions options)
+      throws IOException {
     this.converter = new ParquetMetadataConverter(conf);
     this.file = HadoopInputFile.fromPath(file, conf);
-    this.f = this.file.newStream();
+    this.f = (null != f ? f : this.file.newStream());
     this.fileMetaData = footer.getFileMetaData();
     this.fileDecryptor = fileMetaData.getFileDecryptor();
     this.options = options;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Support to transfer the parquet file inputstream when building the ParquetFileReader, so that we can re-use the existing inputstream and reduce the open file rpcs.

### What changes are included in this PR?

As title.

### Are these changes tested?

Existing UT. It only a new constructors.

### Are there any user-facing changes?
No break change.

Closes #3031
