### PR TITLE
MINOR: Support int value for timeOfDay in ProtoTimeConverter

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoMessageConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoMessageConverter.java
@@ -655,6 +655,11 @@ class ProtoMessageConverter extends GroupConverter {
     }
 
     @Override
+    public void addInt(int value) {
+      addLong(value);
+    }
+
+    @Override
     public void addLong(long value) {
       LocalTime localTime;
       switch (logicalTypeAnnotation.getUnit()) {


### PR DESCRIPTION
### Rationale for this change

TimeOfDay can sometimes be encoded as INT32 rather than INT64, especially if saved from Kafka Connect. 

### What changes are included in this PR?

Add support for Int as well as Long.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
