### PR TITLE
GH-3035: ParquetRewriter: Add a column renaming feature

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
@@ -624,6 +624,29 @@ class IntColumnChunkMetaData extends ColumnChunkMetaData {
   public SizeStatistics getSizeStatistics() {
     return sizeStatistics;
   }
+
+  /**
+   * Copies this ColumnChunkMetaData with chunk's path and type changed to provided ones.
+   *
+   * @param path ColumnPath of resulting chunk
+   * @param type PrimitiveType of resulting chunk
+   * @return resulting chunk
+   */
+  public ColumnChunkMetaData copy(ColumnPath path, PrimitiveType type) {
+    return ColumnChunkMetaData.get(
+        path,
+        type,
+        this.getCodec(),
+        this.getEncodingStats(),
+        this.getEncodings(),
+        this.getStatistics(),
+        this.getFirstDataPageOffset(),
+        this.getDictionaryPageOffset(),
+        this.getValueCount(),
+        this.getTotalSize(),
+        this.getTotalUncompressedSize(),
+        this.getSizeStatistics());
+  }
 }
 
 class LongColumnChunkMetaData extends ColumnChunkMetaData {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
@@ -504,29 +504,6 @@ public abstract class ColumnChunkMetaData {
   public boolean isEncrypted() {
     return false;
   }
-
-  /**
-   * Copies this ColumnChunkMetaData with path and type changed to provided ones.
-   *
-   * @param path a new ColumnPath of a chunk
-   * @param type a new PrimitiveType of a chunk
-   * @return resulting chunk
-   */
-  public ColumnChunkMetaData copy(ColumnPath path, PrimitiveType type) {
-    return ColumnChunkMetaData.get(
-        path,
-        type,
-        this.getCodec(),
-        this.getEncodingStats(),
-        this.getEncodings(),
-        this.getStatistics(),
-        this.getFirstDataPageOffset(),
-        this.getDictionaryPageOffset(),
-        this.getValueCount(),
-        this.getTotalSize(),
-        this.getTotalUncompressedSize(),
-        this.getSizeStatistics());
-  }
 }
 
 class IntColumnChunkMetaData extends ColumnChunkMetaData {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
@@ -504,6 +504,29 @@ public abstract class ColumnChunkMetaData {
   public boolean isEncrypted() {
     return false;
   }
+
+  /**
+   * Copies this ColumnChunkMetaData with path and type changed to provided ones.
+   *
+   * @param path a new ColumnPath of a chunk
+   * @param type a new PrimitiveType of a chunk
+   * @return resulting chunk
+   */
+  public ColumnChunkMetaData copy(ColumnPath path, PrimitiveType type) {
+    return ColumnChunkMetaData.get(
+        path,
+        type,
+        this.getCodec(),
+        this.getEncodingStats(),
+        this.getEncodings(),
+        this.getStatistics(),
+        this.getFirstDataPageOffset(),
+        this.getDictionaryPageOffset(),
+        this.getValueCount(),
+        this.getTotalSize(),
+        this.getTotalUncompressedSize(),
+        this.getSizeStatistics());
+  }
 }
 
 class IntColumnChunkMetaData extends ColumnChunkMetaData {
@@ -623,29 +646,6 @@ class IntColumnChunkMetaData extends ColumnChunkMetaData {
   @Override
   public SizeStatistics getSizeStatistics() {
     return sizeStatistics;
-  }
-
-  /**
-   * Copies this ColumnChunkMetaData with chunk's path and type changed to provided ones.
-   *
-   * @param path ColumnPath of resulting chunk
-   * @param type PrimitiveType of resulting chunk
-   * @return resulting chunk
-   */
-  public ColumnChunkMetaData copy(ColumnPath path, PrimitiveType type) {
-    return ColumnChunkMetaData.get(
-        path,
-        type,
-        this.getCodec(),
-        this.getEncodingStats(),
-        this.getEncodings(),
-        this.getStatistics(),
-        this.getFirstDataPageOffset(),
-        this.getDictionaryPageOffset(),
-        this.getValueCount(),
-        this.getTotalSize(),
-        this.getTotalUncompressedSize(),
-        this.getSizeStatistics());
   }
 }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -464,7 +464,7 @@ public class ParquetRewriter implements Closeable {
     if (readerToJoin != null) readerToJoin.close();
   }
 
-  private ColumnPath renameFieldsInPath(ColumnPath path) {
+  private ColumnPath normalizeFieldsInPath(ColumnPath path) {
     if (renamedColumns.isEmpty()) {
       return path;
     } else {
@@ -474,7 +474,7 @@ public class ParquetRewriter implements Closeable {
     }
   }
 
-  private PrimitiveType renameNameInType(PrimitiveType type) {
+  private PrimitiveType normalizeNameInType(PrimitiveType type) {
     if (renamedColumns.isEmpty()) {
       return type;
     } else {
@@ -496,11 +496,11 @@ public class ParquetRewriter implements Closeable {
       throw new IOException("Column " + chunk.getPath().toDotString() + " is already encrypted");
     }
 
-    ColumnChunkMetaData chunkColumnsRenamed = chunk;
+    ColumnChunkMetaData chunkColumnsNormalized = chunk;
     if (!renamedColumns.isEmpty()) {
-      chunkColumnsRenamed = ColumnChunkMetaData.get(
-          renameFieldsInPath(chunk.getPath()),
-          renameNameInType(chunk.getPrimitiveType()),
+      chunkColumnsNormalized = ColumnChunkMetaData.get(
+          normalizeFieldsInPath(chunk.getPath()),
+          normalizeNameInType(chunk.getPrimitiveType()),
           chunk.getCodec(),
           chunk.getEncodingStats(),
           chunk.getEncodings(),
@@ -573,7 +573,12 @@ public class ParquetRewriter implements Closeable {
       ColumnIndex columnIndex = indexCache.getColumnIndex(chunk);
       OffsetIndex offsetIndex = indexCache.getOffsetIndex(chunk);
       writer.appendColumnChunk(
-          descriptorRenamed, reader.getStream(), chunkColumnsRenamed, bloomFilter, columnIndex, offsetIndex);
+          descriptorRenamed,
+          reader.getStream(),
+          chunkColumnsNormalized,
+          bloomFilter,
+          columnIndex,
+          offsetIndex);
     }
   }
 
@@ -615,7 +620,7 @@ public class ParquetRewriter implements Closeable {
     }
 
     if (bloomFilter != null) {
-      writer.addBloomFilter(renameFieldsInPath(chunk.getPath()).toDotString(), bloomFilter);
+      writer.addBloomFilter(normalizeFieldsInPath(chunk.getPath()).toDotString(), bloomFilter);
     }
 
     reader.setStreamPosition(chunk.getStartingPos());
@@ -673,7 +678,7 @@ public class ParquetRewriter implements Closeable {
               dataPageAAD);
           statistics = convertStatistics(
               originalCreatedBy,
-              renameNameInType(chunk.getPrimitiveType()),
+              normalizeNameInType(chunk.getPrimitiveType()),
               headerV1.getStatistics(),
               columnIndex,
               pageOrdinal,
@@ -741,7 +746,7 @@ public class ParquetRewriter implements Closeable {
               dataPageAAD);
           statistics = convertStatistics(
               originalCreatedBy,
-              renameNameInType(chunk.getPrimitiveType()),
+              normalizeNameInType(chunk.getPrimitiveType()),
               headerV2.getStatistics(),
               columnIndex,
               pageOrdinal,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -498,19 +498,8 @@ public class ParquetRewriter implements Closeable {
 
     ColumnChunkMetaData chunkColumnsNormalized = chunk;
     if (!renamedColumns.isEmpty()) {
-      chunkColumnsNormalized = ColumnChunkMetaData.get(
-          normalizeFieldsInPath(chunk.getPath()),
-          normalizeNameInType(chunk.getPrimitiveType()),
-          chunk.getCodec(),
-          chunk.getEncodingStats(),
-          chunk.getEncodings(),
-          chunk.getStatistics(),
-          chunk.getFirstDataPageOffset(),
-          chunk.getDictionaryPageOffset(),
-          chunk.getValueCount(),
-          chunk.getTotalSize(),
-          chunk.getTotalUncompressedSize(),
-          chunk.getSizeStatistics());
+      chunkColumnsNormalized =
+          chunk.copy(normalizeFieldsInPath(chunk.getPath()), normalizeNameInType(chunk.getPrimitiveType()));
     }
 
     ColumnDescriptor descriptorOriginal = outSchema.getColumns().get(outColumnIdx);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -155,7 +155,7 @@ public class ParquetRewriter implements Closeable {
     this.newCodecName = options.getNewCodecName();
     this.indexCacheStrategy = options.getIndexCacheStrategy();
     this.overwriteInputWithJoinColumns = options.getOverwriteInputWithJoinColumns();
-    this.renamedColumns = options.gerRenameColumns();
+    this.renamedColumns = options.getRenameColumns();
     ParquetConfiguration conf = options.getParquetConfiguration();
     this.inputFiles.addAll(getFileReaders(options.getParquetInputFiles(), conf));
     this.inputFilesToJoin.addAll(getFileReaders(options.getParquetInputFilesToJoin(), conf));
@@ -495,8 +495,19 @@ public class ParquetRewriter implements Closeable {
 
     ColumnChunkMetaData chunkNormalized = chunk;
     if (!renamedColumns.isEmpty()) {
-      chunkNormalized =
-          chunk.copy(normalizeFieldsInPath(chunk.getPath()), normalizeNameInType(chunk.getPrimitiveType()));
+      chunkNormalized = ColumnChunkMetaData.get(
+          normalizeFieldsInPath(chunk.getPath()),
+          normalizeNameInType(chunk.getPrimitiveType()),
+          chunk.getCodec(),
+          chunk.getEncodingStats(),
+          chunk.getEncodings(),
+          chunk.getStatistics(),
+          chunk.getFirstDataPageOffset(),
+          chunk.getDictionaryPageOffset(),
+          chunk.getValueCount(),
+          chunk.getTotalSize(),
+          chunk.getTotalUncompressedSize(),
+          chunk.getSizeStatistics());
     }
 
     ColumnDescriptor descriptorOriginal = outSchema.getColumns().get(outColumnIdx);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -495,6 +495,7 @@ public class ParquetRewriter implements Closeable {
 
     ColumnChunkMetaData chunkNormalized = chunk;
     if (!renamedColumns.isEmpty()) {
+      // Keep an eye if this get stale because of ColumnChunkMetaData change
       chunkNormalized = ColumnChunkMetaData.get(
           normalizeFieldsInPath(chunk.getPath()),
           normalizeNameInType(chunk.getPrimitiveType()),

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -171,7 +171,7 @@ public class ParquetRewriter implements Closeable {
         inputFiles.size() + inputFilesToJoin.size(),
         Stream.concat(options.getParquetInputFiles().stream(), options.getParquetInputFilesToJoin().stream())
             .collect(Collectors.toList()),
-        options.getParquetOutputFile());
+        out);
 
     if (options.getMaskColumns() != null) {
       this.maskColumns = new HashMap<>();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -227,7 +227,7 @@ public class ParquetRewriter implements Closeable {
       MaskMode maskMode) {
     this.writer = writer;
     this.outSchema = outSchema;
-    this.outSchemaWithRenamedColumns = null;
+    this.outSchemaWithRenamedColumns = outSchema;
     this.newCodecName = codecName;
     extraMetaData = new HashMap<>(meta.getFileMetaData().getKeyValueMetaData());
     extraMetaData.put(

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.curator.shaded.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.Preconditions;
@@ -627,7 +628,11 @@ public class RewriteOptions {
           pruneColumns,
           newCodecName,
           maskColumns,
-          renameColumns,
+          (renameColumns == null
+              ? ImmutableMap.of()
+              : renameColumns.entrySet().stream()
+                  .collect(Collectors.toMap(
+                      Map.Entry::getKey, x -> x.getValue().trim()))),
           encryptColumns,
           fileEncryptionProperties,
           indexCacheStrategy,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -198,7 +198,7 @@ public class RewriteOptions {
     return maskColumns;
   }
 
-  public Map<String, String> gerRenameColumns() {
+  public Map<String, String> getRenameColumns() {
     return renameColumns;
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -18,11 +18,11 @@
  */
 package org.apache.parquet.hadoop.rewrite;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.ArrayList;
-import java.util.Map;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -589,15 +589,15 @@ public class RewriteOptions {
                 !encryptColumns.contains(pruneColumn), "Cannot prune and encrypt same column");
           }
         }
-        if (renameColumns != null) {
+      }
+
+      if (renameColumns != null && !renameColumns.isEmpty()) {
+        if (encryptColumns != null && !encryptColumns.isEmpty()) {
           for (Map.Entry<String, String> entry : renameColumns.entrySet()) {
             Preconditions.checkArgument(
                 !encryptColumns.contains(entry.getKey()), "Cannot prune and rename same column");
           }
         }
-      }
-
-      if (renameColumns != null && !renameColumns.isEmpty()) {
         for (Map.Entry<String, String> entry : renameColumns.entrySet()) {
           Preconditions.checkArgument(
               entry.getValue() != null && !entry.getValue().trim().isEmpty(),

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -18,12 +18,12 @@
  */
 package org.apache.parquet.hadoop.rewrite;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.stream.Collectors;
-import org.apache.curator.shaded.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.Preconditions;
@@ -629,7 +629,7 @@ public class RewriteOptions {
           newCodecName,
           maskColumns,
           (renameColumns == null
-              ? ImmutableMap.of()
+              ? new HashMap<>()
               : renameColumns.entrySet().stream()
                   .collect(Collectors.toMap(
                       Map.Entry::getKey, x -> x.getValue().trim()))),

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -573,6 +573,28 @@ public class RewriteOptions {
      * @return a RewriterOptions
      */
     public RewriteOptions build() {
+      checkPreconditions();
+      return new RewriteOptions(
+          conf,
+          inputFiles,
+          (inputFilesToJoin != null ? inputFilesToJoin : new ArrayList<>()),
+          outputFile,
+          pruneColumns,
+          newCodecName,
+          maskColumns,
+          (renameColumns == null
+              ? new HashMap<>()
+              : renameColumns.entrySet().stream()
+                  .collect(Collectors.toMap(
+                      Map.Entry::getKey, x -> x.getValue().trim()))),
+          encryptColumns,
+          fileEncryptionProperties,
+          indexCacheStrategy,
+          overwriteInputWithJoinColumns,
+          ignoreJoinFilesMetadata);
+    }
+
+    private void checkPreconditions() {
       Preconditions.checkArgument(inputFiles != null && !inputFiles.isEmpty(), "Input file is required");
       Preconditions.checkArgument(outputFile != null, "Output file is required");
 
@@ -619,25 +641,6 @@ public class RewriteOptions {
             encryptColumns != null && !encryptColumns.isEmpty(),
             "Encrypt columns is required when FileEncryptionProperties is set");
       }
-
-      return new RewriteOptions(
-          conf,
-          inputFiles,
-          (inputFilesToJoin != null ? inputFilesToJoin : new ArrayList<>()),
-          outputFile,
-          pruneColumns,
-          newCodecName,
-          maskColumns,
-          (renameColumns == null
-              ? new HashMap<>()
-              : renameColumns.entrySet().stream()
-                  .collect(Collectors.toMap(
-                      Map.Entry::getKey, x -> x.getValue().trim()))),
-          encryptColumns,
-          fileEncryptionProperties,
-          indexCacheStrategy,
-          overwriteInputWithJoinColumns,
-          ignoreJoinFilesMetadata);
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/RewriteOptions.java
@@ -21,11 +21,11 @@ package org.apache.parquet.hadoop.rewrite;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.curator.shaded.com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.Preconditions;
@@ -617,7 +617,7 @@ public class RewriteOptions {
 
       if (renameColumns != null) {
         Set<String> nullifiedColumns = maskColumns == null
-            ? ImmutableSet.of()
+            ? new HashSet<>()
             : maskColumns.entrySet().stream()
                 .filter(x -> x.getValue() == MaskMode.NULLIFY)
                 .map(Map.Entry::getKey)

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.hadoop.rewrite;
 
+import static java.util.Collections.emptyMap;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
@@ -181,10 +182,10 @@ public class ParquetRewriterTest {
         null);
 
     // Verify the data are not changed for the columns not pruned
-    validateColumnData(new HashSet<>(pruneColumns), Collections.emptySet(), null, false);
+    validateColumnData(new HashSet<>(pruneColumns), Collections.emptySet(), null, false, emptyMap());
 
     // Verify the page index
-    validatePageIndex(new HashSet<>(), false);
+    validatePageIndex(new HashSet<>(), false, emptyMap());
 
     // Verify original.created.by is preserved
     validateCreatedBy();
@@ -199,7 +200,7 @@ public class ParquetRewriterTest {
 
   @Test
   public void testPruneSingleColumnTranslateCodecSingleFile() throws Exception {
-    ensureContainsGzipFile();
+    addGzipInputFile();
     List<Path> inputPaths = new ArrayList<Path>() {
       {
         add(new Path(inputFiles.get(0).getFileName()));
@@ -210,8 +211,8 @@ public class ParquetRewriterTest {
 
   @Test
   public void testPruneSingleColumnTranslateCodecTwoFiles() throws Exception {
-    ensureContainsGzipFile();
-    ensureContainsUncompressedFile();
+    addGzipInputFile();
+    addUncompressedInputFile();
     List<Path> inputPaths = new ArrayList<Path>() {
       {
         add(new Path(inputFiles.get(0).getFileName()));
@@ -252,10 +253,10 @@ public class ParquetRewriterTest {
         null);
 
     // Verify the data are not changed for the columns not pruned
-    validateColumnData(new HashSet<>(pruneColumns), maskColumns.keySet(), null, false);
+    validateColumnData(new HashSet<>(pruneColumns), maskColumns.keySet(), null, false, emptyMap());
 
     // Verify the page index
-    validatePageIndex(ImmutableSet.of("Links.Forward"), false);
+    validatePageIndex(ImmutableSet.of("Links.Forward"), false, emptyMap());
 
     // Verify original.created.by is preserved
     validateCreatedBy();
@@ -264,7 +265,7 @@ public class ParquetRewriterTest {
 
   @Test
   public void testPruneNullifyTranslateCodecSingleFile() throws Exception {
-    ensureContainsGzipFile();
+    addGzipInputFile();
 
     List<Path> inputPaths = new ArrayList<Path>() {
       {
@@ -276,8 +277,8 @@ public class ParquetRewriterTest {
 
   @Test
   public void testPruneNullifyTranslateCodecTwoFiles() throws Exception {
-    ensureContainsGzipFile();
-    ensureContainsUncompressedFile();
+    addGzipInputFile();
+    addUncompressedInputFile();
 
     List<Path> inputPaths = new ArrayList<Path>() {
       {
@@ -327,7 +328,8 @@ public class ParquetRewriterTest {
         fileDecryptionProperties);
 
     // Verify the data are not changed for the columns not pruned
-    validateColumnData(new HashSet<>(pruneColumns), Collections.emptySet(), fileDecryptionProperties, false);
+    validateColumnData(
+        new HashSet<>(pruneColumns), Collections.emptySet(), fileDecryptionProperties, false, emptyMap());
 
     // Verify column encryption
     ParquetMetadata metaData = getFileMetaData(outputFile, fileDecryptionProperties);
@@ -349,7 +351,7 @@ public class ParquetRewriterTest {
 
   @Test
   public void testPruneEncryptTranslateCodecSingleFile() throws Exception {
-    ensureContainsGzipFile();
+    addGzipInputFile();
 
     List<Path> inputPaths = new ArrayList<Path>() {
       {
@@ -361,8 +363,8 @@ public class ParquetRewriterTest {
 
   @Test
   public void testPruneEncryptTranslateCodecTwoFiles() throws Exception {
-    ensureContainsGzipFile();
-    ensureContainsUncompressedFile();
+    addGzipInputFile();
+    addUncompressedInputFile();
 
     List<Path> inputPaths = new ArrayList<Path>() {
       {
@@ -488,10 +490,10 @@ public class ParquetRewriterTest {
 
     // Verify the data are not changed for non-encrypted and non-masked columns.
     // Also make sure the masked column is nullified.
-    validateColumnData(Collections.emptySet(), maskColumns.keySet(), fileDecryptionProperties, false);
+    validateColumnData(Collections.emptySet(), maskColumns.keySet(), fileDecryptionProperties, false, emptyMap());
 
     // Verify the page index
-    validatePageIndex(ImmutableSet.of("DocId", "Links.Forward"), false);
+    validatePageIndex(ImmutableSet.of("DocId", "Links.Forward"), false, emptyMap());
 
     // Verify the column is encrypted
     ParquetMetadata metaData = getFileMetaData(outputFile, fileDecryptionProperties);
@@ -511,7 +513,7 @@ public class ParquetRewriterTest {
 
   @Test
   public void testNullifyEncryptSingleFile() throws Exception {
-    ensureContainsGzipFile();
+    addGzipInputFile();
 
     List<Path> inputPaths = new ArrayList<Path>() {
       {
@@ -523,8 +525,8 @@ public class ParquetRewriterTest {
 
   @Test
   public void testNullifyEncryptTwoFiles() throws Exception {
-    ensureContainsGzipFile();
-    ensureContainsUncompressedFile();
+    addGzipInputFile();
+    addUncompressedInputFile();
 
     List<Path> inputPaths = new ArrayList<Path>() {
       {
@@ -537,8 +539,8 @@ public class ParquetRewriterTest {
 
   @Test
   public void testMergeTwoFilesOnly() throws Exception {
-    ensureContainsGzipFile();
-    ensureContainsUncompressedFile();
+    addGzipInputFile();
+    addUncompressedInputFile();
 
     // Only merge two files but do not change anything.
     List<Path> inputPaths = new ArrayList<>();
@@ -571,10 +573,59 @@ public class ParquetRewriterTest {
         null);
 
     // Verify the merged data are not changed
-    validateColumnData(Collections.emptySet(), Collections.emptySet(), null, false);
+    validateColumnData(Collections.emptySet(), Collections.emptySet(), null, false, emptyMap());
 
     // Verify the page index
-    validatePageIndex(new HashSet<>(), false);
+    validatePageIndex(new HashSet<>(), false, emptyMap());
+
+    // Verify original.created.by is preserved
+    validateCreatedBy();
+    validateRowGroupRowCount();
+  }
+
+  @Test
+  public void testMergeTwoFilesOnlyRenameColumn() throws Exception {
+    addGzipInputFile();
+    addUncompressedInputFile();
+
+    // Only merge two files but do not change anything.
+    List<Path> inputPaths = new ArrayList<>();
+    for (EncryptionTestFile inputFile : inputFiles) {
+      inputPaths.add(new Path(inputFile.getFileName()));
+    }
+    Map<String, String> renameColumns = ImmutableMap.of("Name", "NameRenamed");
+    RewriteOptions.Builder builder = createBuilder(inputPaths);
+    RewriteOptions options = builder.indexCacheStrategy(indexCacheStrategy)
+        .renameColumns(ImmutableMap.of("Name", "NameRenamed"))
+        .build();
+
+    rewriter = new ParquetRewriter(options);
+    rewriter.processBlocks();
+    rewriter.close();
+
+    // Verify the schema is not changed
+    ParquetMetadata pmd =
+        ParquetFileReader.readFooter(conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER);
+    MessageType schema = pmd.getFileMetaData().getSchema();
+    MessageType expectSchema = createSchemaWithRenamed();
+    assertEquals(expectSchema, schema);
+
+    // Verify codec has not been translated
+    verifyCodec(
+        outputFile,
+        new HashSet<CompressionCodecName>() {
+          {
+            add(CompressionCodecName.GZIP);
+            add(CompressionCodecName.UNCOMPRESSED);
+          }
+        },
+        null);
+
+    // Verify the merged data are not changed
+    validateColumnData(Collections.emptySet(), Collections.emptySet(), null, false, renameColumns);
+
+    // Verify the page index
+    validatePageIndex(new HashSet<>(), false, renameColumns);
 
     // Verify original.created.by is preserved
     validateCreatedBy();
@@ -648,7 +699,7 @@ public class ParquetRewriterTest {
 
   @Test
   public void testRewriteFileWithMultipleBlocks() throws Exception {
-    ensureContainsGzipFile();
+    addGzipInputFile();
 
     List<Path> inputPaths = new ArrayList<Path>() {
       {
@@ -823,12 +874,13 @@ public class ParquetRewriterTest {
         new HashSet<>(pruneColumns),
         maskColumns.keySet(),
         fileDecryptionProperties,
-        joinColumnsOverwrite); // Verify data
+        joinColumnsOverwrite,
+        emptyMap()); // Verify data
     validateSchemaWithGenderColumnPruned(true); // Verify schema
     validateCreatedBy(); // Verify original.created.by
     assertEquals(inputBloomFilters.keySet(), rBloomFilters); // Verify bloom filters
     verifyCodec(outputFile, ImmutableSet.of(CompressionCodecName.ZSTD), fileDecryptionProperties); // Verify codec
-    validatePageIndex(ImmutableSet.of(encryptColumn), joinColumnsOverwrite);
+    validatePageIndex(ImmutableSet.of(encryptColumn), joinColumnsOverwrite, emptyMap());
   }
 
   private void testOneInputFileManyInputFilesToJoinSetup() throws IOException {
@@ -884,11 +936,27 @@ public class ParquetRewriterTest {
             new PrimitiveType(REPEATED, BINARY, "Forward")));
   }
 
+  private MessageType createSchemaWithRenamed() {
+    return new MessageType(
+        "schema",
+        new PrimitiveType(OPTIONAL, INT64, "DocId"),
+        new PrimitiveType(REQUIRED, BINARY, "NameRenamed"),
+        new PrimitiveType(OPTIONAL, BINARY, "Gender"),
+        new PrimitiveType(REPEATED, FLOAT, "FloatFraction"),
+        new PrimitiveType(OPTIONAL, DOUBLE, "DoubleFraction"),
+        new GroupType(
+            OPTIONAL,
+            "Links",
+            new PrimitiveType(REPEATED, BINARY, "Backward"),
+            new PrimitiveType(REPEATED, BINARY, "Forward")));
+  }
+
   private void validateColumnData(
       Set<String> prunePaths,
       Set<String> nullifiedPaths,
       FileDecryptionProperties fileDecryptionProperties,
-      Boolean joinColumnsOverwrite)
+      Boolean joinColumnsOverwrite,
+      Map<String, String> renameColumns)
       throws IOException {
     ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(), new Path(outputFile))
         .withConf(conf)
@@ -901,7 +969,7 @@ public class ParquetRewriterTest {
     List<SimpleGroup> filesJoined = inputFilesToJoin.stream()
         .flatMap(x -> Arrays.stream(x.getFileContent()))
         .collect(Collectors.toList());
-    BiFunction<String, Integer, Group> groups = (name, rowIdx) -> {
+    BiFunction<String, Integer, Group> groupsExpected = (name, rowIdx) -> {
       if (!filesMain.get(0).getType().containsField(name)
           || joinColumnsOverwrite
               && !filesJoined.isEmpty()
@@ -915,50 +983,53 @@ public class ParquetRewriterTest {
     int totalRows =
         inputFiles.stream().mapToInt(x -> x.getFileContent().length).sum();
     for (int i = 0; i < totalRows; i++) {
-      Group group = reader.read();
-      assertNotNull(group);
+      Group groupActual = reader.read();
+      assertNotNull(groupActual);
 
       if (!prunePaths.contains("DocId")) {
         if (nullifiedPaths.contains("DocId")) {
-          assertThrows(RuntimeException.class, () -> group.getLong("DocId", 0));
+          assertThrows(RuntimeException.class, () -> groupActual.getLong("DocId", 0));
         } else {
           assertEquals(
-              group.getLong("DocId", 0), groups.apply("DocId", i).getLong("DocId", 0));
+              groupActual.getLong("DocId", 0),
+              groupsExpected.apply("DocId", i).getLong("DocId", 0));
         }
       }
 
       if (!prunePaths.contains("Name") && !nullifiedPaths.contains("Name")) {
+        String colName = renameColumns.getOrDefault("Name", "Name");
         assertArrayEquals(
-            group.getBinary("Name", 0).getBytes(),
-            groups.apply("Name", i).getBinary("Name", 0).getBytes());
+            groupActual.getBinary(colName, 0).getBytes(),
+            groupsExpected.apply("Name", i).getBinary("Name", 0).getBytes());
       }
 
       if (!prunePaths.contains("Gender") && !nullifiedPaths.contains("Gender")) {
         assertArrayEquals(
-            group.getBinary("Gender", 0).getBytes(),
-            groups.apply("Gender", i).getBinary("Gender", 0).getBytes());
+            groupActual.getBinary("Gender", 0).getBytes(),
+            groupsExpected.apply("Gender", i).getBinary("Gender", 0).getBytes());
       }
 
       if (!prunePaths.contains("FloatFraction") && !nullifiedPaths.contains("FloatFraction")) {
         assertEquals(
-            group.getFloat("FloatFraction", 0),
-            groups.apply("FloatFraction", i).getFloat("FloatFraction", 0),
+            groupActual.getFloat("FloatFraction", 0),
+            groupsExpected.apply("FloatFraction", i).getFloat("FloatFraction", 0),
             0);
       }
 
       if (!prunePaths.contains("DoubleFraction") && !nullifiedPaths.contains("DoubleFraction")) {
         assertEquals(
-            group.getDouble("DoubleFraction", 0),
-            groups.apply("DoubleFraction", i).getDouble("DoubleFraction", 0),
+            groupActual.getDouble("DoubleFraction", 0),
+            groupsExpected.apply("DoubleFraction", i).getDouble("DoubleFraction", 0),
             0);
       }
 
-      Group subGroup = group.getGroup("Links", 0);
+      Group subGroup = groupActual.getGroup("Links", 0);
 
       if (!prunePaths.contains("Links.Backward") && !nullifiedPaths.contains("Links.Backward")) {
         assertArrayEquals(
             subGroup.getBinary("Backward", 0).getBytes(),
-            groups.apply("Links", i)
+            groupsExpected
+                .apply("Links", i)
                 .getGroup("Links", 0)
                 .getBinary("Backward", 0)
                 .getBytes());
@@ -970,7 +1041,8 @@ public class ParquetRewriterTest {
         } else {
           assertArrayEquals(
               subGroup.getBinary("Forward", 0).getBytes(),
-              groups.apply("Links", i)
+              groupsExpected
+                  .apply("Links", i)
                   .getGroup("Links", 0)
                   .getBinary("Forward", 0)
                   .getBytes());
@@ -1014,13 +1086,22 @@ public class ParquetRewriterTest {
     R apply(T t) throws IOException;
   }
 
+  private ColumnPath renameFieldsInPath(ColumnPath path, Map<String, String> renameColumns) {
+    String[] pathArray = path.toArray();
+    if (renameColumns != null) {
+      pathArray[0] = renameColumns.getOrDefault(pathArray[0], pathArray[0]);
+    }
+    return ColumnPath.get(pathArray);
+  }
+
   /**
    * Verify the page index is correct.
    *
    * @param exclude the columns to exclude from comparison, for example because they were nullified.
    * @param joinColumnsOverwrite whether a join columns overwrote existing overlapping columns.
    */
-  private void validatePageIndex(Set<String> exclude, boolean joinColumnsOverwrite) throws Exception {
+  private void validatePageIndex(Set<String> exclude, boolean joinColumnsOverwrite, Map<String, String> renameColumns)
+      throws Exception {
     class BlockMeta {
       final TransParquetFileReader reader;
       final BlockMetaData blockMeta;
@@ -1058,6 +1139,8 @@ public class ParquetRewriterTest {
     List<BlockMeta> inBlocksJoined = blockMetaExtractor.apply(
         inputFilesToJoin.stream().map(EncryptionTestFile::getFileName).collect(Collectors.toList()));
     List<BlockMeta> outBlocks = blockMetaExtractor.apply(ImmutableList.of(outputFile));
+    Map<String, String> renameColumnsInverted =
+        renameColumns.entrySet().stream().collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
     for (int blockIdx = 0; blockIdx < outBlocks.size(); blockIdx++) {
       BlockMetaData outBlockMeta = outBlocks.get(blockIdx).blockMeta;
       TransParquetFileReader outReader = outBlocks.get(blockIdx).reader;
@@ -1066,17 +1149,18 @@ public class ParquetRewriterTest {
         TransParquetFileReader inReader;
         BlockMetaData inBlockMeta;
         ColumnChunkMetaData inChunk;
-        if (!inBlocksMain.get(blockIdx).colPathToMeta.containsKey(outChunk.getPath())
+        ColumnPath colPath = renameFieldsInPath(outChunk.getPath(), renameColumnsInverted);
+        if (!inBlocksMain.get(blockIdx).colPathToMeta.containsKey(colPath)
             || joinColumnsOverwrite
                 && !inBlocksJoined.isEmpty()
-                && inBlocksJoined.get(blockIdx).colPathToMeta.containsKey(outChunk.getPath())) {
+                && inBlocksJoined.get(blockIdx).colPathToMeta.containsKey(colPath)) {
           inReader = inBlocksJoined.get(blockIdx).reader;
           inBlockMeta = inBlocksJoined.get(blockIdx).blockMeta;
-          inChunk = inBlocksJoined.get(blockIdx).colPathToMeta.get(outChunk.getPath());
+          inChunk = inBlocksJoined.get(blockIdx).colPathToMeta.get(colPath);
         } else {
           inReader = inBlocksMain.get(blockIdx).reader;
           inBlockMeta = inBlocksMain.get(blockIdx).blockMeta;
-          inChunk = inBlocksMain.get(blockIdx).colPathToMeta.get(outChunk.getPath());
+          inChunk = inBlocksMain.get(blockIdx).colPathToMeta.get(colPath);
         }
 
         ColumnIndex inColumnIndex = inReader.readColumnIndex(inChunk);
@@ -1284,13 +1368,13 @@ public class ParquetRewriterTest {
     assertEquals(expectSchema, actualSchema);
   }
 
-  private void ensureContainsGzipFile() {
+  private void addGzipInputFile() {
     if (!inputFiles.contains(gzipEncryptionTestFileWithoutBloomFilterColumn)) {
       inputFiles.add(this.gzipEncryptionTestFileWithoutBloomFilterColumn);
     }
   }
 
-  private void ensureContainsUncompressedFile() {
+  private void addUncompressedInputFile() {
     if (!inputFiles.contains(uncompressedEncryptionTestFileWithoutBloomFilterColumn)) {
       inputFiles.add(uncompressedEncryptionTestFileWithoutBloomFilterColumn);
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -1086,7 +1086,7 @@ public class ParquetRewriterTest {
     R apply(T t) throws IOException;
   }
 
-  private ColumnPath renameFieldsInPath(ColumnPath path, Map<String, String> renameColumns) {
+  private ColumnPath normalizeFieldsInPath(ColumnPath path, Map<String, String> renameColumns) {
     String[] pathArray = path.toArray();
     if (renameColumns != null) {
       pathArray[0] = renameColumns.getOrDefault(pathArray[0], pathArray[0]);
@@ -1149,7 +1149,7 @@ public class ParquetRewriterTest {
         TransParquetFileReader inReader;
         BlockMetaData inBlockMeta;
         ColumnChunkMetaData inChunk;
-        ColumnPath colPath = renameFieldsInPath(outChunk.getPath(), renameColumnsInverted);
+        ColumnPath colPath = normalizeFieldsInPath(outChunk.getPath(), renameColumnsInverted);
         if (!inBlocksMain.get(blockIdx).colPathToMeta.containsKey(colPath)
             || joinColumnsOverwrite
                 && !inBlocksJoined.isEmpty()


### PR DESCRIPTION

### Rationale for this change
This feature extension is based on a real use-case when a input parquet dataset need to transformed to a new one using a set of basic schema transformations.  `ParquetRewriter` already supports some of transformations: pruning, masking, encrypting, changing a codec. This PR add one of missing transformations - renaming.


### What changes are included in this PR?
- Add a new option `renameColumns` to `RewriteOptions` class which is options builder for `ParquetRewriter`
- Add support of to `renameColumns` to `ParquetRewriter`

### Are these changes tested?
Yes.

### Are there any user-facing changes?
Yes.


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
