### PR TITLE
GH-3029: Fix EncryptionPropertiesHelper not to use java.nio.file.Path

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/EncryptionPropertiesHelper.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/EncryptionPropertiesHelper.java
@@ -18,27 +18,25 @@
  */
 package org.apache.parquet.hadoop;
 
-import java.net.URI;
-import java.nio.file.Path;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.conf.ParquetConfiguration;
 import org.apache.parquet.crypto.EncryptionPropertiesFactory;
 import org.apache.parquet.crypto.FileEncryptionProperties;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.hadoop.util.ConfigurationUtil;
+import org.apache.parquet.io.OutputFile;
 
 final class EncryptionPropertiesHelper {
   static FileEncryptionProperties createEncryptionProperties(
-      ParquetConfiguration fileParquetConfig, Path tempFilePath, WriteSupport.WriteContext fileWriteContext) {
+      ParquetConfiguration fileParquetConfig, OutputFile file, WriteSupport.WriteContext fileWriteContext) {
     EncryptionPropertiesFactory cryptoFactory = EncryptionPropertiesFactory.loadFactory(fileParquetConfig);
     if (null == cryptoFactory) {
       return null;
     }
 
     Configuration hadoopConf = ConfigurationUtil.createHadoopConfiguration(fileParquetConfig);
-    URI path = tempFilePath == null ? null : tempFilePath.toUri();
     return cryptoFactory.getFileEncryptionProperties(
-        hadoopConf, path == null ? null : new org.apache.hadoop.fs.Path(path), fileWriteContext);
+        hadoopConf, file == null ? null : new org.apache.hadoop.fs.Path(file.getPath()), fileWriteContext);
   }
 
   static FileEncryptionProperties createEncryptionProperties(

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -20,7 +20,6 @@ package org.apache.parquet.hadoop;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
@@ -387,9 +386,7 @@ public class ParquetWriter<T> implements Closeable {
     // encryptionProperties could be built from the implementation of EncryptionPropertiesFactory when it is
     // attached.
     if (encryptionProperties == null) {
-      String path = file == null ? null : file.getPath();
-      encryptionProperties = EncryptionPropertiesHelper.createEncryptionProperties(
-          conf, path == null ? null : Paths.get(path), writeContext);
+      encryptionProperties = EncryptionPropertiesHelper.createEncryptionProperties(conf, file, writeContext);
     }
 
     ParquetFileWriter fileWriter = new ParquetFileWriter(


### PR DESCRIPTION
### Rationale for this change

EncryptionPropertiesHelper has been changed to use java.nio.file.Path but the `file:` URI will fail on Windows.

See #3029 for detail.

### What changes are included in this PR?

Change EncryptionPropertiesHelper not to use java.nio.file.Path.

### Are these changes tested?

Pass CI.

### Are there any user-facing changes?

No

Closes #3029
