### PR TITLE
GH-3059: Add configuration to disable size statistics

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnValueCollector.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnValueCollector.java
@@ -37,6 +37,7 @@ class ColumnValueCollector {
 
   private final ColumnDescriptor path;
   private final boolean statisticsEnabled;
+  private final boolean sizeStatisticsEnabled;
   private BloomFilterWriter bloomFilterWriter;
   private BloomFilter bloomFilter;
   private Statistics<?> statistics;
@@ -45,6 +46,7 @@ class ColumnValueCollector {
   ColumnValueCollector(ColumnDescriptor path, BloomFilterWriter bloomFilterWriter, ParquetProperties props) {
     this.path = path;
     this.statisticsEnabled = props.getStatisticsEnabled(path);
+    this.sizeStatisticsEnabled = props.getSizeStatisticsEnabled(path);
     resetPageStatistics();
     initBloomFilter(bloomFilterWriter, props);
   }
@@ -53,8 +55,11 @@ class ColumnValueCollector {
     this.statistics = statisticsEnabled
         ? Statistics.createStats(path.getPrimitiveType())
         : Statistics.noopStats(path.getPrimitiveType());
-    this.sizeStatisticsBuilder = SizeStatistics.newBuilder(
-        path.getPrimitiveType(), path.getMaxRepetitionLevel(), path.getMaxDefinitionLevel());
+    this.sizeStatisticsBuilder = sizeStatisticsEnabled
+        ? SizeStatistics.newBuilder(
+            path.getPrimitiveType(), path.getMaxRepetitionLevel(), path.getMaxDefinitionLevel())
+        : SizeStatistics.noopBuilder(
+            path.getPrimitiveType(), path.getMaxRepetitionLevel(), path.getMaxDefinitionLevel());
   }
 
   void writeNull(int repetitionLevel, int definitionLevel) {

--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/SizeStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/SizeStatistics.java
@@ -52,7 +52,7 @@ public class SizeStatistics {
    * Builder to create a SizeStatistics.
    */
   public static class Builder {
-    private final PrimitiveType type;
+    protected final PrimitiveType type;
     private long unencodedByteArrayDataBytes;
     private final long[] repetitionLevelHistogram;
     private final long[] definitionLevelHistogram;
@@ -256,5 +256,39 @@ public class SizeStatistics {
    */
   public boolean isValid() {
     return valid;
+  }
+
+  /**
+   * Creates a no-op size statistics builder that collects no data.
+   * Used when size statistics collection is disabled.
+   */
+  private static class NoopBuilder extends Builder {
+    private NoopBuilder(PrimitiveType type, int maxRepetitionLevel, int maxDefinitionLevel) {
+      super(type, maxRepetitionLevel, maxDefinitionLevel);
+    }
+
+    @Override
+    public void add(int repetitionLevel, int definitionLevel) {
+      // Do nothing
+    }
+
+    @Override
+    public void add(int repetitionLevel, int definitionLevel, Binary value) {
+      // Do nothing
+    }
+
+    @Override
+    public SizeStatistics build() {
+      SizeStatistics stats = new SizeStatistics(type, 0L, Collections.emptyList(), Collections.emptyList());
+      stats.valid = false; // Mark as invalid since this is a noop builder
+      return stats;
+    }
+  }
+
+  /**
+   * Creates a builder that doesn't collect any statistics.
+   */
+  public static Builder noopBuilder(PrimitiveType type, int maxRepetitionLevel, int maxDefinitionLevel) {
+    return new NoopBuilder(type, maxRepetitionLevel, maxDefinitionLevel);
   }
 }

--- a/parquet-hadoop/README.md
+++ b/parquet-hadoop/README.md
@@ -525,3 +525,20 @@ conf.set("parquet.column.statistics.enabled", true);
 conf.set("parquet.column.statistics.enabled#column.path", false);
 // The final configuration will be: Enable statistics for all columns except 'column.path'
 ```
+
+---
+
+**Property:** `parquet.size.statistics.enabled`
+**Description:** Whether to enable size statistics collection.
+If `true`, size statistics will be collected for all columns unless explicitly disabled for specific columns.
+If `false`, size statistics will be disabled for all columns regardless of column-specific settings.
+It is possible to enable or disable size statistics for specific columns by appending `#` followed by the column path.
+**Default value:** `true`
+**Example:**
+```java
+// Enable size statistics for all columns
+conf.set("parquet.size.statistics.enabled", true);
+// Disable size statistics for 'column.path'
+conf.set("parquet.size.statistics.enabled#column.path", false);
+// The final configuration will be: Enable size statistics for all columns except 'column.path'
+```

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -157,6 +157,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String PAGE_ROW_COUNT_LIMIT = "parquet.page.row.count.limit";
   public static final String PAGE_WRITE_CHECKSUM_ENABLED = "parquet.page.write-checksum.enabled";
   public static final String STATISTICS_ENABLED = "parquet.column.statistics.enabled";
+  public static final String SIZE_STATISTICS_ENABLED = "parquet.size.statistics.enabled";
 
   public static JobSummaryLevel getJobSummaryLevel(Configuration conf) {
     String level = conf.get(JOB_SUMMARY_LEVEL);
@@ -407,6 +408,22 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
       return Boolean.parseBoolean(columnSpecific);
     }
     return conf.getBoolean(STATISTICS_ENABLED, ParquetProperties.DEFAULT_STATISTICS_ENABLED);
+  }
+
+  public static void setSizeStatisticsEnabled(Configuration conf, boolean enabled) {
+    conf.setBoolean(SIZE_STATISTICS_ENABLED, enabled);
+  }
+
+  public static void setSizeStatisticsEnabled(Configuration conf, String path, boolean enabled) {
+    conf.setBoolean(SIZE_STATISTICS_ENABLED + "#" + path, enabled);
+  }
+
+  public static boolean getSizeStatisticsEnabled(Configuration conf) {
+    return conf.getBoolean(SIZE_STATISTICS_ENABLED, ParquetProperties.DEFAULT_SIZE_STATISTICS_ENABLED);
+  }
+
+  public static boolean getSizeStatisticsEnabled(Configuration conf, String path) {
+    return conf.getBoolean(SIZE_STATISTICS_ENABLED + "#" + path, getSizeStatisticsEnabled(conf));
   }
 
   private WriteSupport<T> writeSupport;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -919,6 +919,30 @@ public class ParquetWriter<T> implements Closeable {
     }
 
     /**
+     * Sets the size statistics enabled/disabled for the specified column. All column size statistics are enabled by default.
+     *
+     * @param columnPath the path of the column (dot-string)
+     * @param enabled    whether to collect size statistics for the column
+     * @return this builder for method chaining
+     */
+    public SELF withSizeStatisticsEnabled(String columnPath, boolean enabled) {
+      encodingPropsBuilder.withSizeStatisticsEnabled(columnPath, enabled);
+      return self();
+    }
+
+    /**
+     * Sets whether size statistics are enabled globally. When disabled, size statistics will not be collected
+     * for any column unless explicitly enabled for specific columns.
+     *
+     * @param enabled whether to collect size statistics globally
+     * @return this builder for method chaining
+     */
+    public SELF withSizeStatisticsEnabled(boolean enabled) {
+      encodingPropsBuilder.withSizeStatisticsEnabled(enabled);
+      return self();
+    }
+
+    /**
      * Build a {@link ParquetWriter} with the accumulated configuration.
      *
      * @return a configured {@code ParquetWriter} instance.


### PR DESCRIPTION
### Rationale for this change

Now size statistics are enabled globally. We need to better control the behavior when it is not necessary.

### What changes are included in this PR?

Add a new flag `parquet.size.statistics.enabled` to control whether to enable size statistics globally. It also supports a per-column control.

### Are these changes tested?

Yes, added a test case in TestParquetWriter.java.

### Are there any user-facing changes?

Yes, a new flag `parquet.size.statistics.enabled` has been added.

Closes #3059
