### PR TITLE
MINOR: Optimize bit-packing decoder performance by increasing unpackCount in Packer16

### DIFF
--- a/parquet-plugins/parquet-encoding-vector/src/main/java/org/apache/parquet/column/values/bitpacking/ByteBitPacking512VectorLE.java
+++ b/parquet-plugins/parquet-encoding-vector/src/main/java/org/apache/parquet/column/values/bitpacking/ByteBitPacking512VectorLE.java
@@ -1652,7 +1652,7 @@ public abstract class ByteBitPacking512VectorLE {
     private static final VectorSpecies<Integer> I512 = IntVector.SPECIES_512;
     private static final VectorMask<Byte> inp_mask = VectorMask.fromLong(B512, 0xffffffffffffffffL);
 
-    private int unpackCount = 16;
+    private int unpackCount = 32;
 
     public int getUnpackCount() {
       return unpackCount;


### PR DESCRIPTION
**Rationale for this change**
The current Packer16 decoder implementation using JDK Vector API has performance limitations with unpackCount = 16 for bit-packing decoding.

**What changes are included in this PR?**
Modified ByteBitPacking512VectorLE.java to increase the processing batch size:
// Before
private static final int UNPACK_COUNT = 16;
// After
private static final int UNPACK_COUNT = **32**;

**Testing Details**
Testing environment:
- JDK: OpenJDK 17.0.2 
- Test framework: JMH Benchmark
- Platform: x86_64

**Performance results:**
- Baseline throughput: 29.587 ops/s  
- Optimized throughput: **54.524** ops/s
- Performance gain: 84.3% improvement


