### PR TITLE
MINOR: Add shading for JDK22 specific classes

### DIFF
--- a/parquet-jackson/pom.xml
+++ b/parquet-jackson/pom.xml
@@ -117,6 +117,10 @@
                   <pattern>META-INF.versions.21.${jackson.package}</pattern>
                   <shadedPattern>META-INF.versions.21.${shade.prefix}.${jackson.package}</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>META-INF.versions.22.${jackson.package}</pattern>
+                  <shadedPattern>META-INF.versions.22.${shade.prefix}.${jackson.package}</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>


### PR DESCRIPTION
### Rationale for this change

JDK 22 specific classes were added in Jackson, but we forgot to shade them explicitly as pointed out in:

https://github.com/apache/parquet-java/blob/8fa70320a9cdeeba12a4d17ef248cd4e535f0907/pom.xml#L70

### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
