### PR TITLE
MINOR: Revert `buildnumber-maven-plugin` to 3.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -453,7 +453,8 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>3.2.1</version>
+        <!-- Warning! 3.2.1 caused issues during verification, 3.2.0 is known to work correctly. -->
+        <version>3.2.0</version>
         <executions>
           <execution>
             <phase>validate</phase>


### PR DESCRIPTION
### Rationale for this change

During verification of the 1.15.0 release, @gszadovszky noticed that this specific version caused issues, therefore it is better to revert it for now.

### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
