### PR TITLE
GH-3083: Make DELTA_LENGTH_BYTE_ARRAY default encoding for binary

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -67,6 +67,7 @@ public class ParquetProperties {
   public static final int DEFAULT_BLOOM_FILTER_CANDIDATES_NUMBER = 5;
   public static final boolean DEFAULT_STATISTICS_ENABLED = true;
   public static final boolean DEFAULT_SIZE_STATISTICS_ENABLED = true;
+  public static final boolean DEFAULT_DELTA_LENGTH_BYTE_ARRAY_FOR_BINARY = true;
 
   public static final boolean DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED = true;
 
@@ -133,6 +134,7 @@ public class ParquetProperties {
   private final int pageRowCountLimit;
   private final boolean pageWriteChecksumEnabled;
   private final ColumnProperty<ByteStreamSplitMode> byteStreamSplitEnabled;
+  private final boolean deltaLengthByteArrayForBinary;
   private final Map<String, String> extraMetaData;
   private final ColumnProperty<Boolean> statistics;
   private final ColumnProperty<Boolean> sizeStatistics;
@@ -167,6 +169,7 @@ public class ParquetProperties {
     this.pageRowCountLimit = builder.pageRowCountLimit;
     this.pageWriteChecksumEnabled = builder.pageWriteChecksumEnabled;
     this.byteStreamSplitEnabled = builder.byteStreamSplitEnabled.build();
+    this.deltaLengthByteArrayForBinary = builder.deltaLengthByteArrayForBinary;
     this.extraMetaData = builder.extraMetaData;
     this.statistics = builder.statistics.build();
     this.sizeStatistics = builder.sizeStatistics.build();
@@ -353,6 +356,10 @@ public class ParquetProperties {
     return numBloomFilterCandidates.getValue(column);
   }
 
+  public boolean isDeltaLengthByteArrayForBinaryEnabled() {
+    return deltaLengthByteArrayForBinary;
+  }
+
   public Map<String, String> getExtraMetaData() {
     return extraMetaData;
   }
@@ -455,6 +462,7 @@ public class ParquetProperties {
     private int pageRowCountLimit = DEFAULT_PAGE_ROW_COUNT_LIMIT;
     private boolean pageWriteChecksumEnabled = DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED;
     private final ColumnProperty.Builder<ByteStreamSplitMode> byteStreamSplitEnabled;
+    private boolean deltaLengthByteArrayForBinary = DEFAULT_DELTA_LENGTH_BYTE_ARRAY_FOR_BINARY;
     private Map<String, String> extraMetaData = new HashMap<>();
     private final ColumnProperty.Builder<Boolean> statistics;
     private final ColumnProperty.Builder<Boolean> sizeStatistics;
@@ -504,6 +512,7 @@ public class ParquetProperties {
       this.numBloomFilterCandidates = ColumnProperty.builder(toCopy.numBloomFilterCandidates);
       this.maxBloomFilterBytes = toCopy.maxBloomFilterBytes;
       this.byteStreamSplitEnabled = ColumnProperty.builder(toCopy.byteStreamSplitEnabled);
+      this.deltaLengthByteArrayForBinary = toCopy.deltaLengthByteArrayForBinary;
       this.extraMetaData = toCopy.extraMetaData;
       this.statistics = ColumnProperty.builder(toCopy.statistics);
       this.statisticsEnabled = toCopy.statisticsEnabled;
@@ -582,6 +591,18 @@ public class ParquetProperties {
     public Builder withExtendedByteStreamSplitEncoding(boolean enable) {
       this.byteStreamSplitEnabled.withDefaultValue(
           enable ? ByteStreamSplitMode.EXTENDED : ByteStreamSplitMode.NONE);
+      return this;
+    }
+
+    /**
+     * Enable or disable DELTA_LENGTH_BYTE_ARRAY encoding as the fallback for BINARY columns in
+     * PARQUET_1_0 writer version. When disabled, PLAIN encoding is used as the fallback instead.
+     *
+     * @param enable whether DELTA_LENGTH_BYTE_ARRAY encoding should be used for binary
+     * @return this builder for method chaining.
+     */
+    public Builder withDeltaLengthByteArrayForBinary(boolean enable) {
+      this.deltaLengthByteArrayForBinary = enable;
       return this;
     }
 

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV1ValuesWriterFactory.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/factory/DefaultV1ValuesWriterFactory.java
@@ -25,6 +25,7 @@ import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesWriter;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
 import org.apache.parquet.column.values.plain.BooleanPlainValuesWriter;
 import org.apache.parquet.column.values.plain.FixedLenByteArrayPlainValuesWriter;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
@@ -93,10 +94,18 @@ public class DefaultV1ValuesWriterFactory implements ValuesWriterFactory {
   }
 
   private ValuesWriter getBinaryValuesWriter(ColumnDescriptor path) {
-    ValuesWriter fallbackWriter = new PlainValuesWriter(
-        parquetProperties.getInitialSlabSize(),
-        parquetProperties.getPageSizeThreshold(),
-        parquetProperties.getAllocator());
+    final ValuesWriter fallbackWriter;
+    if (parquetProperties.isDeltaLengthByteArrayForBinaryEnabled()) {
+      fallbackWriter = new DeltaLengthByteArrayValuesWriter(
+          parquetProperties.getInitialSlabSize(),
+          parquetProperties.getPageSizeThreshold(),
+          parquetProperties.getAllocator());
+    } else {
+      fallbackWriter = new PlainValuesWriter(
+          parquetProperties.getInitialSlabSize(),
+          parquetProperties.getPageSizeThreshold(),
+          parquetProperties.getAllocator());
+    }
     return DefaultValuesWriterFactory.dictWriterWithFallBack(
         path, parquetProperties, getEncodingForDictionaryPage(), getEncodingForDataPage(), fallbackWriter);
   }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
@@ -35,6 +35,7 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
 import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainBinaryDictionaryValuesWriter;
@@ -151,13 +152,42 @@ public class DefaultValuesWriterFactoryTest {
         false,
         false,
         PlainBinaryDictionaryValuesWriter.class,
-        PlainValuesWriter.class);
+        DeltaLengthByteArrayValuesWriter.class);
   }
 
   @Test
   public void testBinary_NoDict() {
     doTestValueWriter(
-        PrimitiveTypeName.BINARY, WriterVersion.PARQUET_1_0, false, false, false, PlainValuesWriter.class);
+        PrimitiveTypeName.BINARY,
+        WriterVersion.PARQUET_1_0,
+        false,
+        false,
+        false,
+        DeltaLengthByteArrayValuesWriter.class);
+  }
+
+  @Test
+  public void testBinary_NoDeltaLengthByteArray() {
+    doTestValueWriter(
+        createColumnDescriptor(PrimitiveTypeName.BINARY),
+        ParquetProperties.builder()
+            .withWriterVersion(WriterVersion.PARQUET_1_0)
+            .withDeltaLengthByteArrayForBinary(false)
+            .build(),
+        PlainBinaryDictionaryValuesWriter.class,
+        PlainValuesWriter.class);
+  }
+
+  @Test
+  public void testBinary_NoDict_NoDeltaLengthByteArray() {
+    doTestValueWriter(
+        createColumnDescriptor(PrimitiveTypeName.BINARY),
+        ParquetProperties.builder()
+            .withWriterVersion(WriterVersion.PARQUET_1_0)
+            .withDictionaryEncoding(false)
+            .withDeltaLengthByteArrayForBinary(false)
+            .build(),
+        PlainValuesWriter.class);
   }
 
   @Test

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -157,6 +157,8 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static final String BLOOM_FILTER_MAX_BYTES = "parquet.bloom.filter.max.bytes";
   public static final String BLOOM_FILTER_FPP = "parquet.bloom.filter.fpp";
   public static final String ADAPTIVE_BLOOM_FILTER_ENABLED = "parquet.bloom.filter.adaptive.enabled";
+  public static final String ENABLE_DELTA_LENGTH_BYTE_ARRAY_FOR_BINARY =
+      "parquet.enable.delta-length-byte-array-for-binary";
   public static final String BLOOM_FILTER_CANDIDATES_NUMBER = "parquet.bloom.filter.candidates.number";
   public static final String BLOCK_ROW_COUNT_LIMIT = "parquet.block.row.count.limit";
   public static final String PAGE_ROW_COUNT_LIMIT = "parquet.page.row.count.limit";
@@ -286,6 +288,12 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
   public static boolean getByteStreamSplitEnabled(Configuration configuration) {
     return configuration.getBoolean(
         ENABLE_BYTE_STREAM_SPLIT, ParquetProperties.DEFAULT_IS_BYTE_STREAM_SPLIT_ENABLED);
+  }
+
+  public static boolean getDeltaLengthByteArrayForBinaryEnabled(Configuration configuration) {
+    return configuration.getBoolean(
+        ENABLE_DELTA_LENGTH_BYTE_ARRAY_FOR_BINARY,
+        ParquetProperties.DEFAULT_DELTA_LENGTH_BYTE_ARRAY_FOR_BINARY);
   }
 
   public static int getMinRowCountForPageSizeCheck(Configuration configuration) {
@@ -522,6 +530,7 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         .withDictionaryPageSize(getDictionaryPageSize(conf))
         .withDictionaryEncoding(getEnableDictionary(conf))
         .withByteStreamSplitEncoding(getByteStreamSplitEnabled(conf))
+        .withDeltaLengthByteArrayForBinary(getDeltaLengthByteArrayForBinaryEnabled(conf))
         .withWriterVersion(getWriterVersion(conf))
         .estimateRowCountForPageSizeCheck(getEstimatePageSizeCheck(conf))
         .withMinRowCountForPageSizeCheck(getMinRowCountForPageSizeCheck(conf))

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -737,6 +737,11 @@ public class ParquetWriter<T> implements Closeable {
       return self();
     }
 
+    public SELF withDeltaLengthByteArrayForBinary(boolean enable) {
+      encodingPropsBuilder.withDeltaLengthByteArrayForBinary(enable);
+      return self();
+    }
+
     /**
      * Enable or disable dictionary encoding of the specified column for the constructed writer.
      *

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
@@ -326,19 +326,20 @@ public class DictionaryFilterTest {
         assertFalse(
             "Column should not have plain data pages" + name,
             column.getEncodings().contains(Encoding.PLAIN));
+      } else if (name.startsWith("fallback_binary")) {
+        assertTrue(
+            "Column should have DELTA_LENGTH_BYTE_ARRAY encoding: " + name,
+            column.getEncodings().contains(Encoding.DELTA_LENGTH_BYTE_ARRAY));
+        assertTrue(
+            "Column should have some dictionary encoding: " + name,
+            column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
       } else {
         assertTrue(
             "Column should have plain encoding: " + name,
             column.getEncodings().contains(Encoding.PLAIN));
-        if (name.startsWith("fallback")) {
-          assertTrue(
-              "Column should have some dictionary encoding: " + name,
-              column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
-        } else {
-          assertFalse(
-              "Column should have no dictionary encoding: " + name,
-              column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
-        }
+        assertFalse(
+            "Column should have no dictionary encoding: " + name,
+            column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
       }
     }
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnIndexFiltering.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnIndexFiltering.java
@@ -352,15 +352,17 @@ public class TestColumnIndexFiltering {
     int rowGroupSize = pageSize * 6 * 5; // Ensure that there are more row-groups created
 
     try (TrackingByteBufferAllocator allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator())) {
-      PhoneBookWriter.write(
-          ExampleParquetWriter.builder(file)
-              .withAllocator(allocator)
-              .withWriteMode(OVERWRITE)
-              .withRowGroupSize(rowGroupSize)
-              .withPageSize(pageSize)
-              .withEncryption(encryptionProperties)
-              .withWriterVersion(parquetVersion),
-          DATA);
+      ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(file)
+          .withAllocator(allocator)
+          .withWriteMode(OVERWRITE)
+          .withRowGroupSize(rowGroupSize)
+          .withPageSize(pageSize)
+          .withEncryption(encryptionProperties)
+          .withWriterVersion(parquetVersion);
+      if (parquetVersion == WriterVersion.PARQUET_1_0) {
+        builder.withDeltaLengthByteArrayForBinary(false);
+      }
+      PhoneBookWriter.write(builder, DATA);
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -19,7 +19,7 @@
 package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.column.Encoding.DELTA_BYTE_ARRAY;
-import static org.apache.parquet.column.Encoding.PLAIN;
+import static org.apache.parquet.column.Encoding.DELTA_LENGTH_BYTE_ARRAY;
 import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
 import static org.apache.parquet.column.Encoding.RLE_DICTIONARY;
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
@@ -174,7 +174,7 @@ public class TestParquetWriter {
     SimpleGroupFactory f = new SimpleGroupFactory(schema);
     Map<String, Encoding> expected = new HashMap<String, Encoding>();
     expected.put("10-" + PARQUET_1_0, PLAIN_DICTIONARY);
-    expected.put("1000-" + PARQUET_1_0, PLAIN);
+    expected.put("1000-" + PARQUET_1_0, DELTA_LENGTH_BYTE_ARRAY);
     expected.put("10-" + PARQUET_2_0, RLE_DICTIONARY);
     expected.put("1000-" + PARQUET_2_0, DELTA_BYTE_ARRAY);
     for (int modulo : List.of(10, 1000)) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterNewPage.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterNewPage.java
@@ -19,7 +19,7 @@
 package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.column.Encoding.DELTA_BYTE_ARRAY;
-import static org.apache.parquet.column.Encoding.PLAIN;
+import static org.apache.parquet.column.Encoding.DELTA_LENGTH_BYTE_ARRAY;
 import static org.apache.parquet.column.Encoding.PLAIN_DICTIONARY;
 import static org.apache.parquet.column.Encoding.RLE_DICTIONARY;
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
@@ -76,7 +76,7 @@ public class TestParquetWriterNewPage {
     SimpleGroupFactory f = new SimpleGroupFactory(schema);
     Map<String, Encoding> expected = new HashMap<String, Encoding>();
     expected.put("10-" + PARQUET_1_0, PLAIN_DICTIONARY);
-    expected.put("1000-" + PARQUET_1_0, PLAIN);
+    expected.put("1000-" + PARQUET_1_0, DELTA_LENGTH_BYTE_ARRAY);
     expected.put("10-" + PARQUET_2_0, RLE_DICTIONARY);
     expected.put("1000-" + PARQUET_2_0, DELTA_BYTE_ARRAY);
     for (int modulo : List.of(10, 1000)) {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
The current default for V1 pages is PLAIN encoding. This encoding mixes string length with string data. This is inefficient for for skipping N values, as the encoding does not allow random access. It's also slow to decode as the interleaving of lengths with data does not allow efficient batched implementations and forces most implementations to make copies of the data to fit the usual representation of separate offsets and data for strings.

DELTA_LENGTH_BYTE_ARRAY has none of the above problems as it separates offsets and data. The parquet-format spec also seems to recommend this https://github.com/apache/parquet-format/blob/c70281359087dfaee8bd43bed9748675f4aabe11/Encodings.md?plain=1#L299

### What changes are included in this PR?
- Changes the default fallback encoding for BINARY columns in the V1 writer from PLAIN to DELTA_LENGTH_BYTE_ARRAY.
- Adds a new configuration property `parquet.enable.delta-length-byte-array-for-binary` (default: `true`) to allow disabling the new default and reverting to PLAIN encoding.
- The toggle is wired through `ParquetProperties.Builder.withDeltaLengthByteArrayForBinary(boolean)`, `ParquetWriter.Builder`, and `ParquetOutputFormat` (Hadoop configuration).

### Are these changes tested?
Yes. Existing tests updated to reflect the new default, and two new test cases added for the disabled configuration path (`testBinary_NoDeltaLengthByteArray` and `testBinary_NoDict_NoDeltaLengthByteArray`).

### Are there any user-facing changes?
Yes. BINARY columns written with `PARQUET_1_0` writer version now use DELTA_LENGTH_BYTE_ARRAY encoding by default instead of PLAIN when dictionary encoding falls back. Users can set `parquet.enable.delta-length-byte-array-for-binary=false` to revert to the previous behavior.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->