### PR TITLE
GH-3099 add libthrift to parquet-cli shaded jar

### DIFF
--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -191,6 +191,12 @@
       <scope>${deps.scope}</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>${format.thrift.version}</version>
+      <scope>${deps.scope}</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>${jsr305.version}</version>


### PR DESCRIPTION
### Rationale for this change

Closes #3099

the parquet-cli shaded "runtime.jar" does not work. Getting NoClassDefFoundError on libthrift class.

### What changes are included in this PR?
add libthrift to parquet-cli/pom.xml.
it is already a transitive dependency, but was not in shaded jar.

