### PR TITLE
GH-3091: Add verification guide and .rat-excludes.txt for release

### DIFF
--- a/.rat-excludes.txt
+++ b/.rat-excludes.txt
@@ -1,0 +1,15 @@
+.gitignore
+.rat-excludes.txt
+PULL_REQUEST_TEMPLATE.md
+strings-2.parquet$
+nested_array.avsc$
+map_with_nulls.avsc$
+map.avsc$
+list_with_nulls.avsc$
+fixedToInt96.avsc$
+array.avsc$
+allFromParquetOldBehavior.avsc$
+allFromParquetNewBehavior.avsc$
+all.avsc$
+stringBehavior.avsc$
+logicalType.avsc$

--- a/dev/README.md
+++ b/dev/README.md
@@ -91,3 +91,57 @@ Merge hash: 485658a5
 Would you like to pick 485658a5 into another branch? (y/n):
 ```
 For now just say n as we have 1 branch
+
+# Release Verification
+
+The Apache Arrow Release Approval process follows the guidelines defined at the
+`Apache Software Foundation Release Approval <https://www.apache.org/legal/release-policy.html#release-approval>`_.
+
+For a release vote to pass, a minimum of three positive binding votes and more
+positive binding votes than negative binding votes MUST be cast.
+Releases may not be vetoed. Votes cast by PMC members are binding, however,
+non-binding votes are greatly encouraged and a sign of a healthy project.
+
+In order to cast a vote individuals are expected to follow the following steps.
+
+## Download source package, signature file, hash file and KEYS
+
+The Release candidate will be present at `https://dist.apache.org/repos/dist/dev/parquet/`.
+The RC folder will depend on the version and the release candidate id. See the following example files for
+Apache Parquet 1.15.0 RC 1:
+```
+wget https://dist.apache.org/repos/dist/dev/parquet/apache-parquet-1.15.0-rc1/apache-parquet-1.15.0.tar.gz
+wget https://dist.apache.org/repos/dist/dev/parquet/apache-parquet-1.15.0-rc1/apache-parquet-1.15.0.tar.gz.asc
+wget https://dist.apache.org/repos/dist/dev/parquet/apache-parquet-1.15.0-rc1/apache-parquet-1.15.0.tar.gz.sha512
+wget https://dist.apache.org/repos/dist/release/parquet/KEYS
+```
+
+## Verify signature and hash
+
+GnuPG is recommended, which can install by yum install gnupg or apt-get install gnupg.
+
+```
+gpg --import KEYS
+gpg --verify apache-parquet-1.15.0.tar.gz.asc apache-parquet-1.15.0.tar.gz
+sha512sum --check apache-parquet-1.15.0.tar.gz.sha512
+```
+
+## Verify license header
+
+Apache RAT is recommended to verify license header, which can dowload as following command.
+
+```
+wget https://archive.apache.org/dist/creadur/apache-rat-0.16.1/apache-rat-0.16.1-bin.tar.gz
+tar zxvf apache-rat-0.16.1-bin.tar.gz
+```
+
+You can check with following command. It will output a file list which don't include ASF license header, and these files used other licenses.
+Please substitute `$PARQUET_SRC_FOLDER` with your `parquet-java` source folder.
+
+```
+java  -jar apache-rat-0.16.1/apache-rat-0.16.1.jar -a -d apache-parquet-1.15.0.tar.gz -E $PARQUET_SRC_FOLDER/.rat-excludes.txt
+```
+
+## Verify building and tests
+
+Check the [building section](../README.md#building)

--- a/dev/README.md
+++ b/dev/README.md
@@ -118,7 +118,10 @@ wget https://dist.apache.org/repos/dist/release/parquet/KEYS
 
 ## Verify signature and hash
 
-GnuPG is recommended, which can install by yum install gnupg or apt-get install gnupg.
+GnuPG is recommended, which can be install by:
+- `yum install gnupg`, `apt-get install gnupg` on Linux based environments.
+- `brew install gnupg` on macOS environments.
+
 
 ```
 gpg --import KEYS
@@ -128,15 +131,16 @@ sha512sum --check apache-parquet-1.15.0.tar.gz.sha512
 
 ## Verify license header
 
-Apache RAT is recommended to verify license header, which can dowload as following command.
+Apache RAT is recommended to verify the license header, which can be dowload with the following command.
 
 ```
 wget https://archive.apache.org/dist/creadur/apache-rat-0.16.1/apache-rat-0.16.1-bin.tar.gz
 tar zxvf apache-rat-0.16.1-bin.tar.gz
 ```
 
-You can check with following command. It will output a file list which don't include ASF license header, and these files used other licenses.
-Please substitute `$PARQUET_SRC_FOLDER` with your `parquet-java` source folder.
+You can check with the following command.
+It will output a file list which doesn't include ASF license headers.
+Please substitute `$PARQUET_SRC_FOLDER` with your `parquet-java` source folder from the following command.
 
 ```
 java  -jar apache-rat-0.16.1/apache-rat-0.16.1.jar -a -d apache-parquet-1.15.0.tar.gz -E $PARQUET_SRC_FOLDER/.rat-excludes.txt

--- a/pom.xml
+++ b/pom.xml
@@ -498,6 +498,7 @@
           <consoleOutput>true</consoleOutput>
           <excludes>
             <exclude>.github/PULL_REQUEST_TEMPLATE.md</exclude>
+            <exclude>.rat-excludes.txt</exclude>
             <exclude>**/*.parquet</exclude>
             <exclude>**/*.avro</exclude>
             <exclude>**/*.json</exclude>


### PR DESCRIPTION
### Rationale for this change

There is currently no guide on how to verify. Having a guider will encourage people to verify the release.
This guide should be linked on the Voting thread.

### What changes are included in this PR?

Added documentation about how to verify and add `.rat-excludes.txt` file with the files that do not contain a current license but we are fine with those. Those files are mainly testing `.avsc`, `.parquet` , `.gitignore` and `PULL_REQUEST_TEMPLATE.md` files.

### Are these changes tested?

I've validated all steps localy

### Are there any user-facing changes?

No, just more docs.

Closes #3091 
