### PR TITLE
GH-3114: Fix LogicalType conversions for nested records on Avro <= 1.8

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -196,10 +196,10 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
             }
           } catch (NoSuchFieldException e) {
             // Avro classes without logical types (denoted by the "conversions" field)
-          } finally {
-            for (Schema.Field field : schema.getFields()) {
-              addLogicalTypeConversion(model, field.schema(), seenSchemas);
-            }
+          }
+
+          for (Schema.Field field : schema.getFields()) {
+            addLogicalTypeConversion(model, field.schema(), seenSchemas);
           }
         }
         break;

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -194,12 +194,12 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
                 model.addLogicalTypeConversion(conversion);
               }
             }
-
+          } catch (NoSuchFieldException e) {
+            // Avro classes without logical types (denoted by the "conversions" field)
+          } finally {
             for (Schema.Field field : schema.getFields()) {
               addLogicalTypeConversion(model, field.schema(), seenSchemas);
             }
-          } catch (NoSuchFieldException e) {
-            // Avro classes without logical types (denoted by the "conversions" field)
           }
         }
         break;

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
@@ -88,12 +88,20 @@ public class TestAvroRecordConverter {
   public void testModelForSpecificRecordWithLogicalTypesWithDeprecatedAvro1_8() {
     Mockito.when(AvroRecordConverter.getRuntimeAvroVersion()).thenReturn("1.8.2");
 
-    // Test that model is generated correctly
-    final SpecificData model = AvroRecordConverter.getModelForSchema(LogicalTypesTestDeprecated.SCHEMA$);
+    // Test that model is generated correctly when record contains both top-level and nested logical types
+    SpecificData model = AvroRecordConverter.getModelForSchema(LogicalTypesTestDeprecated.SCHEMA$);
     // Test that model is generated correctly
     Collection<Conversion<?>> conversions = model.getConversions();
-    assertEquals(conversions.size(), 3);
+    assertEquals(3, conversions.size());
     assertNotNull(model.getConversionByClass(Instant.class));
+    assertNotNull(model.getConversionByClass(LocalDate.class));
+    assertNotNull(model.getConversionByClass(LocalTime.class));
+
+    // Test that model is generated correctly when record contains only nested logical types
+    model = AvroRecordConverter.getModelForSchema(NestedOnlyLogicalTypesDeprecated.SCHEMA$);
+    // Test that model is generated correctly
+    conversions = model.getConversions();
+    assertEquals(2, conversions.size());
     assertNotNull(model.getConversionByClass(LocalDate.class));
     assertNotNull(model.getConversionByClass(LocalTime.class));
   }
@@ -147,6 +155,7 @@ public class TestAvroRecordConverter {
     };
   }
 
+  // An Avro class generated from Avro 1.8 that contains both nested and top-level logical type fields
   @org.apache.avro.specific.AvroGenerated
   public abstract static class LogicalTypesTestDeprecated extends org.apache.avro.specific.SpecificRecordBase
       implements org.apache.avro.specific.SpecificRecord {
@@ -178,5 +187,27 @@ public class TestAvroRecordConverter {
     private static final org.apache.avro.Conversion<?>[] conversions = new org.apache.avro.Conversion<?>[] {
       new org.apache.avro.data.TimeConversions.TimestampMillisConversion(), null, null
     };
+  }
+
+  // An Avro class generated from Avro 1.8 that contains only nested logical type fields
+  @org.apache.avro.specific.AvroGenerated
+  public abstract static class NestedOnlyLogicalTypesDeprecated extends org.apache.avro.specific.SpecificRecordBase
+      implements org.apache.avro.specific.SpecificRecord {
+    public static final org.apache.avro.Schema SCHEMA$ = SchemaBuilder.builder()
+        .record("NestedOnlyLogicalTypesDeprecated")
+        .namespace("org.apache.parquet.avro.TestAvroRecordConverter")
+        .fields()
+        .name("local_date_time")
+        .type(LocalDateTimeTestDeprecated.getClassSchema())
+        .noDefault()
+        .endRecord();
+
+    public static org.apache.avro.Schema getClassSchema() {
+      return SCHEMA$;
+    }
+
+    private static SpecificData MODEL$ = new SpecificData();
+
+    // No top-level conversions field, since logical types are all nested
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Fixes logical type conversions for nested records on Avro <= 1.8. This was also addressed in https://github.com/apache/parquet-java/pull/1296/files but was missing the test case where _all_ logical types are in nested classes and there are zero top-level logical types. In this case, invoking `clazz.getDeclaredField("conversions")` in AvroRecordConverter throws a `NoSuchFieldException` and terminates the loop before attempting to traverse the record's inner fields.

Fixes #3114 

### What changes are included in this PR?

Fixes built-in logical type conversions for Avro records that contain only nested logical type fields on <= 1.8

### Are these changes tested?

Included a test for the case described above

### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
