### PR TITLE
GH-3127: Enabled `parquet.hadoop.vectored.io.enabled` by default

### DIFF
--- a/parquet-hadoop/README.md
+++ b/parquet-hadoop/README.md
@@ -507,7 +507,7 @@ If `false`, key material is stored in separate new files, created in the same fo
 **Description:** Flag to enable use of the FileSystem Vector IO API on Hadoop releases which support the feature.
 If `true` then an attempt will be made to dynamically load the relevant classes; 
 if not found then the library will use the classic non-vectored reads: it is safe to enable this option on older releases. 
-**Default value:** `false`
+**Default value:** `true`
 
 ---
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetInputFormat.java
@@ -170,7 +170,7 @@ public class ParquetInputFormat<T> extends FileInputFormat<Void, T> {
   /**
    * Default value of parquet.hadoop.vectored.io.enabled is {@value}.
    */
-  public static final boolean HADOOP_VECTORED_IO_DEFAULT = false;
+  public static final boolean HADOOP_VECTORED_IO_DEFAULT = true;
 
   public static void setTaskSideMetaData(Job job, boolean taskSideMetadata) {
     ContextUtil.getConfiguration(job).setBoolean(TASK_SIDE_METADATA, taskSideMetadata);


### PR DESCRIPTION
### Rationale for this change

To help users to use this features more easily if it's supported by the underlying Hadoop and all parts are applicable.

### What changes are included in this PR?

`parquet.hadoop.vectored.io.enabled` was introduced at Apache Parquet 1.14.0.

- https://github.com/apache/parquet-java/pull/1139

To switch the default value to `true` for `parquet.hadoop.vectored.io.enabled` in Apache Parquet 1.16.0.

This is applied only when the following conditions are met.

https://github.com/apache/parquet-java/blob/7a99d86d579a00bbf9e29153118773485cba4fc4/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java#L1250-L1254

### Are these changes tested?

Pass the CIs.

### Are there any user-facing changes?

Yes, this is the change of default value of `parquet.hadoop.vectored.io.enabled`

Closes #3127
