### PR TITLE
MINOR: Remove Joda as a direct dependency

### DIFF
--- a/parquet-pig/pom.xml
+++ b/parquet-pig/pom.xml
@@ -100,12 +100,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.7</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.antlr</groupId>
       <artifactId>antlr-runtime</artifactId>
       <version>3.5.3</version>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -133,12 +133,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>joda-time</groupId>
-      <artifactId>joda-time</artifactId>
-      <version>2.12.7</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>${javax.annotation.version}</version>


### PR DESCRIPTION
I saw https://github.com/apache/parquet-java/pull/3130 and I couldn't find any direct references to the Joda library in the Parquet code.

Instead of bumping it, it would be better to just remove it.

<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
