### PR TITLE
GH-3133: Fix SizeStatistics to handle omitted histogram

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/SizeStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/SizeStatistics.java
@@ -148,8 +148,10 @@ public class SizeStatistics {
       List<Long> definitionLevelHistogram) {
     this.type = type;
     this.unencodedByteArrayDataBytes = unencodedByteArrayDataBytes;
-    this.repetitionLevelHistogram = repetitionLevelHistogram;
-    this.definitionLevelHistogram = definitionLevelHistogram;
+    this.repetitionLevelHistogram =
+        repetitionLevelHistogram == null ? Collections.emptyList() : repetitionLevelHistogram;
+    this.definitionLevelHistogram =
+        definitionLevelHistogram == null ? Collections.emptyList() : definitionLevelHistogram;
   }
 
   /**

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestSizeStatistics.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestSizeStatistics.java
@@ -125,4 +125,20 @@ public class TestSizeStatistics {
     Assert.assertEquals(Arrays.asList(1L, 1L, 1L), copy.getRepetitionLevelHistogram());
     Assert.assertEquals(Arrays.asList(1L, 1L, 1L), copy.getDefinitionLevelHistogram());
   }
+
+  @Test
+  public void testOmittedHistogram() {
+    PrimitiveType type = Types.optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("a");
+    SizeStatistics statistics = new SizeStatistics(type, 1024L, null, null);
+    Assert.assertEquals(Optional.of(1024L), statistics.getUnencodedByteArrayDataBytes());
+    Assert.assertEquals(Collections.emptyList(), statistics.getRepetitionLevelHistogram());
+    Assert.assertEquals(Collections.emptyList(), statistics.getDefinitionLevelHistogram());
+
+    SizeStatistics copy = statistics.copy();
+    Assert.assertEquals(Optional.of(1024L), copy.getUnencodedByteArrayDataBytes());
+    Assert.assertEquals(Collections.emptyList(), copy.getRepetitionLevelHistogram());
+    Assert.assertEquals(Collections.emptyList(), copy.getDefinitionLevelHistogram());
+  }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -2382,8 +2382,14 @@ public class ParquetMetadataConverter {
       formatStats.setUnencoded_byte_array_data_bytes(
           stats.getUnencodedByteArrayDataBytes().get());
     }
-    formatStats.setRepetition_level_histogram(stats.getRepetitionLevelHistogram());
-    formatStats.setDefinition_level_histogram(stats.getDefinitionLevelHistogram());
+    List<Long> repLevelHistogram = stats.getRepetitionLevelHistogram();
+    if (repLevelHistogram != null && !repLevelHistogram.isEmpty()) {
+      formatStats.setRepetition_level_histogram(repLevelHistogram);
+    }
+    List<Long> defLevelHistogram = stats.getDefinitionLevelHistogram();
+    if (defLevelHistogram != null && !defLevelHistogram.isEmpty()) {
+      formatStats.setDefinition_level_histogram(defLevelHistogram);
+    }
     return formatStats;
   }
 }


### PR DESCRIPTION
### Rationale for this change

If SizeStatistics has omitted level histogram, creating an `SizeStatistics` will result in a null object which leads to NullPointerException when calling getter or copy methods.

### What changes are included in this PR?

Use a zero-length list for omitted histogram.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

Closes #3133
