### PR TITLE
MINOR: Reader fails fast when footer size is larger than INT_MAX

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -589,7 +589,12 @@ public class ParquetFileReader implements Closeable {
     long fileMetadataLengthIndex = fileLen - magic.length - FOOTER_LENGTH_SIZE;
     LOG.debug("reading footer index at {}", fileMetadataLengthIndex);
     f.seek(fileMetadataLengthIndex);
-    int fileMetadataLength = readIntLittleEndian(f);
+    long readFileMetadataLength = readIntLittleEndian(f) & 0xFFFFFFFFL;
+    if (readFileMetadataLength > Integer.MAX_VALUE) {
+      throw new RuntimeException("footer is too large: " + readFileMetadataLength + "to be read");
+    }
+    int fileMetadataLength = (int) readFileMetadataLength;
+
     f.readFully(magic);
 
     boolean encryptedFooterMode;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -1915,7 +1915,7 @@ public class ParquetFileWriter implements AutoCloseable {
       out.write(serializedFooter);
       out.write(signature);
       LOG.debug("{}: footer and signature length = {}", out.getPos(), (out.getPos() - footerIndex));
-      BytesUtils.writeIntLittleEndian(out, toIntWithCheck(out.getPos() - footerIndex, "page"));
+      BytesUtils.writeIntLittleEndian(out, toIntWithCheck(out.getPos() - footerIndex, "footer"));
       out.write(MAGIC);
       return;
     }
@@ -1925,7 +1925,7 @@ public class ParquetFileWriter implements AutoCloseable {
     writeFileCryptoMetaData(fileEncryptor.getFileCryptoMetaData(), out);
     byte[] footerAAD = AesCipher.createFooterAAD(fileEncryptor.getFileAAD());
     writeFileMetaData(parquetMetadata, out, fileEncryptor.getFooterEncryptor(), footerAAD);
-    int combinedMetaDataLength = toIntWithCheck(out.getPos() - cryptoFooterIndex, "page");
+    int combinedMetaDataLength = toIntWithCheck(out.getPos() - cryptoFooterIndex, "footer");
     LOG.debug("{}: crypto metadata and footer length = {}", out.getPos(), combinedMetaDataLength);
     BytesUtils.writeIntLittleEndian(out, combinedMetaDataLength);
     out.write(EFMAGIC);


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

The footer size is limited to unsigned int for some other language implementations, such as Rust. However, it is limited to Int.MaxValue on the Java side due to some limitations(eg, lack of unsigned int supports, the biggest byte array/buffer is limited to Int.MaxValue). So this PR reads the footer size as long and fails fast if it is larger than Int.MaxValue.


### What changes are included in this PR?


### Are these changes tested?

Existed UTs.


### Are there any user-facing changes?

No


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
