### PR TITLE
MINOR: Remove `parquet-tools` from `NOTICE`

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -7,25 +7,6 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-This product includes parquet-tools, initially developed at ARRIS, Inc. with
-the following copyright notice:
-
-  Copyright 2013 ARRIS, Inc.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-
---------------------------------------------------------------------------------
-
 This product includes parquet-protobuf, initially developed by Lukas Nalezenc
 with the following copyright notice:
 


### PR DESCRIPTION
### Rationale for this change

Parquet-tools has been removed since 1.12.0: https://mvnrepository.com/artifact/org.apache.parquet/parquet-tools


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
