### PR TITLE
MINOR: Improve exception message in InternalFileDecryptor

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/InternalFileDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/InternalFileDecryptor.java
@@ -232,7 +232,7 @@ public class InternalFileDecryptor {
               "Re-use: wrong encryption key (column vs footer). Column: " + path);
         }
         if (!encryptedWithFooterKey && !Arrays.equals(columnDecryptionSetup.getKeyMetadata(), keyMetadata)) {
-          throw new ParquetCryptoRuntimeException("Decryptor re-use: Different footer key metadata ");
+          throw new ParquetCryptoRuntimeException("Decryptor re-use: Different footer key metadata");
         }
       }
       return columnDecryptionSetup;
@@ -244,7 +244,8 @@ public class InternalFileDecryptor {
     } else {
       if (encryptedWithFooterKey) {
         if (null == footerKey) {
-          throw new ParquetCryptoRuntimeException("Column " + path + " is encrypted with NULL footer key");
+          throw new ParquetCryptoRuntimeException(
+              "Column " + path + " is encrypted with footer key, but the provided footer key is NULL");
         }
         columnDecryptionSetup = new InternalColumnDecryptionSetup(
             path,
@@ -269,7 +270,8 @@ public class InternalFileDecryptor {
           }
         }
         if (null == columnKeyBytes) {
-          throw new ParquetCryptoRuntimeException("Column " + path + "is encrypted with NULL column key");
+          throw new ParquetCryptoRuntimeException("Column " + path
+              + " is encrypted with column-specific key, but the provided column key is NULL");
         }
         columnDecryptionSetup = new InternalColumnDecryptionSetup(
             path,


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
When reading encrypted columns, if the provided key is NULL, the thrown exception message might be confusing: "Column [foo] is encrypted with NULL column key".  However NULL key is certainly not permitted for encryption, the occurrence of such an exception invariably indicates an issue with the key provisioning process. So this PR explicitly states this in the exception message.


### What changes are included in this PR?
Exception msg change.

### Are these changes tested?
No need.

### Are there any user-facing changes?
No.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->

@wgtmac @ggershinsky can you please take a look? Thanks!
