### PR TITLE
[GH-3146] Optimize the binaryToDecimal function

### DIFF
--- a/parquet-pig/src/main/java/org/apache/parquet/pig/convert/DecimalUtils.java
+++ b/parquet-pig/src/main/java/org/apache/parquet/pig/convert/DecimalUtils.java
@@ -19,8 +19,6 @@
 
 package org.apache.parquet.pig.convert;
 
-import static java.lang.Math.pow;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -53,11 +51,7 @@ public class DecimalUtils {
       }
       int bits = 8 * (end - start);
       long unscaledNew = (unscaled << (64 - bits)) >> (64 - bits);
-      if (unscaledNew <= -pow(10, 18) || unscaledNew >= pow(10, 18)) {
-        return new BigDecimal(unscaledNew);
-      } else {
-        return BigDecimal.valueOf(unscaledNew / pow(10, scale));
-      }
+      return BigDecimal.valueOf(unscaledNew, scale);
     } else {
       return new BigDecimal(new BigInteger(value.getBytes()), scale);
     }

--- a/parquet-pig/src/test/java/org/apache/parquet/pig/TestDecimalUtils.java
+++ b/parquet-pig/src/test/java/org/apache/parquet/pig/TestDecimalUtils.java
@@ -60,12 +60,12 @@ public class TestDecimalUtils {
     // Test LONG
     testDecimalConversion(Long.MAX_VALUE, 19, 0, "9223372036854775807");
     testDecimalConversion(Long.MIN_VALUE, 19, 0, "-9223372036854775808");
-    testDecimalConversion(0L, 0, 0, "0.0");
+    testDecimalConversion(0L, 0, 0, "0");
 
     // Test INTEGER
     testDecimalConversion(Integer.MAX_VALUE, 10, 0, "2147483647");
     testDecimalConversion(Integer.MIN_VALUE, 10, 0, "-2147483648");
-    testDecimalConversion(0, 0, 0, "0.0");
+    testDecimalConversion(0, 0, 0, "0");
 
     // Test DOUBLE
     testDecimalConversion(12345678912345678d, 17, 0, "12345678912345678");


### PR DESCRIPTION
### Rationale for this change
#3146 
If precision is less than 18, the condition unscaledNew <= -pow(10, 18) || unscaledNew >= pow(10, 18) can not be true, so we can remove the judgment logic here. Additionally, using BigDecimal.valueOf(unscaledNew, scale) is preferable over using BigDecimal.valueOf(unscaledNew / pow(10, scale)), as it does not convert the unscaled value to double.

### What changes are included in this PR?
Optimize the binaryToDecimal function

### Are these changes tested?
pass unit test.

### Are there any user-facing changes?
No

Closes #3146 
