### PR TITLE
GH-3122: Correct V2 page header compression fields for zero-size data pages

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesCtrDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesCtrDecryptor.java
@@ -55,7 +55,11 @@ public class AesCtrDecryptor extends AesCipher implements BlockCipher.Decryptor 
   public byte[] decrypt(byte[] ciphertext, int cipherTextOffset, int cipherTextLength, byte[] AAD) {
 
     int plainTextLength = cipherTextLength - NONCE_LENGTH;
-    if (plainTextLength < 1) {
+    if (plainTextLength == 0) {
+      return new byte[0];
+    }
+
+    if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
     }
 
@@ -91,7 +95,11 @@ public class AesCtrDecryptor extends AesCipher implements BlockCipher.Decryptor 
     int cipherTextLength = ciphertext.limit() - ciphertext.position() - SIZE_LENGTH;
 
     int plainTextLength = cipherTextLength - NONCE_LENGTH;
-    if (plainTextLength < 1) {
+    if (plainTextLength == 0) {
+      return ByteBuffer.allocate(0);
+    }
+
+    if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesCtrDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesCtrDecryptor.java
@@ -55,10 +55,6 @@ public class AesCtrDecryptor extends AesCipher implements BlockCipher.Decryptor 
   public byte[] decrypt(byte[] ciphertext, int cipherTextOffset, int cipherTextLength, byte[] AAD) {
 
     int plainTextLength = cipherTextLength - NONCE_LENGTH;
-    if (plainTextLength == 0) {
-      return new byte[0];
-    }
-
     if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
     }
@@ -95,10 +91,6 @@ public class AesCtrDecryptor extends AesCipher implements BlockCipher.Decryptor 
     int cipherTextLength = ciphertext.limit() - ciphertext.position() - SIZE_LENGTH;
 
     int plainTextLength = cipherTextLength - NONCE_LENGTH;
-    if (plainTextLength == 0) {
-      return ByteBuffer.allocate(0);
-    }
-
     if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesGcmDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesGcmDecryptor.java
@@ -51,9 +51,6 @@ public class AesGcmDecryptor extends AesCipher implements BlockCipher.Decryptor 
   public byte[] decrypt(byte[] ciphertext, int cipherTextOffset, int cipherTextLength, byte[] AAD) {
 
     int plainTextLength = cipherTextLength - GCM_TAG_LENGTH - NONCE_LENGTH;
-    if (plainTextLength == 0) {
-      return new byte[0];
-    }
 
     if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
@@ -85,10 +82,6 @@ public class AesGcmDecryptor extends AesCipher implements BlockCipher.Decryptor 
     int cipherTextOffset = SIZE_LENGTH;
     int cipherTextLength = ciphertext.limit() - ciphertext.position() - SIZE_LENGTH;
     int plainTextLength = cipherTextLength - GCM_TAG_LENGTH - NONCE_LENGTH;
-
-    if (plainTextLength == 0) {
-      return ByteBuffer.allocate(0);
-    }
 
     if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesGcmDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesGcmDecryptor.java
@@ -51,7 +51,6 @@ public class AesGcmDecryptor extends AesCipher implements BlockCipher.Decryptor 
   public byte[] decrypt(byte[] ciphertext, int cipherTextOffset, int cipherTextLength, byte[] AAD) {
 
     int plainTextLength = cipherTextLength - GCM_TAG_LENGTH - NONCE_LENGTH;
-
     if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
     }
@@ -82,7 +81,6 @@ public class AesGcmDecryptor extends AesCipher implements BlockCipher.Decryptor 
     int cipherTextOffset = SIZE_LENGTH;
     int cipherTextLength = ciphertext.limit() - ciphertext.position() - SIZE_LENGTH;
     int plainTextLength = cipherTextLength - GCM_TAG_LENGTH - NONCE_LENGTH;
-
     if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesGcmDecryptor.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/crypto/AesGcmDecryptor.java
@@ -51,7 +51,11 @@ public class AesGcmDecryptor extends AesCipher implements BlockCipher.Decryptor 
   public byte[] decrypt(byte[] ciphertext, int cipherTextOffset, int cipherTextLength, byte[] AAD) {
 
     int plainTextLength = cipherTextLength - GCM_TAG_LENGTH - NONCE_LENGTH;
-    if (plainTextLength < 1) {
+    if (plainTextLength == 0) {
+      return new byte[0];
+    }
+
+    if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
     }
 
@@ -81,7 +85,12 @@ public class AesGcmDecryptor extends AesCipher implements BlockCipher.Decryptor 
     int cipherTextOffset = SIZE_LENGTH;
     int cipherTextLength = ciphertext.limit() - ciphertext.position() - SIZE_LENGTH;
     int plainTextLength = cipherTextLength - GCM_TAG_LENGTH - NONCE_LENGTH;
-    if (plainTextLength < 1) {
+
+    if (plainTextLength == 0) {
+      return ByteBuffer.allocate(0);
+    }
+
+    if (plainTextLength < 0) {
       throw new ParquetCryptoRuntimeException("Wrong input length " + plainTextLength);
     }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -1044,7 +1044,9 @@ public class ParquetFileWriter implements AutoCloseable {
    * @param uncompressedDataSize the size of uncompressed data
    * @param statistics           the statistics of the page
    * @throws IOException if any I/O error occurs during writing the file
+   * @deprecated will be removed in 2.0.0. Use {@link ParquetFileWriter#writeDataPageV2(int, int, int, BytesInput, BytesInput, Encoding, BytesInput, boolean, int, Statistics)} instead
    */
+  @Deprecated
   public void writeDataPageV2(
       int rowCount,
       int nullCount,
@@ -1064,6 +1066,50 @@ public class ParquetFileWriter implements AutoCloseable {
         definitionLevels,
         dataEncoding,
         compressedData,
+        true, /* compressed by default */
+        uncompressedDataSize,
+        statistics,
+        null,
+        null,
+        null);
+  }
+
+  /**
+   * Writes a single v2 data page
+   *
+   * @param rowCount             count of rows
+   * @param nullCount            count of nulls
+   * @param valueCount           count of values
+   * @param repetitionLevels     repetition level bytes
+   * @param definitionLevels     definition level bytes
+   * @param dataEncoding         encoding for data
+   * @param bytes                data bytes
+   * @param compressed           whether the data bytes is compressed
+   * @param uncompressedDataSize the size of uncompressed data
+   * @param statistics           the statistics of the page
+   * @throws IOException if any I/O error occurs during writing the file
+   */
+  public void writeDataPageV2(
+      int rowCount,
+      int nullCount,
+      int valueCount,
+      BytesInput repetitionLevels,
+      BytesInput definitionLevels,
+      Encoding dataEncoding,
+      BytesInput bytes,
+      boolean compressed,
+      int uncompressedDataSize,
+      Statistics<?> statistics)
+      throws IOException {
+    writeDataPageV2(
+        rowCount,
+        nullCount,
+        valueCount,
+        repetitionLevels,
+        definitionLevels,
+        dataEncoding,
+        bytes,
+        compressed,
         uncompressedDataSize,
         statistics,
         null,
@@ -1086,7 +1132,9 @@ public class ParquetFileWriter implements AutoCloseable {
    * @param metadataBlockEncryptor encryptor for block data
    * @param pageHeaderAAD          pageHeader AAD
    * @throws IOException if any I/O error occurs during writing the file
+   * @deprecated will be removed in 2.0.0. Use {@link ParquetFileWriter#writeDataPageV2(int, int, int, BytesInput, BytesInput, Encoding, BytesInput, boolean, int, Statistics, BlockCipher.Encryptor, byte[])} instead
    */
+  @Deprecated
   public void writeDataPageV2(
       int rowCount,
       int nullCount,
@@ -1108,6 +1156,54 @@ public class ParquetFileWriter implements AutoCloseable {
         definitionLevels,
         dataEncoding,
         compressedData,
+        true, /* compressed by default */
+        uncompressedDataSize,
+        statistics,
+        metadataBlockEncryptor,
+        pageHeaderAAD,
+        null);
+  }
+
+  /**
+   * Writes a single v2 data page
+   *
+   * @param rowCount               count of rows
+   * @param nullCount              count of nulls
+   * @param valueCount             count of values
+   * @param repetitionLevels       repetition level bytes
+   * @param definitionLevels       definition level bytes
+   * @param dataEncoding           encoding for data
+   * @param bytes                  data bytes
+   * @param compressed             whether the data bytes is compressed
+   * @param uncompressedDataSize   the size of uncompressed data
+   * @param statistics             the statistics of the page
+   * @param metadataBlockEncryptor encryptor for block data
+   * @param pageHeaderAAD          pageHeader AAD
+   * @throws IOException if any I/O error occurs during writing the file
+   */
+  public void writeDataPageV2(
+      int rowCount,
+      int nullCount,
+      int valueCount,
+      BytesInput repetitionLevels,
+      BytesInput definitionLevels,
+      Encoding dataEncoding,
+      BytesInput bytes,
+      boolean compressed,
+      int uncompressedDataSize,
+      Statistics<?> statistics,
+      BlockCipher.Encryptor metadataBlockEncryptor,
+      byte[] pageHeaderAAD)
+      throws IOException {
+    writeDataPageV2(
+        rowCount,
+        nullCount,
+        valueCount,
+        repetitionLevels,
+        definitionLevels,
+        dataEncoding,
+        bytes,
+        compressed,
         uncompressedDataSize,
         statistics,
         metadataBlockEncryptor,
@@ -1131,7 +1227,9 @@ public class ParquetFileWriter implements AutoCloseable {
    * @param pageHeaderAAD pageHeader AAD
    * @param sizeStatistics size statistics for the page
    * @throws IOException if any I/O error occurs during writing the file
+   * @deprecated will be removed in 2.0.0. Use {@link ParquetFileWriter#writeDataPageV2(int, int, int, BytesInput, BytesInput, Encoding, BytesInput, boolean, int, Statistics, BlockCipher.Encryptor, byte[], SizeStatistics)} instead
    */
+  @Deprecated
   public void writeDataPageV2(
       int rowCount,
       int nullCount,
@@ -1146,12 +1244,60 @@ public class ParquetFileWriter implements AutoCloseable {
       byte[] pageHeaderAAD,
       SizeStatistics sizeStatistics)
       throws IOException {
+    writeDataPageV2(
+        rowCount,
+        nullCount,
+        valueCount,
+        repetitionLevels,
+        definitionLevels,
+        dataEncoding,
+        compressedData,
+        true, /* compressed by default */
+        uncompressedDataSize,
+        statistics,
+        metadataBlockEncryptor,
+        pageHeaderAAD,
+        sizeStatistics);
+  }
+
+  /**
+   * Writes a single v2 data page
+   *
+   * @param rowCount count of rows
+   * @param nullCount count of nulls
+   * @param valueCount count of values
+   * @param repetitionLevels repetition level bytes
+   * @param definitionLevels definition level bytes
+   * @param dataEncoding encoding for data
+   * @param bytes data bytes
+   * @param compressed whether the data bytes is compressed
+   * @param uncompressedDataSize the size of uncompressed data
+   * @param statistics the statistics of the page
+   * @param metadataBlockEncryptor encryptor for block data
+   * @param pageHeaderAAD pageHeader AAD
+   * @param sizeStatistics size statistics for the page
+   * @throws IOException if any I/O error occurs during writing the file
+   */
+  public void writeDataPageV2(
+      int rowCount,
+      int nullCount,
+      int valueCount,
+      BytesInput repetitionLevels,
+      BytesInput definitionLevels,
+      Encoding dataEncoding,
+      BytesInput bytes,
+      boolean compressed,
+      int uncompressedDataSize,
+      Statistics<?> statistics,
+      BlockCipher.Encryptor metadataBlockEncryptor,
+      byte[] pageHeaderAAD,
+      SizeStatistics sizeStatistics)
+      throws IOException {
     state = state.write();
     int rlByteLength = toIntWithCheck(repetitionLevels.size(), "page repetition levels");
     int dlByteLength = toIntWithCheck(definitionLevels.size(), "page definition levels");
 
-    int compressedSize =
-        toIntWithCheck(compressedData.size() + repetitionLevels.size() + definitionLevels.size(), "page");
+    int compressedSize = toIntWithCheck(bytes.size() + repetitionLevels.size() + definitionLevels.size(), "page");
 
     int uncompressedSize =
         toIntWithCheck(uncompressedDataSize + repetitionLevels.size() + definitionLevels.size(), "page");
@@ -1169,8 +1315,8 @@ public class ParquetFileWriter implements AutoCloseable {
       if (definitionLevels.size() > 0) {
         crcUpdate(definitionLevels);
       }
-      if (compressedData.size() > 0) {
-        crcUpdate(compressedData);
+      if (bytes.size() > 0) {
+        crcUpdate(bytes);
       }
       metadataConverter.writeDataPageV2Header(
           uncompressedSize,
@@ -1181,6 +1327,7 @@ public class ParquetFileWriter implements AutoCloseable {
           dataEncoding,
           rlByteLength,
           dlByteLength,
+          compressed,
           (int) crc.getValue(),
           out,
           metadataBlockEncryptor,
@@ -1195,6 +1342,7 @@ public class ParquetFileWriter implements AutoCloseable {
           dataEncoding,
           rlByteLength,
           dlByteLength,
+          compressed,
           out,
           metadataBlockEncryptor,
           pageHeaderAAD);
@@ -1209,7 +1357,7 @@ public class ParquetFileWriter implements AutoCloseable {
     currentEncodings.add(dataEncoding);
     encodingStatsBuilder.addDataEncoding(dataEncoding);
 
-    BytesInput.concat(repetitionLevels, definitionLevels, compressedData).writeAllTo(out);
+    BytesInput.concat(repetitionLevels, definitionLevels, bytes).writeAllTo(out);
 
     offsetIndexBuilder.add(
         toIntWithCheck(out.getPos() - beforeHeader, "page"),

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -737,7 +737,7 @@ public class ParquetRewriter implements Closeable {
               encryptColumn,
               dataEncryptor,
               dataPageAAD);
-          boolean compressed = compressor != null;
+          boolean compressed = compressor != null || headerV2.is_compressed;
           statistics = convertStatistics(
               originalCreatedBy,
               normalizeNameInType(chunk.getPrimitiveType()),

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -737,7 +737,6 @@ public class ParquetRewriter implements Closeable {
               encryptColumn,
               dataEncryptor,
               dataPageAAD);
-          boolean compressed = compressor != null || headerV2.is_compressed;
           statistics = convertStatistics(
               originalCreatedBy,
               normalizeNameInType(chunk.getPrimitiveType()),
@@ -763,7 +762,7 @@ public class ParquetRewriter implements Closeable {
               dlLevels,
               converter.getEncoding(headerV2.getEncoding()),
               BytesInput.from(pageLoad),
-              compressed,
+              headerV2.is_compressed,
               rawDataLength,
               statistics,
               metaEncryptor,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -737,6 +737,7 @@ public class ParquetRewriter implements Closeable {
               encryptColumn,
               dataEncryptor,
               dataPageAAD);
+          boolean compressed = compressor != null;
           statistics = convertStatistics(
               originalCreatedBy,
               normalizeNameInType(chunk.getPrimitiveType()),
@@ -762,6 +763,7 @@ public class ParquetRewriter implements Closeable {
               dlLevels,
               converter.getEncoding(headerV2.getEncoding()),
               BytesInput.from(pageLoad),
+              compressed,
               rawDataLength,
               statistics,
               metaEncryptor,

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -513,15 +513,15 @@ public class TestParquetFileWriter {
 
     w.startColumn(C1, 6, CODEC);
     long c1Starts = w.getPos();
-    w.writeDataPageV2(4, 1, 3, repLevels, defLevels, PLAIN, data, 4, statsC1P1);
-    w.writeDataPageV2(3, 0, 3, repLevels, defLevels, PLAIN, data, 4, statsC1P2);
+    w.writeDataPageV2(4, 1, 3, repLevels, defLevels, PLAIN, data, false, 4, statsC1P1);
+    w.writeDataPageV2(3, 0, 3, repLevels, defLevels, PLAIN, data, false, 4, statsC1P2);
     w.endColumn();
     long c1Ends = w.getPos();
 
     w.startColumn(C2, 5, CODEC);
     long c2Starts = w.getPos();
-    w.writeDataPageV2(5, 2, 3, repLevels, defLevels, PLAIN, data2, 4, EMPTY_STATS);
-    w.writeDataPageV2(2, 0, 2, repLevels, defLevels, PLAIN, data2, 4, EMPTY_STATS);
+    w.writeDataPageV2(5, 2, 3, repLevels, defLevels, PLAIN, data2, false, 4, EMPTY_STATS);
+    w.writeDataPageV2(2, 0, 2, repLevels, defLevels, PLAIN, data2, false, 4, EMPTY_STATS);
     w.endColumn();
     long c2Ends = w.getPos();
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Fixes #3122 

### What changes are included in this PR?

Set `is_compressed` to false and `compressed_page_size` to 0 for the V2 page with no data size.

### Are these changes tested?

Yes, new UTs.

### Are there any user-facing changes?

No.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
