### PR TITLE
GH-3163: Reduce memory and time overhead of ParquetRewriterTests

### DIFF
--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -122,7 +122,9 @@ public class ParquetRewriterTest {
   private final EncryptionTestFile gzipEncryptionTestFileWithoutBloomFilterColumn;
   private final EncryptionTestFile uncompressedEncryptionTestFileWithoutBloomFilterColumn;
 
-  @Parameterized.Parameters(name = "WriterVersion = {0}, IndexCacheStrategy = {1}, UsingHadoop = {2}, numRecord = {3}, rowsPerPage = {4}")
+  @Parameterized.Parameters(
+      name =
+          "WriterVersion = {0}, IndexCacheStrategy = {1}, UsingHadoop = {2}, numRecord = {3}, rowsPerPage = {4}")
   public static Object[][] parameters() {
     final int DefaultNumRecord = 10000;
     final int DefaultRowsPerPage = DefaultNumRecord / 5;
@@ -134,7 +136,8 @@ public class ParquetRewriterTest {
     };
   }
 
-  public ParquetRewriterTest(String writerVersion, String indexCacheStrategy, boolean _usingHadoop, int _numRecord, int rowsPerPage)
+  public ParquetRewriterTest(
+      String writerVersion, String indexCacheStrategy, boolean _usingHadoop, int _numRecord, int rowsPerPage)
       throws IOException {
     this.writerVersion = ParquetProperties.WriterVersion.fromString(writerVersion);
     this.indexCacheStrategy = IndexCache.CacheStrategy.valueOf(indexCacheStrategy);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -107,7 +107,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class ParquetRewriterTest {
 
-  private final int numRecord = 100000;
+  private final int numRecord = 10000;
   private final Configuration conf = new Configuration();
   private final ParquetConfiguration parquetConf = new PlainParquetConfiguration();
   private final ParquetProperties.WriterVersion writerVersion;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Reduce the memory overhead and the time taken to run ParquetRewriterTests

### What changes are included in this PR?
Reducing number of records from 100000 to 10000

### Are these changes tested?


### Are there any user-facing changes?
No

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #GH-3163
