### PR TITLE
GH-3141: Add constructor to ParquetFileReader to allow passing in parquet footer

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -744,7 +744,7 @@ public class ParquetFileReader implements Closeable {
     return new ParquetFileReader(file, footer, options, f);
   }
 
-  protected final SeekableInputStream f;
+  protected SeekableInputStream f;
   private final InputFile file;
   private final ParquetReadOptions options;
   private final Map<ColumnPath, ColumnDescriptor> paths = new HashMap<>();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -960,7 +960,7 @@ public class ParquetFileReader implements Closeable {
       this.footer = readFooter(file, options, f, converter);
     } catch (IOException e) {
       // In case that reading footer throws an exception in the constructor, the new stream
-	    // should be closed. Otherwise, there's no way to close this outside.
+      // should be closed. Otherwise, there's no way to close this outside.
       f.close();
       throw e;
     }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -958,7 +958,7 @@ public class ParquetFileReader implements Closeable {
     this.options = options;
     try {
       this.footer = readFooter(file, options, f, converter);
-    } catch (IOException e) {
+    } catch (Exception e) {
       // In case that reading footer throws an exception in the constructor, the new stream
       // should be closed. Otherwise, there's no way to close this outside.
       f.close();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -931,18 +931,16 @@ public class ParquetFileReader implements Closeable {
   }
 
   public ParquetFileReader(InputFile file, ParquetReadOptions options, SeekableInputStream f) throws IOException {
+    this(file, readFooter(file, options, f, new ParquetMetadataConverter(options)), options, f);
+  }
+
+  public ParquetFileReader(InputFile file, ParquetMetadata footer,ParquetReadOptions options, SeekableInputStream f) throws IOException {
     this.converter = new ParquetMetadataConverter(options);
     this.file = file;
     this.f = f;
     this.options = options;
-    try {
-      this.footer = readFooter(file, options, f, converter);
-    } catch (Exception e) {
-      // In case that reading footer throws an exception in the constructor, the new stream
-      // should be closed. Otherwise, there's no way to close this outside.
-      f.close();
-      throw e;
-    }
+    this.footer = footer;
+
     this.fileMetaData = footer.getFileMetaData();
     this.fileDecryptor = fileMetaData.getFileDecryptor(); // must be called before filterRowGroups!
     if (null != fileDecryptor && fileDecryptor.plaintextFile()) {


### PR DESCRIPTION
### Rationale for this change
HadoopFile is getting deprecated, it is useful to be able to pass in a parsed footer instead of reading the footer every time

### What changes are included in this PR?
a new constructor

### Are these changes tested?
Yes

### Are there any user-facing changes?
No

Some code duplication is there, because we cant call another constructor and catch the IOException to close the stream. Let me know if you would like this handled in another way. Thanks. 

Closes #3141
