### PR TITLE
GH-3168: Restrict trusted packages in the parquet-avro module

### DIFF
--- a/parquet-avro/src/test/java/org/apache/parquet/UntrustedStringableClass.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/UntrustedStringableClass.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet;
+
+public class UntrustedStringableClass {
+  private final String value;
+
+  public UntrustedStringableClass(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public String toString() {
+    return this.value;
+  }
+}

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java
@@ -37,6 +37,7 @@ import org.apache.avro.reflect.Stringable;
 import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.UntrustedStringableClass;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -74,6 +75,40 @@ public class TestReflectReadWrite {
       }
       assertNull(reader.read());
     }
+  }
+
+  @Test(expected = SecurityException.class)
+  public void testUntrustedStringableClass() {
+    new AvroConverters.FieldStringableConverter(
+        new ParentValueContainer() {
+          @Override
+          public void add(Object value) {}
+
+          @Override
+          public void addBoolean(boolean value) {}
+
+          @Override
+          public void addInt(int value) {}
+
+          @Override
+          public void addLong(long value) {}
+
+          @Override
+          public void addFloat(float value) {}
+
+          @Override
+          public void addDouble(double value) {}
+
+          @Override
+          public void addChar(char value) {}
+
+          @Override
+          public void addByte(byte value) {}
+
+          @Override
+          public void addShort(short value) {}
+        },
+        UntrustedStringableClass.class);
   }
 
   private GenericRecord getGenericPojoUtf8() {


### PR DESCRIPTION
### Rationale for this change

See the Avro parity: https://github.com/apache/avro/pull/2934

### What changes are included in this PR?

### Are these changes tested?

### Are there any user-facing changes?

Closes #3168
