### PR TITLE
GH-3172: Do not drop blocks with some null values if `DictionaryFilter` is applied for `UserDefinedPredicate` which keeps null values

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilter.java
@@ -529,6 +529,10 @@ public class DictionaryFilter implements FilterPredicate.Visitor<Boolean> {
       return BLOCK_MIGHT_MATCH;
     }
 
+    if (udp.acceptsNullValue()) {
+      return BLOCK_MIGHT_MATCH;
+    }
+
     try {
       Set<T> dictSet = expandDictionary(meta);
       if (dictSet == null) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
@@ -676,15 +676,13 @@ public class DictionaryFilterTest {
 
   @Test
   public void testNullAcceptingUdp() throws Exception {
-    InInt32UDP drop42DenyNulls = new InInt32UDP(Sets.newHashSet( 205));
+    InInt32UDP drop42DenyNulls = new InInt32UDP(Sets.newHashSet(205));
     InInt32UDP drop42AcceptNulls = new InInt32UDP(Sets.newHashSet(null, 205));
 
     // A column with value 42 and 10% nulls
     IntColumn intColumnWithNulls = intColumn("optional_single_value_int32_field");
 
-    assertTrue(
-        "Should drop block",
-        canDrop(userDefined(intColumnWithNulls, drop42DenyNulls), ccmd, dictionaries));
+    assertTrue("Should drop block", canDrop(userDefined(intColumnWithNulls, drop42DenyNulls), ccmd, dictionaries));
     assertFalse(
         "Should not drop block for null accepting udp",
         canDrop(userDefined(intColumnWithNulls, drop42AcceptNulls), ccmd, dictionaries));

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
@@ -120,39 +120,39 @@ public class DictionaryFilterTest {
 
   private static final String ALPHABET = "abcdefghijklmnopqrstuvwxyz";
   private static final int[] intValues = new int[] {
-      -100, 302, 3333333, 7654321, 1234567, -2000, -77775, 0, 75, 22223,
-      77, 22221, -444443, 205, 12, 44444, 889, 66665, -777889, -7,
-      52, 33, -257, 1111, 775, 26
+    -100, 302, 3333333, 7654321, 1234567, -2000, -77775, 0, 75, 22223,
+    77, 22221, -444443, 205, 12, 44444, 889, 66665, -777889, -7,
+    52, 33, -257, 1111, 775, 26
   };
   private static final long[] longValues = new long[] {
-      -100L, 302L, 3333333L, 7654321L, 1234567L, -2000L, -77775L, 0L, 75L, 22223L, 77L, 22221L, -444443L, 205L, 12L,
-      44444L, 889L, 66665L, -777889L, -7L, 52L, 33L, -257L, 1111L, 775L, 26L
+    -100L, 302L, 3333333L, 7654321L, 1234567L, -2000L, -77775L, 0L, 75L, 22223L, 77L, 22221L, -444443L, 205L, 12L,
+    44444L, 889L, 66665L, -777889L, -7L, 52L, 33L, -257L, 1111L, 775L, 26L
   };
   private static final Binary[] DECIMAL_VALUES = new Binary[] {
-      toBinary("-9999999999999999999999999999999999999999", 17),
-      toBinary("-9999999999999999999999999999999999999998", 17),
-      toBinary(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE), 17),
-      toBinary(BigInteger.valueOf(Long.MIN_VALUE), 17),
-      toBinary(BigInteger.valueOf(Long.MIN_VALUE).add(BigInteger.ONE), 17),
-      toBinary("-1", 17),
-      toBinary("0", 17),
-      toBinary(BigInteger.valueOf(Long.MAX_VALUE).subtract(BigInteger.ONE), 17),
-      toBinary(BigInteger.valueOf(Long.MAX_VALUE), 17),
-      toBinary(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE), 17),
-      toBinary("999999999999999999999999999999999999999", 17),
-      toBinary("9999999999999999999999999999999999999998", 17),
-      toBinary("9999999999999999999999999999999999999999", 17)
+    toBinary("-9999999999999999999999999999999999999999", 17),
+    toBinary("-9999999999999999999999999999999999999998", 17),
+    toBinary(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE), 17),
+    toBinary(BigInteger.valueOf(Long.MIN_VALUE), 17),
+    toBinary(BigInteger.valueOf(Long.MIN_VALUE).add(BigInteger.ONE), 17),
+    toBinary("-1", 17),
+    toBinary("0", 17),
+    toBinary(BigInteger.valueOf(Long.MAX_VALUE).subtract(BigInteger.ONE), 17),
+    toBinary(BigInteger.valueOf(Long.MAX_VALUE), 17),
+    toBinary(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE), 17),
+    toBinary("999999999999999999999999999999999999999", 17),
+    toBinary("9999999999999999999999999999999999999998", 17),
+    toBinary("9999999999999999999999999999999999999999", 17)
   };
   private static final Binary[] INT96_VALUES = new Binary[] {
-      toBinary("-9999999999999999999999999999", 12),
-      toBinary("-9999999999999999999999999998", 12),
-      toBinary("-1234567890", 12),
-      toBinary("-1", 12),
-      toBinary("-0", 12),
-      toBinary("1", 12),
-      toBinary("1234567890", 12),
-      toBinary("-9999999999999999999999999998", 12),
-      toBinary("9999999999999999999999999999", 12)
+    toBinary("-9999999999999999999999999999", 12),
+    toBinary("-9999999999999999999999999998", 12),
+    toBinary("-1234567890", 12),
+    toBinary("-1", 12),
+    toBinary("-0", 12),
+    toBinary("1", 12),
+    toBinary("1234567890", 12),
+    toBinary("-9999999999999999999999999998", 12),
+    toBinary("9999999999999999999999999999", 12)
   };
 
   private static Binary toBinary(String decimalWithoutScale, int byteCount) {


### PR DESCRIPTION
### Rationale for this change

Fix for https://github.com/apache/parquet-java/issues/3172

### What changes are included in this PR?

Adding an explicit check for the existence of null values in the block if 'UserDefinedPredicate' accepts nulls. If null values exist and the predicate accepts nulls, the block cannot be dropped. 

### Are these changes tested?

Yes, a new test was created.

### Are there any user-facing changes?

No.

Closes #3172
