### PR TITLE
[MINOR] Enable jitpack.io repo only when brotli is required

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -230,6 +230,13 @@
           <arch>!aarch64</arch>
         </os>
       </activation>
+      <repositories>
+        <repository>
+          <id>jitpack.io</id>
+          <url>https://jitpack.io</url>
+          <name>Jitpack.io repository</name>
+        </repository>
+      </repositories>
       <dependencies>
         <dependency>
           <groupId>com.github.rdblue</groupId>

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -235,6 +235,7 @@
           <id>jitpack.io</id>
           <url>https://jitpack.io</url>
           <name>Jitpack.io repository</name>
+          <!-- needed for brotli-codec -->
         </repository>
       </repositories>
       <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -69,15 +69,6 @@
     </mailingList>
   </mailingLists>
 
-  <repositories>
-    <repository>
-      <id>jitpack.io</id>
-      <url>https://jitpack.io</url>
-      <name>Jitpack.io repository</name>
-      <!-- needed for brotli-codec -->
-    </repository>
-  </repositories>
-
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

`jitpack.io` Maven repo was added globally but for conditionally `brotli-codec`, my network is very slow to access `jitpack.io` and I'm using an Apple Silicon machine which does not support `brotli-codec`, it causes a fresh `mvn install` very slow due to each jar pull will try `jitpack.io`(I don't understand why Maven does not try Maven Central first ...)

### What changes are included in this PR?

Move `jitpack.io` Maven repo definition from global to profile `non-aarch64`.

### Are these changes tested?

Pass GHA.

### Are there any user-facing changes?

No.
<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
