### PR TITLE
MINOR: Fix display of logicalTypeAnnotation for parquet cli

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/util/RawUtils.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/util/RawUtils.java
@@ -103,8 +103,8 @@ public class RawUtils {
   static class LogicalTypeAnnotationJsonSerializer extends JsonSerializer<LogicalTypeAnnotation> {
 
     @Override
-    public void serialize(
-        LogicalTypeAnnotation value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+    public void serialize(LogicalTypeAnnotation value, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
       gen.writeString(value.toString());
     }
   }

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/util/RawUtils.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/util/RawUtils.java
@@ -22,9 +22,14 @@ import static org.apache.parquet.bytes.BytesUtils.readIntLittleEndian;
 import static org.apache.parquet.hadoop.ParquetFileWriter.EFMAGIC;
 import static org.apache.parquet.hadoop.ParquetFileWriter.MAGIC;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.module.SimpleSerializers;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,6 +39,7 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.format.FileMetaData;
 import org.apache.parquet.format.Util;
 import org.apache.parquet.io.SeekableInputStream;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 
 public class RawUtils {
 
@@ -79,6 +85,27 @@ public class RawUtils {
     mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     mapper.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
     mapper.registerModule(new JavaTimeModule());
+    mapper.registerModule(new ParquetModule());
     return mapper;
+  }
+
+  static class ParquetModule extends SimpleModule {
+
+    @Override
+    public void setupModule(SetupContext context) {
+      super.setupModule(context);
+      SimpleSerializers sers = new SimpleSerializers();
+      sers.addSerializer(LogicalTypeAnnotation.class, new LogicalTypeAnnotationJsonSerializer());
+      context.addSerializers(sers);
+    }
+  }
+
+  static class LogicalTypeAnnotationJsonSerializer extends JsonSerializer<LogicalTypeAnnotation> {
+
+    @Override
+    public void serialize(
+        LogicalTypeAnnotation value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+      gen.writeString(value.toString());
+    }
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

I found the partial output of `parquet footer xxx.parquet` is incorrect, for example,
```
"logicalTypeAnnotation" : { }
```
while the value is actually a `DateLogicalTypeAnnotation`

### What changes are included in this PR?

Supply a custom `JsonSerializer` for `LogicalTypeAnnotation`

### Are these changes tested?

Currently, there is no output verification for parquet-cli modules, I manually checked the output of `org.apache.parquet.cli.commands.ShowFooterCommandTest`

```patch
      }, {
        "name" : "date_field",
        "repetition" : "REQUIRED",
-       "logicalTypeAnnotation" : { },
+       "logicalTypeAnnotation" : "DATE",
        "id" : null,
        "primitive" : "INT32",
        "length" : 0,
        "decimalMeta" : null,
        "columnOrder" : {
          "columnOrderName" : "TYPE_DEFINED_ORDER"
        }
      } ],
```

### Are there any user-facing changes?

Only affects the output of parquet-cli.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
