### PR TITLE
PARQUET-2249: Add column order for IEEE 754 total order

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/ColumnOrder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/ColumnOrder.java
@@ -36,11 +36,16 @@ public class ColumnOrder {
     /**
      * Type defined order meaning that the comparison order of the elements are based on its type.
      */
-    TYPE_DEFINED_ORDER
+    TYPE_DEFINED_ORDER,
+    /**
+     * The column order is defined by the IEEE 754 standard.
+     */
+    IEEE_754_TOTAL_ORDER,
   }
 
   private static final ColumnOrder UNDEFINED_COLUMN_ORDER = new ColumnOrder(ColumnOrderName.UNDEFINED);
   private static final ColumnOrder TYPE_DEFINED_COLUMN_ORDER = new ColumnOrder(ColumnOrderName.TYPE_DEFINED_ORDER);
+  private static final ColumnOrder IEEE_754_TOTAL_ORDER = new ColumnOrder(ColumnOrderName.IEEE_754_TOTAL_ORDER);
 
   /**
    * @return a {@link ColumnOrder} instance representing an undefined order
@@ -56,6 +61,14 @@ public class ColumnOrder {
    */
   public static ColumnOrder typeDefined() {
     return TYPE_DEFINED_COLUMN_ORDER;
+  }
+
+  /**
+   * @return a {@link ColumnOrder} instance representing an IEEE 754 total order
+   * @see ColumnOrderName#IEEE_754_TOTAL_ORDER
+   */
+  public static ColumnOrder ieee754TotalOrder() {
+    return IEEE_754_TOTAL_ORDER;
   }
 
   private final ColumnOrderName columnOrderName;

--- a/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
@@ -20,6 +20,7 @@ package org.apache.parquet.schema;
 
 import static java.util.Arrays.asList;
 import static java.util.Optional.empty;
+import static org.apache.parquet.schema.ColumnOrder.ColumnOrderName.IEEE_754_TOTAL_ORDER;
 import static org.apache.parquet.schema.ColumnOrder.ColumnOrderName.TYPE_DEFINED_ORDER;
 import static org.apache.parquet.schema.ColumnOrder.ColumnOrderName.UNDEFINED;
 import static org.apache.parquet.schema.PrimitiveStringifier.TIMESTAMP_MICROS_STRINGIFIER;
@@ -1050,6 +1051,13 @@ public abstract class LogicalTypeAnnotation {
     @Override
     PrimitiveStringifier valueStringifier(PrimitiveType primitiveType) {
       return PrimitiveStringifier.FLOAT16_STRINGIFIER;
+    }
+
+    @Override
+    boolean isValidColumnOrder(ColumnOrder columnOrder) {
+      return columnOrder.getColumnOrderName() == UNDEFINED
+          || columnOrder.getColumnOrderName() == TYPE_DEFINED_ORDER
+          || columnOrder.getColumnOrderName() == IEEE_754_TOTAL_ORDER;
     }
   }
 

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveComparator.java
@@ -293,4 +293,65 @@ public abstract class PrimitiveComparator<T> implements Comparator<T>, Serializa
       return "BINARY_AS_FLOAT16_COMPARATOR";
     }
   };
+
+  static final PrimitiveComparator<Float> FLOAT_IEEE_754_TOTAL_ORDER_COMPARATOR = new PrimitiveComparator<Float>() {
+    @Override
+    int compareNotNulls(Float o1, Float o2) {
+      return compare(o1.floatValue(), o2.floatValue());
+    }
+
+    @Override
+    public int compare(float f1, float f2) {
+      int f1Int = Float.floatToRawIntBits(f1);
+      int f2Int = Float.floatToRawIntBits(f2);
+      f1Int ^= ((f1Int >> 31) >>> 1);
+      f2Int ^= ((f2Int >> 31) >>> 1);
+      return Integer.compare(f1Int, f2Int);
+    }
+
+    @Override
+    public String toString() {
+      return "FLOAT_IEEE_754_TOTAL_ORDER_COMPARATOR";
+    }
+  };
+
+  static final PrimitiveComparator<Double> DOUBLE_IEEE_754_TOTAL_ORDER_COMPARATOR =
+      new PrimitiveComparator<Double>() {
+        @Override
+        int compareNotNulls(Double o1, Double o2) {
+          return compare(o1.doubleValue(), o2.doubleValue());
+        }
+
+        @Override
+        public int compare(double d1, double d2) {
+          long d1Long = Double.doubleToRawLongBits(d1);
+          long d2Long = Double.doubleToRawLongBits(d2);
+          d1Long ^= ((d1Long >> 63) >>> 1);
+          d2Long ^= ((d2Long >> 63) >>> 1);
+          return Long.compare(d1Long, d2Long);
+        }
+
+        @Override
+        public String toString() {
+          return "DOUBLE_IEEE_754_TOTAL_ORDER_COMPARATOR";
+        }
+      };
+
+  static final PrimitiveComparator<Binary> BINARY_AS_FLOAT16_IEEE_754_TOTAL_ORDER_COMPARATOR =
+      new BinaryComparator() {
+
+        @Override
+        int compareBinary(Binary b1, Binary b2) {
+          int b1Short = b1.get2BytesLittleEndian();
+          int b2Short = b2.get2BytesLittleEndian();
+          b1Short ^= ((b1Short >> 15) >>> 1);
+          b2Short ^= ((b2Short >> 15) >>> 1);
+          return Integer.compare(b1Short, b2Short);
+        }
+
+        @Override
+        public String toString() {
+          return "BINARY_AS_FLOAT16_IEEE_754_TOTAL_ORDER_COMPARATOR";
+        }
+      };
 }

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
@@ -88,7 +88,7 @@ public final class PrimitiveType extends Type {
       }
 
       @Override
-      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType) {
+      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder) {
         if (logicalType == null) {
           return PrimitiveComparator.SIGNED_INT64_COMPARATOR;
         }
@@ -146,7 +146,7 @@ public final class PrimitiveType extends Type {
       }
 
       @Override
-      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType) {
+      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder) {
         if (logicalType == null) {
           return PrimitiveComparator.SIGNED_INT32_COMPARATOR;
         }
@@ -210,7 +210,7 @@ public final class PrimitiveType extends Type {
       }
 
       @Override
-      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType) {
+      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder) {
         return PrimitiveComparator.BOOLEAN_COMPARATOR;
       }
     },
@@ -236,7 +236,7 @@ public final class PrimitiveType extends Type {
       }
 
       @Override
-      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType) {
+      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder) {
         if (logicalType == null) {
           return PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR;
         }
@@ -310,8 +310,10 @@ public final class PrimitiveType extends Type {
       }
 
       @Override
-      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType) {
-        return PrimitiveComparator.FLOAT_COMPARATOR;
+      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder) {
+        return columnOrder.getColumnOrderName() == ColumnOrderName.IEEE_754_TOTAL_ORDER
+            ? PrimitiveComparator.FLOAT_IEEE_754_TOTAL_ORDER_COMPARATOR
+            : PrimitiveComparator.FLOAT_COMPARATOR;
       }
     },
     DOUBLE("getDouble", Double.TYPE) {
@@ -336,8 +338,10 @@ public final class PrimitiveType extends Type {
       }
 
       @Override
-      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType) {
-        return PrimitiveComparator.DOUBLE_COMPARATOR;
+      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder) {
+        return columnOrder.getColumnOrderName() == ColumnOrderName.IEEE_754_TOTAL_ORDER
+            ? PrimitiveComparator.DOUBLE_IEEE_754_TOTAL_ORDER_COMPARATOR
+            : PrimitiveComparator.DOUBLE_COMPARATOR;
       }
     },
     INT96("getBinary", Binary.class) {
@@ -362,7 +366,7 @@ public final class PrimitiveType extends Type {
       }
 
       @Override
-      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType) {
+      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder) {
         return PrimitiveComparator.BINARY_AS_SIGNED_INTEGER_COMPARATOR;
       }
     },
@@ -388,8 +392,13 @@ public final class PrimitiveType extends Type {
       }
 
       @Override
-      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType) {
+      PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder) {
         if (logicalType == null) {
+          return PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR;
+        }
+
+        if (logicalType.getType() == LogicalTypeAnnotation.LogicalTypeToken.FLOAT16
+            && columnOrder.getColumnOrderName() == ColumnOrderName.IEEE_754_TOTAL_ORDER) {
           return PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR;
         }
 
@@ -453,7 +462,7 @@ public final class PrimitiveType extends Type {
 
     public abstract <T, E extends Exception> T convert(PrimitiveTypeNameConverter<T, E> converter) throws E;
 
-    abstract PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType);
+    abstract PrimitiveComparator<?> comparator(LogicalTypeAnnotation logicalType, ColumnOrder columnOrder);
   }
 
   private final PrimitiveTypeName primitive;
@@ -545,6 +554,12 @@ public final class PrimitiveType extends Type {
       columnOrder = primitive == PrimitiveTypeName.INT96 || originalType == OriginalType.INTERVAL
           ? ColumnOrder.undefined()
           : ColumnOrder.typeDefined();
+    } else if (columnOrder.getColumnOrderName() == ColumnOrderName.IEEE_754_TOTAL_ORDER) {
+      Preconditions.checkArgument(
+          primitive == PrimitiveTypeName.FLOAT || primitive == PrimitiveTypeName.DOUBLE,
+          "The column order %s is not supported by type %s",
+          columnOrder,
+          primitive);
     }
     this.columnOrder = requireValidColumnOrder(columnOrder);
   }
@@ -591,6 +606,17 @@ public final class PrimitiveType extends Type {
               || logicalTypeAnnotation instanceof LogicalTypeAnnotation.IntervalLogicalTypeAnnotation
           ? ColumnOrder.undefined()
           : ColumnOrder.typeDefined();
+    } else if (columnOrder.getColumnOrderName() == ColumnOrderName.IEEE_754_TOTAL_ORDER) {
+      Preconditions.checkArgument(
+          primitive == PrimitiveTypeName.FLOAT
+              || primitive == PrimitiveTypeName.DOUBLE
+              || (logicalTypeAnnotation != null
+                  && logicalTypeAnnotation.getType()
+                      == LogicalTypeAnnotation.LogicalTypeToken.FLOAT16),
+          "The column order %s is not supported by type %s logical type %s",
+          columnOrder,
+          primitive,
+          logicalTypeAnnotation);
     }
     this.columnOrder = requireValidColumnOrder(columnOrder);
   }
@@ -629,6 +655,15 @@ public final class PrimitiveType extends Type {
    */
   public PrimitiveType withLogicalTypeAnnotation(LogicalTypeAnnotation logicalType) {
     return new PrimitiveType(getRepetition(), primitive, length, getName(), logicalType, getId());
+  }
+
+  /**
+   * @param columnOrder the column order
+   * @return the same type with the column order set
+   */
+  public Type withColumnOrder(ColumnOrder columnOrder) {
+    return new PrimitiveType(
+        getRepetition(), primitive, length, getName(), getLogicalTypeAnnotation(), getId(), columnOrder);
   }
 
   /**
@@ -845,7 +880,7 @@ public final class PrimitiveType extends Type {
    */
   @SuppressWarnings("unchecked")
   public <T> PrimitiveComparator<T> comparator() {
-    return (PrimitiveComparator<T>) getPrimitiveTypeName().comparator(getLogicalTypeAnnotation());
+    return (PrimitiveComparator<T>) getPrimitiveTypeName().comparator(getLogicalTypeAnnotation(), columnOrder());
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
     <hadoop.version>3.3.0</hadoop.version>
-    <parquet.format.version>2.11.0</parquet.format.version>
+    <parquet.format.version>2.12.0-SNAPSHOT</parquet.format.version>
     <previous.version>1.15.1</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>${thrift.executable}</format.thrift.executable>


### PR DESCRIPTION
### Rationale for this change

PoC implementation for the spec change: https://github.com/apache/parquet-format/pull/221

### What changes are included in this PR?

- Added a new ColumnOrder for IEEE 754 total order.
- Added comparators for Float, Double and Float16.

### Are these changes tested?

- Added test cases for comparators.
- Added test cases for metadata converter.

### Are there any user-facing changes?

Yes, users can now set the new column order but by default it is not used.

Closes #406
