### PR TITLE
PARQUET-2417: Add `geometry` and `geography` logical type annotations

### DIFF
--- a/parquet-column/pom.xml
+++ b/parquet-column/pom.xml
@@ -77,6 +77,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>${jts.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>com.carrotsearch</groupId>
       <artifactId>junit-benchmarks</artifactId>
       <version>0.7.2</version>

--- a/parquet-column/src/main/java/org/apache/parquet/column/schema/EdgeInterpolationAlgorithm.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/schema/EdgeInterpolationAlgorithm.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column.schema;
+
+/**
+ * Edge interpolation algorithm for Geography logical type
+ */
+public enum EdgeInterpolationAlgorithm {
+  SPHERICAL(0),
+  VINCENTY(1),
+  THOMAS(2),
+  ANDOYER(3),
+  KARNEY(4);
+
+  private final int value;
+
+  private EdgeInterpolationAlgorithm(int value) {
+    this.value = value;
+  }
+
+  /**
+   * Get the integer value of this enum value, as defined in the Thrift IDL.
+   */
+  public int getValue() {
+    return value;
+  }
+
+  /**
+   * Find the enum type by its integer value, as defined in the Thrift IDL.
+   * @return null if the value is not found.
+   */
+  public static EdgeInterpolationAlgorithm findByValue(int value) {
+    switch (value) {
+      case 0:
+        return SPHERICAL;
+      case 1:
+        return VINCENTY;
+      case 2:
+        return THOMAS;
+      case 3:
+        return ANDOYER;
+      case 4:
+        return KARNEY;
+      default:
+        return null;
+    }
+  }
+}

--- a/parquet-column/src/main/java/org/apache/parquet/column/schema/EdgeInterpolationAlgorithm.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/schema/EdgeInterpolationAlgorithm.java
@@ -58,7 +58,7 @@ public enum EdgeInterpolationAlgorithm {
       case 4:
         return KARNEY;
       default:
-        return null;
+        throw new IllegalArgumentException("Unrecognized EdgeInterpolationAlgorithm value: " + value);
     }
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
@@ -41,7 +41,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import org.apache.parquet.Preconditions;
-import org.apache.parquet.format.EdgeInterpolationAlgorithm;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 
 public abstract class LogicalTypeAnnotation {
   enum LogicalTypeToken {

--- a/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
@@ -1316,12 +1316,20 @@ public abstract class LogicalTypeAnnotation {
     @Override
     protected String typeParametersAsString() {
       StringBuilder sb = new StringBuilder();
+
+      boolean hasCrs = crs != null && !crs.isEmpty();
+      boolean hasEdgeAlgorithm = edgeAlgorithm != null;
+
+      if (!hasCrs && !hasEdgeAlgorithm) {
+        return ""; // Return empty string when both are empty
+      }
+
       sb.append("(");
-      if (crs != null && !crs.isEmpty()) {
+      if (hasCrs) {
         sb.append(crs);
       }
-      if (edgeAlgorithm != null) {
-        if (crs != null && !crs.isEmpty()) sb.append(",");
+      if (hasEdgeAlgorithm) {
+        if (hasCrs) sb.append(",");
         sb.append(edgeAlgorithm);
       }
       sb.append(")");

--- a/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/LogicalTypeAnnotation.java
@@ -44,6 +44,10 @@ import org.apache.parquet.Preconditions;
 import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 
 public abstract class LogicalTypeAnnotation {
+
+  public static final String DEFAULT_CRS = "OGC:CRS84";
+  public static final EdgeInterpolationAlgorithm DEFAULT_ALGO = EdgeInterpolationAlgorithm.SPHERICAL;
+
   enum LogicalTypeToken {
     MAP {
       @Override
@@ -160,14 +164,11 @@ public abstract class LogicalTypeAnnotation {
       @Override
       protected LogicalTypeAnnotation fromString(List<String> params) {
         if (params.size() > 1) {
-          throw new RuntimeException("Expecting only crs for geometry logical type, got " + params.size());
+          throw new RuntimeException(
+              "Expecting at most 1 parameter for geometry logical type, got " + params.size());
         }
-        if (params.size() == 1) {
-          String crs = params.get(0);
-          return geometryType(crs);
-        } else {
-          return geometryType();
-        }
+        String crs = params.isEmpty() ? null : params.get(0);
+        return geometryType(crs);
       }
     },
     GEOGRAPHY {
@@ -175,19 +176,13 @@ public abstract class LogicalTypeAnnotation {
       protected LogicalTypeAnnotation fromString(List<String> params) {
         if (params.size() > 2) {
           throw new RuntimeException(
-              "Expecting at most 2 parameters for geography logical type (crs and edgeAlgorithm), got "
+              "Expecting at most 2 parameters for geography logical type (crs and edge algorithm), got "
                   + params.size());
         }
-        if (params.size() == 1) {
-          String crs = params.get(0);
-          return geographyType(crs, null);
-        }
-        if (params.size() == 2) {
-          String crs = params.get(0);
-          String edgeAlgorithm = params.get(1);
-          return geographyType(crs, EdgeInterpolationAlgorithm.valueOf(edgeAlgorithm));
-        }
-        return geographyType();
+        String crs = !params.isEmpty() ? params.get(0) : null;
+        EdgeInterpolationAlgorithm algo =
+            params.size() > 1 ? EdgeInterpolationAlgorithm.valueOf(params.get(1)) : null;
+        return geographyType(crs, algo);
       }
     },
     UNKNOWN {
@@ -373,16 +368,12 @@ public abstract class LogicalTypeAnnotation {
     return new GeometryLogicalTypeAnnotation(crs);
   }
 
-  public static GeometryLogicalTypeAnnotation geometryType() {
-    return new GeometryLogicalTypeAnnotation("OGC:CRS84");
-  }
-
   public static GeographyLogicalTypeAnnotation geographyType(String crs, EdgeInterpolationAlgorithm edgeAlgorithm) {
     return new GeographyLogicalTypeAnnotation(crs, edgeAlgorithm);
   }
 
   public static GeographyLogicalTypeAnnotation geographyType() {
-    return new GeographyLogicalTypeAnnotation("OGC:CRS84", null);
+    return new GeographyLogicalTypeAnnotation(null, null);
   }
 
   public static UnknownLogicalTypeAnnotation unknownType() {
@@ -1259,9 +1250,10 @@ public abstract class LogicalTypeAnnotation {
 
     @Override
     protected String typeParametersAsString() {
-      StringBuilder sb = new StringBuilder();
-      sb.append("(").append(crs != null && !crs.isEmpty() ? crs : "").append(")");
-      return sb.toString();
+      if (crs == null || crs.isEmpty()) {
+        return "";
+      }
+      return String.format("(%s)", crs);
     }
 
     public String getCrs() {
@@ -1290,11 +1282,11 @@ public abstract class LogicalTypeAnnotation {
 
   public static class GeographyLogicalTypeAnnotation extends LogicalTypeAnnotation {
     private final String crs;
-    private final EdgeInterpolationAlgorithm edgeAlgorithm;
+    private final EdgeInterpolationAlgorithm algorithm;
 
-    private GeographyLogicalTypeAnnotation(String crs, EdgeInterpolationAlgorithm edgeAlgorithm) {
+    private GeographyLogicalTypeAnnotation(String crs, EdgeInterpolationAlgorithm algorithm) {
       this.crs = crs;
-      this.edgeAlgorithm = edgeAlgorithm;
+      this.algorithm = algorithm;
     }
 
     @Override
@@ -1315,33 +1307,20 @@ public abstract class LogicalTypeAnnotation {
 
     @Override
     protected String typeParametersAsString() {
-      StringBuilder sb = new StringBuilder();
-
       boolean hasCrs = crs != null && !crs.isEmpty();
-      boolean hasEdgeAlgorithm = edgeAlgorithm != null;
-
-      if (!hasCrs && !hasEdgeAlgorithm) {
-        return ""; // Return empty string when both are empty
+      boolean hasAlgo = algorithm != null;
+      if (!hasCrs && !hasAlgo) {
+        return "";
       }
-
-      sb.append("(");
-      if (hasCrs) {
-        sb.append(crs);
-      }
-      if (hasEdgeAlgorithm) {
-        if (hasCrs) sb.append(",");
-        sb.append(edgeAlgorithm);
-      }
-      sb.append(")");
-      return sb.toString();
+      return String.format("(%s,%s)", hasCrs ? crs : DEFAULT_CRS, hasAlgo ? algorithm : DEFAULT_ALGO);
     }
 
     public String getCrs() {
       return crs;
     }
 
-    public EdgeInterpolationAlgorithm getEdgeAlgorithm() {
-      return edgeAlgorithm;
+    public EdgeInterpolationAlgorithm getAlgorithm() {
+      return algorithm;
     }
 
     @Override
@@ -1350,12 +1329,12 @@ public abstract class LogicalTypeAnnotation {
         return false;
       }
       GeographyLogicalTypeAnnotation other = (GeographyLogicalTypeAnnotation) obj;
-      return Objects.equals(crs, other.crs) && Objects.equals(edgeAlgorithm, other.edgeAlgorithm);
+      return Objects.equals(crs, other.crs) && Objects.equals(algorithm, other.algorithm);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(crs, edgeAlgorithm);
+      return Objects.hash(crs, algorithm);
     }
 
     @Override

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java
@@ -35,6 +35,9 @@ import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
 import javax.naming.OperationNotSupportedException;
 import org.apache.parquet.io.api.Binary;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKBReader;
 
 /**
  * Class that provides string representations for the primitive values. These string values are to be used for
@@ -438,6 +441,22 @@ public abstract class PrimitiveStringifier {
       for (int i = offset, n = offset + length; i < n; ++i) {
         int value = array[i] & 0xff;
         builder.append(digit[value >>> 4]).append(digit[value & 0x0f]);
+      }
+    }
+  };
+
+  static final PrimitiveStringifier WKB_STRINGIFIER = new BinaryStringifierBase("WKB_STRINGIFIER") {
+
+    @Override
+    String stringifyNotNull(Binary value) {
+
+      Geometry geometry;
+      try {
+        WKBReader reader = new WKBReader();
+        geometry = reader.read(value.getBytesUnsafe());
+        return geometry.toText();
+      } catch (ParseException e) {
+        return BINARY_INVALID;
       }
     }
   };

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java
@@ -450,10 +450,9 @@ public abstract class PrimitiveStringifier {
     @Override
     String stringifyNotNull(Binary value) {
 
-      Geometry geometry;
       try {
         WKBReader reader = new WKBReader();
-        geometry = reader.read(value.getBytesUnsafe());
+        Geometry geometry = reader.read(value.getBytesUnsafe());
         return geometry.toText();
       } catch (ParseException e) {
         return BINARY_INVALID;

--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
@@ -271,6 +271,18 @@ public final class PrimitiveType extends Type {
                   LogicalTypeAnnotation.BsonLogicalTypeAnnotation bsonLogicalType) {
                 return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
               }
+
+              @Override
+              public Optional<PrimitiveComparator> visit(
+                  LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+                return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
+              }
+
+              @Override
+              public Optional<PrimitiveComparator> visit(
+                  LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+                return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
+              }
             })
             .orElseThrow(() -> new ShouldNeverHappenException(
                 "No comparator logic implemented for BINARY logical type: " + logicalType));

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
@@ -579,6 +579,12 @@ public class Types {
 
               @Override
               public Optional<Boolean> visit(
+                  LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+                return checkBinaryPrimitiveType(geometryLogicalType);
+              }
+
+              @Override
+              public Optional<Boolean> visit(
                   LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
                 return checkBinaryPrimitiveType(geographyLogicalType);
               }

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Types.java
@@ -577,6 +577,12 @@ public class Types {
                 return checkBinaryPrimitiveType(enumLogicalType);
               }
 
+              @Override
+              public Optional<Boolean> visit(
+                  LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+                return checkBinaryPrimitiveType(geographyLogicalType);
+              }
+
               private Optional<Boolean> checkFixedPrimitiveType(
                   int l, LogicalTypeAnnotation logicalTypeAnnotation) {
                 Preconditions.checkState(

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -1481,24 +1481,24 @@ public class TestTypeBuilders {
   @Test
   public void testGeometryLogicalType() {
     // Test with default CRS
-    PrimitiveType defaultCrsExpected = new PrimitiveType(
-        REQUIRED, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("OGC:CRS84"));
+    PrimitiveType defaultCrsExpected =
+        new PrimitiveType(REQUIRED, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("OGC:CRS84"));
     PrimitiveType defaultCrsActual = Types.required(BINARY)
         .as(LogicalTypeAnnotation.geometryType("OGC:CRS84"))
         .named("aGeometry");
     Assert.assertEquals(defaultCrsExpected, defaultCrsActual);
 
     // Test with custom CRS
-    PrimitiveType customCrsExpected = new PrimitiveType(
-        REQUIRED, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("EPSG:4326"));
+    PrimitiveType customCrsExpected =
+        new PrimitiveType(REQUIRED, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("EPSG:4326"));
     PrimitiveType customCrsActual = Types.required(BINARY)
         .as(LogicalTypeAnnotation.geometryType("EPSG:4326"))
         .named("aGeometry");
     Assert.assertEquals(customCrsExpected, customCrsActual);
 
     // Test with optional repetition
-    PrimitiveType optionalGeometryExpected = new PrimitiveType(
-        OPTIONAL, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("OGC:CRS84"));
+    PrimitiveType optionalGeometryExpected =
+        new PrimitiveType(OPTIONAL, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("OGC:CRS84"));
     PrimitiveType optionalGeometryActual = Types.optional(BINARY)
         .as(LogicalTypeAnnotation.geometryType("OGC:CRS84"))
         .named("aGeometry");
@@ -1544,11 +1544,10 @@ public class TestTypeBuilders {
   @Test
   public void testGeographyLogicalTypeWithoutEdgeInterpolationAlgorithm() {
     // Test with default CRS and no edge algorithm
-    PrimitiveType defaultCrsExpected = new PrimitiveType(
-        REQUIRED, BINARY, "aGeography", LogicalTypeAnnotation.geographyType());
-    PrimitiveType defaultCrsActual = Types.required(BINARY)
-        .as(LogicalTypeAnnotation.geographyType())
-        .named("aGeography");
+    PrimitiveType defaultCrsExpected =
+        new PrimitiveType(REQUIRED, BINARY, "aGeography", LogicalTypeAnnotation.geographyType());
+    PrimitiveType defaultCrsActual =
+        Types.required(BINARY).as(LogicalTypeAnnotation.geographyType()).named("aGeography");
     Assert.assertEquals(defaultCrsExpected, defaultCrsActual);
 
     // Test with custom CRS and no edge algorithm
@@ -1561,19 +1560,17 @@ public class TestTypeBuilders {
 
     // Test with custom CRS and edge algorithm
     PrimitiveType customCrsWithEdgeAlgorithmExpected = new PrimitiveType(
-        REQUIRED, BINARY, "aGeography",
-        LogicalTypeAnnotation.geographyType("EPSG:4326", null));
+        REQUIRED, BINARY, "aGeography", LogicalTypeAnnotation.geographyType("EPSG:4326", null));
     PrimitiveType customCrsWithEdgeAlgorithmActual = Types.required(BINARY)
         .as(LogicalTypeAnnotation.geographyType("EPSG:4326", null))
         .named("aGeography");
     Assert.assertEquals(customCrsWithEdgeAlgorithmExpected, customCrsWithEdgeAlgorithmActual);
 
     // Test with optional repetition
-    PrimitiveType optionalGeographyExpected = new PrimitiveType(
-        OPTIONAL, BINARY, "aGeography", LogicalTypeAnnotation.geographyType());
-    PrimitiveType optionalGeographyActual = Types.optional(BINARY)
-        .as(LogicalTypeAnnotation.geographyType())
-        .named("aGeography");
+    PrimitiveType optionalGeographyExpected =
+        new PrimitiveType(OPTIONAL, BINARY, "aGeography", LogicalTypeAnnotation.geographyType());
+    PrimitiveType optionalGeographyActual =
+        Types.optional(BINARY).as(LogicalTypeAnnotation.geographyType()).named("aGeography");
     Assert.assertEquals(optionalGeographyExpected, optionalGeographyActual);
   }
 

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -55,7 +55,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
-import org.apache.parquet.format.EdgeInterpolationAlgorithm;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.Repetition;
 import org.junit.Assert;

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -55,6 +55,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import org.apache.parquet.format.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.Repetition;
 import org.junit.Assert;
@@ -1475,6 +1476,105 @@ public class TestTypeBuilders {
         .as(LogicalTypeAnnotation.decimalType(3, 4))
         .precision(5)
         .named("aDecimal");
+  }
+
+  @Test
+  public void testGeometryLogicalType() {
+    // Test with default CRS
+    PrimitiveType defaultCrsExpected = new PrimitiveType(
+        REQUIRED, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("OGC:CRS84"));
+    PrimitiveType defaultCrsActual = Types.required(BINARY)
+        .as(LogicalTypeAnnotation.geometryType("OGC:CRS84"))
+        .named("aGeometry");
+    Assert.assertEquals(defaultCrsExpected, defaultCrsActual);
+
+    // Test with custom CRS
+    PrimitiveType customCrsExpected = new PrimitiveType(
+        REQUIRED, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("EPSG:4326"));
+    PrimitiveType customCrsActual = Types.required(BINARY)
+        .as(LogicalTypeAnnotation.geometryType("EPSG:4326"))
+        .named("aGeometry");
+    Assert.assertEquals(customCrsExpected, customCrsActual);
+
+    // Test with optional repetition
+    PrimitiveType optionalGeometryExpected = new PrimitiveType(
+        OPTIONAL, BINARY, "aGeometry", LogicalTypeAnnotation.geometryType("OGC:CRS84"));
+    PrimitiveType optionalGeometryActual = Types.optional(BINARY)
+        .as(LogicalTypeAnnotation.geometryType("OGC:CRS84"))
+        .named("aGeometry");
+    Assert.assertEquals(optionalGeometryExpected, optionalGeometryActual);
+  }
+
+  @Test
+  public void testGeographyLogicalType() {
+    // Test with default CRS and no edge algorithm
+    PrimitiveType defaultCrsExpected = new PrimitiveType(
+        REQUIRED, BINARY, "aGeography", LogicalTypeAnnotation.geographyType("OGC:CRS84", null));
+    PrimitiveType defaultCrsActual = Types.required(BINARY)
+        .as(LogicalTypeAnnotation.geographyType("OGC:CRS84", null))
+        .named("aGeography");
+    Assert.assertEquals(defaultCrsExpected, defaultCrsActual);
+
+    // Test with custom CRS and no edge algorithm
+    PrimitiveType customCrsExpected = new PrimitiveType(
+        REQUIRED, BINARY, "aGeography", LogicalTypeAnnotation.geographyType("EPSG:4326", null));
+    PrimitiveType customCrsActual = Types.required(BINARY)
+        .as(LogicalTypeAnnotation.geographyType("EPSG:4326", null))
+        .named("aGeography");
+    Assert.assertEquals(customCrsExpected, customCrsActual);
+
+    // Test with custom CRS and edge algorithm
+    EdgeInterpolationAlgorithm greatCircle = EdgeInterpolationAlgorithm.SPHERICAL;
+    PrimitiveType customCrsWithEdgeAlgorithmExpected = new PrimitiveType(
+        REQUIRED, BINARY, "aGeography", LogicalTypeAnnotation.geographyType("EPSG:4326", greatCircle));
+    PrimitiveType customCrsWithEdgeAlgorithmActual = Types.required(BINARY)
+        .as(LogicalTypeAnnotation.geographyType("EPSG:4326", greatCircle))
+        .named("aGeography");
+    Assert.assertEquals(customCrsWithEdgeAlgorithmExpected, customCrsWithEdgeAlgorithmActual);
+
+    // Test with optional repetition
+    PrimitiveType optionalGeographyExpected = new PrimitiveType(
+        OPTIONAL, BINARY, "aGeography", LogicalTypeAnnotation.geographyType("OGC:CRS84", null));
+    PrimitiveType optionalGeographyActual = Types.optional(BINARY)
+        .as(LogicalTypeAnnotation.geographyType("OGC:CRS84", null))
+        .named("aGeography");
+    Assert.assertEquals(optionalGeographyExpected, optionalGeographyActual);
+  }
+
+  @Test
+  public void testGeographyLogicalTypeWithoutEdgeInterpolationAlgorithm() {
+    // Test with default CRS and no edge algorithm
+    PrimitiveType defaultCrsExpected = new PrimitiveType(
+        REQUIRED, BINARY, "aGeography", LogicalTypeAnnotation.geographyType());
+    PrimitiveType defaultCrsActual = Types.required(BINARY)
+        .as(LogicalTypeAnnotation.geographyType())
+        .named("aGeography");
+    Assert.assertEquals(defaultCrsExpected, defaultCrsActual);
+
+    // Test with custom CRS and no edge algorithm
+    PrimitiveType customCrsExpected = new PrimitiveType(
+        REQUIRED, BINARY, "aGeography", LogicalTypeAnnotation.geographyType("EPSG:4326", null));
+    PrimitiveType customCrsActual = Types.required(BINARY)
+        .as(LogicalTypeAnnotation.geographyType("EPSG:4326", null))
+        .named("aGeography");
+    Assert.assertEquals(customCrsExpected, customCrsActual);
+
+    // Test with custom CRS and edge algorithm
+    PrimitiveType customCrsWithEdgeAlgorithmExpected = new PrimitiveType(
+        REQUIRED, BINARY, "aGeography",
+        LogicalTypeAnnotation.geographyType("EPSG:4326", null));
+    PrimitiveType customCrsWithEdgeAlgorithmActual = Types.required(BINARY)
+        .as(LogicalTypeAnnotation.geographyType("EPSG:4326", null))
+        .named("aGeography");
+    Assert.assertEquals(customCrsWithEdgeAlgorithmExpected, customCrsWithEdgeAlgorithmActual);
+
+    // Test with optional repetition
+    PrimitiveType optionalGeographyExpected = new PrimitiveType(
+        OPTIONAL, BINARY, "aGeography", LogicalTypeAnnotation.geographyType());
+    PrimitiveType optionalGeographyActual = Types.optional(BINARY)
+        .as(LogicalTypeAnnotation.geographyType())
+        .named("aGeography");
+    Assert.assertEquals(optionalGeographyExpected, optionalGeographyActual);
   }
 
   /**

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -136,12 +136,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.locationtech.jts</groupId>
-      <artifactId>jts-core</artifactId>
-      <version>${jts.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
       <version>2.0.2</version>

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -136,6 +136,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
+      <version>${jts.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
       <version>2.0.2</version>

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -539,11 +539,15 @@ public class ParquetMetadataConverter {
       if (geographyLogicalType.getCrs() != null) {
         geographyType.setCrs(geographyLogicalType.getCrs());
       }
-      if (geographyLogicalType.getEdgeAlgorithm() != null) {
-        EdgeInterpolationAlgorithm algorithm =
-            EdgeInterpolationAlgorithm.valueOf(String.valueOf(geographyLogicalType.getEdgeAlgorithm()));
-        if (algorithm != null) {
+      if (geographyLogicalType.getAlgorithm() != null) {
+        try {
+          // Convert from schema.EdgeInterpolationAlgorithm to format.EdgeInterpolationAlgorithm
+          EdgeInterpolationAlgorithm algorithm = EdgeInterpolationAlgorithm.valueOf(
+              geographyLogicalType.getAlgorithm().name());
           geographyType.setAlgorithm(algorithm);
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException(
+              "Unknown EdgeInterpolationAlgorithm value: " + geographyLogicalType.getAlgorithm(), e);
         }
       }
       return of(LogicalType.GEOGRAPHY(geographyType));
@@ -1216,7 +1220,10 @@ public class ParquetMetadataConverter {
         return LogicalTypeAnnotation.geometryType(geometry.getCrs());
       case GEOGRAPHY:
         GeographyType geography = type.getGEOGRAPHY();
-        return LogicalTypeAnnotation.geographyType(geography.getCrs(), null);
+        return LogicalTypeAnnotation.geographyType(
+            geography.getCrs(),
+            org.apache.parquet.column.schema.EdgeInterpolationAlgorithm.valueOf(
+                geography.getAlgorithm().name()));
       case VARIANT:
         VariantType variant = type.getVARIANT();
         return LogicalTypeAnnotation.variantType(variant.getSpecification_version());

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -537,16 +537,11 @@ public class ParquetMetadataConverter {
     @Override
     public Optional<LogicalType> visit(LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
       GeographyType geographyType = new GeographyType();
-      if (geographyLogicalType.getCrs() != null) {
+      if (geographyLogicalType.getCrs() != null
+          && !geographyLogicalType.getCrs().isEmpty()) {
         geographyType.setCrs(geographyLogicalType.getCrs());
       }
-      if (geographyLogicalType.getAlgorithm() != null
-          && !geographyLogicalType.getCrs().isEmpty()) {
-        // Convert from schema.EdgeInterpolationAlgorithm to format.EdgeInterpolationAlgorithm
-        EdgeInterpolationAlgorithm algorithm =
-            fromParquetEdgeInterpolationAlgorithm(geographyLogicalType.getAlgorithm());
-        geographyType.setAlgorithm(algorithm);
-      }
+      geographyType.setAlgorithm(fromParquetEdgeInterpolationAlgorithm(geographyLogicalType.getAlgorithm()));
       return of(LogicalType.GEOGRAPHY(geographyType));
     }
   }
@@ -1217,13 +1212,8 @@ public class ParquetMetadataConverter {
         return LogicalTypeAnnotation.geometryType(geometry.getCrs());
       case GEOGRAPHY:
         GeographyType geography = type.getGEOGRAPHY();
-        EdgeInterpolationAlgorithm algorithm = geography.getAlgorithm();
-        org.apache.parquet.column.schema.EdgeInterpolationAlgorithm parquetAlgorithm = null;
-        if (algorithm != null) {
-          parquetAlgorithm = toParquetEdgeInterpolationAlgorithm(algorithm);
-        }
-
-        return LogicalTypeAnnotation.geographyType(geography.getCrs(), parquetAlgorithm);
+        return LogicalTypeAnnotation.geographyType(
+            geography.getCrs(), toParquetEdgeInterpolationAlgorithm(geography.getAlgorithm()));
       case VARIANT:
         VariantType variant = type.getVARIANT();
         return LogicalTypeAnnotation.variantType(variant.getSpecification_version());

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -1220,10 +1220,19 @@ public class ParquetMetadataConverter {
         return LogicalTypeAnnotation.geometryType(geometry.getCrs());
       case GEOGRAPHY:
         GeographyType geography = type.getGEOGRAPHY();
-        return LogicalTypeAnnotation.geographyType(
-            geography.getCrs(),
-            org.apache.parquet.column.schema.EdgeInterpolationAlgorithm.valueOf(
-                geography.getAlgorithm().name()));
+        // Handle when either algorithm or CRS is null
+        if (geography == null) {
+          return LogicalTypeAnnotation.geographyType(null, null);
+        }
+
+        EdgeInterpolationAlgorithm algorithm = geography.getAlgorithm();
+        org.apache.parquet.column.schema.EdgeInterpolationAlgorithm parquetAlgorithm = null;
+        if (algorithm != null) {
+          parquetAlgorithm =
+              org.apache.parquet.column.schema.EdgeInterpolationAlgorithm.valueOf(algorithm.name());
+        }
+
+        return LogicalTypeAnnotation.geographyType(geography.getCrs(), parquetAlgorithm);
       case VARIANT:
         VariantType variant = type.getVARIANT();
         return LogicalTypeAnnotation.variantType(variant.getSpecification_version());

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -76,10 +76,13 @@ import org.apache.parquet.format.DataPageHeader;
 import org.apache.parquet.format.DataPageHeaderV2;
 import org.apache.parquet.format.DecimalType;
 import org.apache.parquet.format.DictionaryPageHeader;
+import org.apache.parquet.format.EdgeInterpolationAlgorithm;
 import org.apache.parquet.format.Encoding;
 import org.apache.parquet.format.EncryptionWithColumnKey;
 import org.apache.parquet.format.FieldRepetitionType;
 import org.apache.parquet.format.FileMetaData;
+import org.apache.parquet.format.GeographyType;
+import org.apache.parquet.format.GeometryType;
 import org.apache.parquet.format.IntType;
 import org.apache.parquet.format.KeyValue;
 import org.apache.parquet.format.LogicalType;
@@ -519,6 +522,31 @@ public class ParquetMetadataConverter {
     @Override
     public Optional<LogicalType> visit(LogicalTypeAnnotation.VariantLogicalTypeAnnotation variantLogicalType) {
       return of(LogicalTypes.VARIANT(variantLogicalType.getSpecVersion()));
+    }
+
+    @Override
+    public Optional<LogicalType> visit(LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+      GeometryType geometryType = new GeometryType();
+      if (geometryLogicalType.getCrs() != null) {
+        geometryType.setCrs(geometryLogicalType.getCrs());
+      }
+      return of(LogicalType.GEOMETRY(geometryType));
+    }
+
+    @Override
+    public Optional<LogicalType> visit(LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+      GeographyType geographyType = new GeographyType();
+      if (geographyLogicalType.getCrs() != null) {
+        geographyType.setCrs(geographyLogicalType.getCrs());
+      }
+      if (geographyLogicalType.getEdgeAlgorithm() != null) {
+        EdgeInterpolationAlgorithm algorithm =
+            EdgeInterpolationAlgorithm.valueOf(String.valueOf(geographyLogicalType.getEdgeAlgorithm()));
+        if (algorithm != null) {
+          geographyType.setAlgorithm(algorithm);
+        }
+      }
+      return of(LogicalType.GEOGRAPHY(geographyType));
     }
   }
 
@@ -1183,6 +1211,12 @@ public class ParquetMetadataConverter {
         return LogicalTypeAnnotation.uuidType();
       case FLOAT16:
         return LogicalTypeAnnotation.float16Type();
+      case GEOMETRY:
+        GeometryType geometry = type.getGEOMETRY();
+        return LogicalTypeAnnotation.geometryType(geometry.getCrs());
+      case GEOGRAPHY:
+        GeographyType geography = type.getGEOGRAPHY();
+        return LogicalTypeAnnotation.geographyType(geography.getCrs(), null);
       case VARIANT:
         VariantType variant = type.getVARIANT();
         return LogicalTypeAnnotation.variantType(variant.getSpecification_version());

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
     <powermock.version>2.0.9</powermock.version>
     <net.openhft.version>0.27ea0</net.openhft.version>
     <exec-maven-plugin.version>3.5.0</exec-maven-plugin.version>
+    <jts.version>1.20.0</jts.version>
 
     <!-- parquet-cli dependencies -->
     <opencsv.version>2.3</opencsv.version>


### PR DESCRIPTION
### Rationale for this change
This is to add geometry and geography logical types in parquet-java according to the new parquet-format spec changes to add the geo types - https://github.com/apache/parquet-format/blob/master/Geospatial.md.

### What changes are included in this PR?
The Geometry and Geography logical type have been added to LogicalTypeAnnotation. For geo columns, the corresponding Parquet group is annotated as GEOMETRY / GEOGRAPHY, with optimal parameters of crs and edge algorithm. Unit tests to test the new logical types are also added.

### Are these changes tested?
Yes, TestTypeBuilders

### Are there any user-facing changes?
Yes, Geometry and Geography types are now available.
