### PR TITLE
GH-3201: Implement a Variant builder to create Variant values

### DIFF
--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantArrayBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantArrayBuilder.java
@@ -42,6 +42,7 @@ public class VariantArrayBuilder extends VariantBuilder {
       throw new IllegalStateException(String.format(
           "Number of offsets (%d) do not match the number of values (%d).", offsets.size(), numValues));
     }
+    checkMultipleNested("Cannot call endArray() while a nested object/array is still open.");
     return offsets;
   }
 
@@ -49,16 +50,13 @@ public class VariantArrayBuilder extends VariantBuilder {
   protected void onAppend() {
     checkAppendWhileNested();
     offsets.add(writePos);
+    numValues++;
   }
 
   @Override
   protected void onStartNested() {
-    checkMultipleNested();
+    checkMultipleNested("Cannot call startObject()/startArray() without calling endObject()/endArray() first.");
     offsets.add(writePos);
-  }
-
-  @Override
-  protected void incrementNumValues() {
     numValues++;
   }
 

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantArrayBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantArrayBuilder.java
@@ -22,6 +22,13 @@ import java.util.ArrayList;
  * Builder for creating Variant arrays, used by VariantBuilder.
  */
 public class VariantArrayBuilder {
+  /** The underlying VariantBuilder. */
+  private final VariantBuilder builder;
+  /** The saved builder.writPos() for the start of this array. */
+  private final int startPos;
+  /** The offsets of the elements in this array. */
+  private final ArrayList<Integer> offsets;
+
   VariantArrayBuilder(VariantBuilder builder) {
     this.builder = builder;
     this.startPos = builder.writePos();
@@ -39,11 +46,4 @@ public class VariantArrayBuilder {
   ArrayList<Integer> offsets() {
     return offsets;
   }
-
-  /** The underlying VariantBuilder. */
-  private final VariantBuilder builder;
-  /** The saved builder.writPos() for the start of this array. */
-  private final int startPos;
-  /** The offsets of the elements in this array. */
-  private final ArrayList<Integer> offsets;
 }

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantArrayBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantArrayBuilder.java
@@ -26,6 +26,8 @@ public class VariantArrayBuilder extends VariantBuilder {
   private final VariantBuilder parent;
   /** The offsets of the elements in this array. */
   private final ArrayList<Integer> offsets;
+  /** The number of values appended to this array. */
+  protected long numValues = 0;
 
   VariantArrayBuilder(VariantBuilder parent) {
     this.parent = parent;
@@ -53,6 +55,11 @@ public class VariantArrayBuilder extends VariantBuilder {
   protected void onStartNested() {
     checkMultipleNested();
     offsets.add(writePos);
+  }
+
+  @Override
+  protected void incrementNumValues() {
+    numValues++;
   }
 
   @Override

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantArrayBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantArrayBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.variant;
+
+import java.util.ArrayList;
+
+/**
+ * Builder for creating Variant arrays, used by VariantBuilder.
+ */
+public class VariantArrayBuilder {
+  VariantArrayBuilder(VariantBuilder builder) {
+    this.builder = builder;
+    this.startPos = builder.writePos();
+    this.offsets = new ArrayList<>();
+  }
+
+  void startElement() {
+    offsets.add(builder.writePos() - startPos);
+  }
+
+  int startPos() {
+    return startPos;
+  }
+
+  ArrayList<Integer> offsets() {
+    return offsets;
+  }
+
+  /** The underlying VariantBuilder. */
+  private final VariantBuilder builder;
+  /** The saved builder.writPos() for the start of this array. */
+  private final int startPos;
+  /** The offsets of the elements in this array. */
+  private final ArrayList<Integer> offsets;
+}

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
@@ -1,0 +1,590 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.variant;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+
+/**
+ * Builder for creating Variant value and metadata.
+ */
+public class VariantBuilder {
+  /**
+   * Creates a VariantBuilder.
+   * @param allowDuplicateKeys if true, only the last occurrence of a duplicate key will be kept.
+   *                           Otherwise, an exception will be thrown.
+   */
+  public VariantBuilder(boolean allowDuplicateKeys) {
+    this.allowDuplicateKeys = allowDuplicateKeys;
+  }
+
+  /**
+   * @return the Variant value
+   */
+  public Variant build() {
+    int numKeys = dictionaryKeys.size();
+    // Use long to avoid overflow in accumulating lengths.
+    long dictionaryStringSize = 0;
+    for (byte[] key : dictionaryKeys) {
+      dictionaryStringSize += key.length;
+    }
+    // Determine the number of bytes required per offset entry.
+    // The largest offset is the one-past-the-end value, which is total string size. It's very
+    // unlikely that the number of keys could be larger, but incorporate that into the calculation
+    // in case of pathological data.
+    long maxSize = Math.max(dictionaryStringSize, numKeys);
+    int offsetSize = getMinIntegerSize((int) maxSize);
+
+    int offsetStart = 1 + offsetSize;
+    int stringStart = offsetStart + (numKeys + 1) * offsetSize;
+    long metadataSize = stringStart + dictionaryStringSize;
+
+    byte[] metadata = new byte[(int) metadataSize];
+    int headerByte = VariantUtil.VERSION | ((offsetSize - 1) << 6);
+    VariantUtil.writeLong(metadata, 0, headerByte, 1);
+    VariantUtil.writeLong(metadata, 1, numKeys, offsetSize);
+    int currentOffset = 0;
+    for (int i = 0; i < numKeys; ++i) {
+      VariantUtil.writeLong(metadata, offsetStart + i * offsetSize, currentOffset, offsetSize);
+      byte[] key = dictionaryKeys.get(i);
+      System.arraycopy(key, 0, metadata, stringStart + currentOffset, key.length);
+      currentOffset += key.length;
+    }
+    VariantUtil.writeLong(metadata, offsetStart + numKeys * offsetSize, currentOffset, offsetSize);
+    return new Variant(Arrays.copyOfRange(writeBuffer, 0, writePos), metadata);
+  }
+
+  /**
+   * Appends a string value to the Variant builder.
+   * @param str the string value to append
+   * @return this builder
+   */
+  public VariantBuilder appendString(String str) {
+    byte[] text = str.getBytes(StandardCharsets.UTF_8);
+    boolean longStr = text.length > VariantUtil.MAX_SHORT_STR_SIZE;
+    checkCapacity((longStr ? 1 + VariantUtil.U32_SIZE : 1) + text.length);
+    if (longStr) {
+      writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.LONG_STR);
+      VariantUtil.writeLong(writeBuffer, writePos, text.length, VariantUtil.U32_SIZE);
+      writePos += VariantUtil.U32_SIZE;
+    } else {
+      writeBuffer[writePos++] = VariantUtil.shortStrHeader(text.length);
+    }
+    System.arraycopy(text, 0, writeBuffer, writePos, text.length);
+    writePos += text.length;
+    return this;
+  }
+
+  /**
+   * Appends a null value to the Variant builder.
+   * @return this builder
+   */
+  public VariantBuilder appendNull() {
+    checkCapacity(1);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.NULL);
+    return this;
+  }
+
+  /**
+   * Appends a boolean value to the Variant builder.
+   * @param b the boolean value to append
+   * @return this builder
+   */
+  public VariantBuilder appendBoolean(boolean b) {
+    checkCapacity(1);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(b ? VariantUtil.TRUE : VariantUtil.FALSE);
+    return this;
+  }
+
+  /**
+   * Appends a long value to the variant builder. The actual encoded integer type depends on the
+   * value range of the long value.
+   * @param l the long value to append
+   * @return this builder
+   */
+  public VariantBuilder appendLong(long l) {
+    if (l == (byte) l) {
+      checkCapacity(1 + 1);
+      writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.INT8);
+      VariantUtil.writeLong(writeBuffer, writePos, l, 1);
+      writePos += 1;
+    } else if (l == (short) l) {
+      checkCapacity(1 + 2);
+      writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.INT16);
+      VariantUtil.writeLong(writeBuffer, writePos, l, 2);
+      writePos += 2;
+    } else if (l == (int) l) {
+      checkCapacity(1 + 4);
+      writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.INT32);
+      VariantUtil.writeLong(writeBuffer, writePos, l, 4);
+      writePos += 4;
+    } else {
+      checkCapacity(1 + 8);
+      writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.INT64);
+      VariantUtil.writeLong(writeBuffer, writePos, l, 8);
+      writePos += 8;
+    }
+    return this;
+  }
+
+  /**
+   * Appends a double value to the variant builder.
+   * @param d the double to append
+   * @return this builder
+   */
+  public VariantBuilder appendDouble(double d) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.DOUBLE);
+    VariantUtil.writeLong(writeBuffer, writePos, Double.doubleToLongBits(d), 8);
+    writePos += 8;
+    return this;
+  }
+
+  /**
+   * Appends a decimal value to the variant builder. The actual encoded decimal type depends on the
+   * precision and scale of the decimal value.
+   * @param d the decimal value to append
+   * @return this builder
+   */
+  public VariantBuilder appendDecimal(BigDecimal d) {
+    BigInteger unscaled = d.unscaledValue();
+    if (d.scale() <= VariantUtil.MAX_DECIMAL4_PRECISION && d.precision() <= VariantUtil.MAX_DECIMAL4_PRECISION) {
+      checkCapacity(2 + 4);
+      writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.DECIMAL4);
+      writeBuffer[writePos++] = (byte) d.scale();
+      VariantUtil.writeLong(writeBuffer, writePos, unscaled.intValueExact(), 4);
+      writePos += 4;
+    } else if (d.scale() <= VariantUtil.MAX_DECIMAL8_PRECISION
+        && d.precision() <= VariantUtil.MAX_DECIMAL8_PRECISION) {
+      checkCapacity(2 + 8);
+      writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.DECIMAL8);
+      writeBuffer[writePos++] = (byte) d.scale();
+      VariantUtil.writeLong(writeBuffer, writePos, unscaled.longValueExact(), 8);
+      writePos += 8;
+    } else {
+      assert d.scale() <= VariantUtil.MAX_DECIMAL16_PRECISION
+          && d.precision() <= VariantUtil.MAX_DECIMAL16_PRECISION;
+      checkCapacity(2 + 16);
+      writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.DECIMAL16);
+      writeBuffer[writePos++] = (byte) d.scale();
+      // `toByteArray` returns a big-endian representation. We need to copy it reversely and sign
+      // extend it to 16 bytes.
+      byte[] bytes = unscaled.toByteArray();
+      for (int i = 0; i < bytes.length; ++i) {
+        writeBuffer[writePos + i] = bytes[bytes.length - 1 - i];
+      }
+      byte sign = (byte) (bytes[0] < 0 ? -1 : 0);
+      for (int i = bytes.length; i < 16; ++i) {
+        writeBuffer[writePos + i] = sign;
+      }
+      writePos += 16;
+    }
+    return this;
+  }
+
+  /**
+   * Appends a date value to the variant builder. The date is represented as the number of days
+   * since the epoch.
+   * @param daysSinceEpoch the number of days since the epoch
+   * @return this builder
+   */
+  public VariantBuilder appendDate(int daysSinceEpoch) {
+    checkCapacity(1 + 4);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.DATE);
+    VariantUtil.writeLong(writeBuffer, writePos, daysSinceEpoch, 4);
+    writePos += 4;
+    return this;
+  }
+
+  /**
+   * Appends a TimestampTz value to the variant builder. The timestamp is represented as the number
+   * of microseconds since the epoch.
+   * @param microsSinceEpoch the number of microseconds since the epoch
+   * @return this builder
+   */
+  public VariantBuilder appendTimestampTz(long microsSinceEpoch) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.TIMESTAMP_TZ);
+    VariantUtil.writeLong(writeBuffer, writePos, microsSinceEpoch, 8);
+    writePos += 8;
+    return this;
+  }
+
+  /**
+   * Appends a TimestampNtz value to the variant builder. The timestamp is represented as the number
+   * of microseconds since the epoch.
+   * @param microsSinceEpoch the number of microseconds since the epoch
+   * @return this builder
+   */
+  public VariantBuilder appendTimestampNtz(long microsSinceEpoch) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.TIMESTAMP_NTZ);
+    VariantUtil.writeLong(writeBuffer, writePos, microsSinceEpoch, 8);
+    writePos += 8;
+    return this;
+  }
+
+  /**
+   * Appends a Time value to the variant builder. The time is represented as the number of
+   * microseconds since midnight.
+   * @param microsSinceMidnight the number of microseconds since midnight
+   * @return this builder
+   */
+  public VariantBuilder appendTime(long microsSinceMidnight) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.TIME);
+    VariantUtil.writeLong(writeBuffer, writePos, microsSinceMidnight, 8);
+    writePos += 8;
+    return this;
+  }
+
+  /**
+   * Appends a TimestampNanosTz value to the variant builder. The timestamp is represented as the
+   * number of nanoseconds since the epoch.
+   * @param nanosSinceEpoch the number of nanoseconds since the epoch
+   * @return this builder
+   */
+  public VariantBuilder appendTimestampNanosTz(long nanosSinceEpoch) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.TIMESTAMP_NANOS_TZ);
+    VariantUtil.writeLong(writeBuffer, writePos, nanosSinceEpoch, 8);
+    writePos += 8;
+    return this;
+  }
+
+  /**
+   * Appends a TimestampNanosNtz value to the variant builder. The timestamp is represented as the
+   * number of nanoseconds since the epoch.
+   * @param nanosSinceEpoch the number of nanoseconds since the epoch
+   * @return this builder
+   */
+  public VariantBuilder appendTimestampNanosNtz(long nanosSinceEpoch) {
+    checkCapacity(1 + 8);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.TIMESTAMP_NANOS_NTZ);
+    VariantUtil.writeLong(writeBuffer, writePos, nanosSinceEpoch, 8);
+    writePos += 8;
+    return this;
+  }
+
+  /**
+   * Appends a float value to the variant builder.
+   * @param f the float to append
+   * @return this builder
+   */
+  public VariantBuilder appendFloat(float f) {
+    checkCapacity(1 + 4);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.FLOAT);
+    VariantUtil.writeLong(writeBuffer, writePos, Float.floatToIntBits(f), 8);
+    writePos += 4;
+    return this;
+  }
+
+  /**
+   * Appends a byte array to the variant builder.
+   * @param binary the byte array to append
+   * @return this builder
+   */
+  public VariantBuilder appendBinary(byte[] binary) {
+    checkCapacity(1 + VariantUtil.U32_SIZE + binary.length);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.BINARY);
+    VariantUtil.writeLong(writeBuffer, writePos, binary.length, VariantUtil.U32_SIZE);
+    writePos += VariantUtil.U32_SIZE;
+    System.arraycopy(binary, 0, writeBuffer, writePos, binary.length);
+    writePos += binary.length;
+    return this;
+  }
+
+  /**
+   * Appends a UUID value to the variant builder.
+   * @param uuid the UUID to append
+   * @return this builder
+   */
+  public VariantBuilder appendUUID(java.util.UUID uuid) {
+    checkCapacity(1 + VariantUtil.UUID_SIZE);
+    writeBuffer[writePos++] = VariantUtil.primitiveHeader(VariantUtil.UUID);
+
+    ByteBuffer bb =
+        ByteBuffer.wrap(writeBuffer, writePos, VariantUtil.UUID_SIZE).order(ByteOrder.BIG_ENDIAN);
+    bb.putLong(uuid.getMostSignificantBits());
+    bb.putLong(uuid.getLeastSignificantBits());
+    writePos += VariantUtil.UUID_SIZE;
+    return this;
+  }
+
+  /**
+   * Starts appending an object to this variant builder. The returned VariantObjectBuilder must
+   * be used for future calls to addObjectKey() and endObject(). To add a (key, value) to the
+   * Variant object, call appendObjectKey() to add the key name, and then append the value.
+   * endObject() must be called to finish writing the Variant object.
+   *
+   * Example usage:
+   * VariantBuilder builder = new VariantBuilder();
+   * VariantObjectBuilder objBuilder = builder.startObject();
+   * builder.appendObjectKey(objBuilder, "key1");
+   * builder.appendString("value1");
+   * builder.endObject(objBuilder);
+   *
+   * @return a VariantObjectBuilder to use for appendObjectKey() and endObject().
+   */
+  public VariantObjectBuilder startObject() {
+    return new VariantObjectBuilder(this);
+  }
+
+  /**
+   * Appends a key to the Variant object. This method must be called before appending the
+   * corresponding value.
+   * @param objBuilder the VariantObjectBuilder to use
+   */
+  public void appendObjectKey(VariantObjectBuilder objBuilder, String key) {
+    objBuilder.appendKey(key);
+  }
+
+  /**
+   * Ends appending an object to this variant builder. This method must be called after all keys and
+   * values have been added to the object.
+   * @param objBuilder the VariantObjectBuilder to use
+   * @return this builder
+   */
+  public VariantBuilder endObject(VariantObjectBuilder objBuilder) {
+    ArrayList<FieldEntry> fields = objBuilder.fields();
+    int size = fields.size();
+    Collections.sort(fields);
+    int maxId = size == 0 ? 0 : fields.get(0).id;
+    if (allowDuplicateKeys) {
+      int distinctPos = 0;
+      // Maintain a list of distinct keys in-place.
+      for (int i = 1; i < size; ++i) {
+        maxId = Math.max(maxId, fields.get(i).id);
+        if (fields.get(i).id == fields.get(i - 1).id) {
+          // Found a duplicate key. Keep the field with the greater offset.
+          if (fields.get(distinctPos).offset < fields.get(i).offset) {
+            fields.set(distinctPos, fields.get(distinctPos).withNewOffset(fields.get(i).offset));
+          }
+        } else {
+          // Found a distinct key. Add the field to the list.
+          ++distinctPos;
+          fields.set(distinctPos, fields.get(i));
+        }
+      }
+      if (distinctPos + 1 < fields.size()) {
+        size = distinctPos + 1;
+        // Resize `fields` to `size`.
+        fields.subList(size, fields.size()).clear();
+        // Sort the fields by offsets so that we can move the value data of each field to the new
+        // offset without overwriting the fields after it.
+        fields.sort(Comparator.comparingInt(f -> f.offset));
+        int currentOffset = 0;
+        for (int i = 0; i < size; ++i) {
+          int oldOffset = fields.get(i).offset;
+          int fieldSize =
+              VariantUtil.valueSize(ByteBuffer.wrap(writeBuffer), objBuilder.startPos() + oldOffset);
+          System.arraycopy(
+              writeBuffer,
+              objBuilder.startPos() + oldOffset,
+              writeBuffer,
+              objBuilder.startPos() + currentOffset,
+              fieldSize);
+          fields.set(i, fields.get(i).withNewOffset(currentOffset));
+          currentOffset += fieldSize;
+        }
+        writePos = objBuilder.startPos() + currentOffset;
+        // Change back to the sort order by field keys, required by the Variant specification.
+        Collections.sort(fields);
+      }
+    } else {
+      for (int i = 1; i < size; ++i) {
+        maxId = Math.max(maxId, fields.get(i).id);
+        String key = fields.get(i).key;
+        if (key.equals(fields.get(i - 1).key)) {
+          throw new IllegalStateException("Failed to build Variant because of duplicate object key: " + key);
+        }
+      }
+    }
+    int dataSize = writePos - objBuilder.startPos();
+    boolean largeSize = size > VariantUtil.U8_MAX;
+    int sizeBytes = largeSize ? VariantUtil.U32_SIZE : 1;
+    int idSize = getMinIntegerSize(maxId);
+    int offsetSize = getMinIntegerSize(dataSize);
+    // The space for header byte, object size, id list, and offset list.
+    int headerSize = 1 + sizeBytes + size * idSize + (size + 1) * offsetSize;
+    checkCapacity(headerSize);
+    // Shift the just-written field data to make room for the object header section.
+    System.arraycopy(writeBuffer, objBuilder.startPos(), writeBuffer, objBuilder.startPos() + headerSize, dataSize);
+    writePos += headerSize;
+    writeBuffer[objBuilder.startPos()] = VariantUtil.objectHeader(largeSize, idSize, offsetSize);
+    VariantUtil.writeLong(writeBuffer, objBuilder.startPos() + 1, size, sizeBytes);
+    int idStart = objBuilder.startPos() + 1 + sizeBytes;
+    int offsetStart = idStart + size * idSize;
+    for (int i = 0; i < size; ++i) {
+      VariantUtil.writeLong(writeBuffer, idStart + i * idSize, fields.get(i).id, idSize);
+      VariantUtil.writeLong(writeBuffer, offsetStart + i * offsetSize, fields.get(i).offset, offsetSize);
+    }
+    VariantUtil.writeLong(writeBuffer, offsetStart + size * offsetSize, dataSize, offsetSize);
+    return this;
+  }
+
+  /**
+   * Starts appending an array to this variant builder. The returned VariantArrayBuilder must be
+   * used for future calls to startArrayElement() and endArray(). To add an element to the array,
+   * call startArrayElement() and then append the value. endArray() must be called to finish writing
+   * the Variant array.
+   *
+   * Example usage:
+   * VariantBuilder builder = new VariantBuilder();
+   * VariantArrayBuilder arrayBuilder = builder.startArray();
+   * arrayBuilder.startArrayElement(arrayBuilder);
+   * builder.appendString("value1");
+   * arrayBuilder.endArray(arrayBuilder);
+   *
+   * @return a VariantArrayBuilder to use for startArrayElement() and endArray().
+   */
+  public VariantArrayBuilder startArray() {
+    return new VariantArrayBuilder(this);
+  }
+
+  /**
+   * Starts appending an element to the array. This method must be called before appending the
+   * corresponding value.
+   * @param arrayBuilder the VariantArrayBuilder to use
+   */
+  public void startArrayElement(VariantArrayBuilder arrayBuilder) {
+    arrayBuilder.startElement();
+  }
+
+  /**
+   * Ends appending an array to this variant builder. This method must be called after all elements
+   * have been added to the array.
+   * @param arrayBuilder the VariantArrayBuilder to use
+   * @return this builder
+   */
+  public VariantBuilder endArray(VariantArrayBuilder arrayBuilder) {
+    int start = arrayBuilder.startPos();
+    int dataSize = writePos - start;
+    int size = arrayBuilder.offsets().size();
+    boolean largeSize = size > VariantUtil.U8_MAX;
+    int sizeBytes = largeSize ? VariantUtil.U32_SIZE : 1;
+    int offsetSize = getMinIntegerSize(dataSize);
+    // The space for header byte, object size, and offset list.
+    int headerSize = 1 + sizeBytes + (size + 1) * offsetSize;
+    checkCapacity(headerSize);
+    // Shift the just-written field data to make room for the header section.
+    System.arraycopy(writeBuffer, start, writeBuffer, start + headerSize, dataSize);
+    writePos += headerSize;
+    writeBuffer[start] = VariantUtil.arrayHeader(largeSize, offsetSize);
+    VariantUtil.writeLong(writeBuffer, start + 1, size, sizeBytes);
+    int offsetStart = start + 1 + sizeBytes;
+    for (int i = 0; i < size; ++i) {
+      VariantUtil.writeLong(
+          writeBuffer,
+          offsetStart + i * offsetSize,
+          arrayBuilder.offsets().get(i),
+          offsetSize);
+    }
+    VariantUtil.writeLong(writeBuffer, offsetStart + size * offsetSize, dataSize, offsetSize);
+    return this;
+  }
+
+  /**
+   * Adds a key to the Variant dictionary. If the key already exists, the dictionary is unmodified.
+   * @param key the key to add
+   * @return the id of the key
+   */
+  int addKey(String key) {
+    return dictionary.computeIfAbsent(key, newKey -> {
+      int id = dictionaryKeys.size();
+      dictionaryKeys.add(newKey.getBytes(StandardCharsets.UTF_8));
+      return id;
+    });
+  }
+
+  /**
+   * @return the current write position of the variant builder
+   */
+  int writePos() {
+    return writePos;
+  }
+
+  /**
+   * Class to store the information of a Variant object field. We need to collect all fields of
+   * an object, sort them by their keys, and build the Variant object in sorted order.
+   */
+  static final class FieldEntry implements Comparable<FieldEntry> {
+    final String key;
+    final int id;
+    final int offset;
+
+    FieldEntry(String key, int id, int offset) {
+      this.key = key;
+      this.id = id;
+      this.offset = offset;
+    }
+
+    FieldEntry withNewOffset(int newOffset) {
+      return new FieldEntry(key, id, newOffset);
+    }
+
+    @Override
+    public int compareTo(FieldEntry other) {
+      return key.compareTo(other.key);
+    }
+  }
+
+  private void checkCapacity(int additionalBytes) {
+    int requiredBytes = writePos + additionalBytes;
+    if (requiredBytes > writeBuffer.length) {
+      // Allocate a new buffer with a capacity of the next power of 2 of `requiredBytes`.
+      int newCapacity = Integer.highestOneBit(requiredBytes);
+      newCapacity = newCapacity < requiredBytes ? newCapacity * 2 : newCapacity;
+      byte[] newValue = new byte[newCapacity];
+      System.arraycopy(writeBuffer, 0, newValue, 0, writePos);
+      writeBuffer = newValue;
+    }
+  }
+
+  private int getMinIntegerSize(int value) {
+    assert value >= 0;
+    if (value <= VariantUtil.U8_MAX) {
+      return VariantUtil.U8_SIZE;
+    }
+    if (value <= VariantUtil.U16_MAX) {
+      return VariantUtil.U16_SIZE;
+    }
+    if (value <= VariantUtil.U24_MAX) {
+      return VariantUtil.U24_SIZE;
+    }
+    return VariantUtil.U32_SIZE;
+  }
+
+  /** The buffer for building the Variant value. The first `writePos` bytes have been written. */
+  private byte[] writeBuffer = new byte[128];
+
+  private int writePos = 0;
+  /** The dictionary for mapping keys to monotonically increasing ids. */
+  private final HashMap<String, Integer> dictionary = new HashMap<>();
+  /** The keys in the dictionary, in id order. */
+  private final ArrayList<byte[]> dictionaryKeys = new ArrayList<>();
+
+  private final boolean allowDuplicateKeys;
+}

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
@@ -126,33 +126,54 @@ public class VariantBuilder {
   }
 
   /**
-   * Appends a long value to the variant builder. The actual encoded integer type depends on the
-   * value range of the long value.
+   * Appends a long value to the variant builder.
    * @param l the long value to append
    * @return this builder
    */
   public VariantBuilder appendLong(long l) {
-    if (l == (byte) l) {
-      checkCapacity(1 /* header size */ + 1);
-      writeBuffer[writePos] = VariantUtil.HDR_INT8;
-      VariantUtil.writeLong(writeBuffer, writePos + 1, l, 1);
-      writePos += 2;
-    } else if (l == (short) l) {
-      checkCapacity(1 /* header size */ + 2);
-      writeBuffer[writePos] = VariantUtil.HDR_INT16;
-      VariantUtil.writeLong(writeBuffer, writePos + 1, l, 2);
-      writePos += 3;
-    } else if (l == (int) l) {
-      checkCapacity(1 /* header size */ + 4);
-      writeBuffer[writePos] = VariantUtil.HDR_INT32;
-      VariantUtil.writeLong(writeBuffer, writePos + 1, l, 4);
-      writePos += 5;
-    } else {
-      checkCapacity(1 /* header size */ + 8);
-      writeBuffer[writePos] = VariantUtil.HDR_INT64;
-      VariantUtil.writeLong(writeBuffer, writePos + 1, l, 8);
-      writePos += 9;
-    }
+    checkCapacity(1 /* header size */ + 8);
+    writeBuffer[writePos] = VariantUtil.HDR_INT64;
+    VariantUtil.writeLong(writeBuffer, writePos + 1, l, 8);
+    writePos += 9;
+    return this;
+  }
+
+  /**
+   * Appends an int value to the variant builder.
+   * @param i the int to append
+   * @return this builder
+   */
+  public VariantBuilder appendInt(int i) {
+    checkCapacity(1 /* header size */ + 4);
+    writeBuffer[writePos] = VariantUtil.HDR_INT32;
+    VariantUtil.writeLong(writeBuffer, writePos + 1, i, 4);
+    writePos += 5;
+    return this;
+  }
+
+  /**
+   * Appends a short value to the variant builder.
+   * @param s the short to append
+   * @return this builder
+   */
+  public VariantBuilder appendShort(short s) {
+    checkCapacity(1 /* header size */ + 2);
+    writeBuffer[writePos] = VariantUtil.HDR_INT16;
+    VariantUtil.writeLong(writeBuffer, writePos + 1, s, 2);
+    writePos += 3;
+    return this;
+  }
+
+  /**
+   * Appends a byte value to the variant builder.
+   * @param b the byte to append
+   * @return this builder
+   */
+  public VariantBuilder appendByte(byte b) {
+    checkCapacity(1 /* header size */ + 1);
+    writeBuffer[writePos] = VariantUtil.HDR_INT8;
+    VariantUtil.writeLong(writeBuffer, writePos + 1, b, 1);
+    writePos += 2;
     return this;
   }
 

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantObjectBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantObjectBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.variant;
+
+import java.util.ArrayList;
+
+/**
+ * Builder for creating Variant object, used by VariantBuilder.
+ */
+public class VariantObjectBuilder {
+  VariantObjectBuilder(VariantBuilder builder) {
+    this.builder = builder;
+    this.startPos = builder.writePos();
+    this.fields = new ArrayList<>();
+  }
+
+  void appendKey(String key) {
+    fields.add(new VariantBuilder.FieldEntry(key, builder.addKey(key), builder.writePos() - startPos));
+  }
+
+  int startPos() {
+    return startPos;
+  }
+
+  ArrayList<VariantBuilder.FieldEntry> fields() {
+    return fields;
+  }
+
+  /** The underlying VariantBuilder. */
+  private final VariantBuilder builder;
+  /** The saved builder.writPos() for the start of this object. */
+  private final int startPos;
+  /** The FieldEntry list for the fields of this object. */
+  private final ArrayList<VariantBuilder.FieldEntry> fields;
+}

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantObjectBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantObjectBuilder.java
@@ -26,6 +26,8 @@ public class VariantObjectBuilder extends VariantBuilder {
   private final VariantBuilder parent;
   /** The FieldEntry list for the fields of this object. */
   private final ArrayList<VariantBuilder.FieldEntry> fields;
+  /** The number of values appended to this object. */
+  protected long numValues = 0;
 
   VariantObjectBuilder(VariantBuilder parent) {
     this.parent = parent;
@@ -64,6 +66,11 @@ public class VariantObjectBuilder extends VariantBuilder {
     if (numValues != fields.size() - 1) {
       throw new IllegalStateException("Cannot append an object value before calling appendKey()");
     }
+  }
+
+  @Override
+  protected void incrementNumValues() {
+    numValues++;
   }
 
   @Override

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantObjectBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantObjectBuilder.java
@@ -40,7 +40,7 @@ public class VariantObjectBuilder extends VariantBuilder {
    */
   void appendKey(String key) {
     if (fields.size() > numValues) {
-      throw new IllegalStateException("Cannot call appendKey() before appending an object value.");
+      throw new IllegalStateException("Cannot call appendKey() before appending a value for the previous key.");
     }
     updateLastValueSize();
     fields.add(new VariantBuilder.FieldEntry(key, addDictionaryKey(key), writePos));
@@ -56,6 +56,7 @@ public class VariantObjectBuilder extends VariantBuilder {
       throw new IllegalStateException(String.format(
           "Number of object keys (%d) do not match the number of values (%d).", fields.size(), numValues));
     }
+    checkMultipleNested("Cannot call endObject() while a nested object/array is still open.");
     updateLastValueSize();
     return fields;
   }
@@ -66,10 +67,12 @@ public class VariantObjectBuilder extends VariantBuilder {
     if (numValues != fields.size() - 1) {
       throw new IllegalStateException("Cannot append an object value before calling appendKey()");
     }
+    numValues++;
   }
 
   @Override
-  protected void incrementNumValues() {
+  protected void onStartNested() {
+    checkMultipleNested("Cannot call startObject()/startArray() without calling endObject()/endArray() first.");
     numValues++;
   }
 

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantObjectBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantObjectBuilder.java
@@ -59,11 +59,8 @@ public class VariantObjectBuilder extends VariantBuilder {
   }
 
   @Override
-  protected void checkAppendState() {
-    if (objectBuilder != null) {
-      throw new IllegalStateException(
-          "Cannot call append() methods while an object is being built. Must call endObject() first.");
-    }
+  protected void onAppend() {
+    checkAppendWhileNested();
     if (numValues != fields.size() - 1) {
       throw new IllegalStateException("Cannot append an object value before calling appendKey()");
     }

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
@@ -187,6 +187,29 @@ class VariantUtil {
   // The size (in bytes) of a UUID.
   static final int UUID_SIZE = 16;
 
+  // header bytes
+  static final byte HDR_NULL = primitiveHeader(NULL);
+  static final byte HDR_LONG_STRING = primitiveHeader(LONG_STR);
+  static final byte HDR_TRUE = primitiveHeader(TRUE);
+  static final byte HDR_FALSE = primitiveHeader(FALSE);
+  static final byte HDR_INT8 = primitiveHeader(INT8);
+  static final byte HDR_INT16 = primitiveHeader(INT16);
+  static final byte HDR_INT32 = primitiveHeader(INT32);
+  static final byte HDR_INT64 = primitiveHeader(INT64);
+  static final byte HDR_DOUBLE = primitiveHeader(DOUBLE);
+  static final byte HDR_DECIMAL4 = primitiveHeader(DECIMAL4);
+  static final byte HDR_DECIMAL8 = primitiveHeader(DECIMAL8);
+  static final byte HDR_DECIMAL16 = primitiveHeader(DECIMAL16);
+  static final byte HDR_DATE = primitiveHeader(DATE);
+  static final byte HDR_TIMESTAMP_TZ = primitiveHeader(TIMESTAMP_TZ);
+  static final byte HDR_TIMESTAMP_NTZ = primitiveHeader(TIMESTAMP_NTZ);
+  static final byte HDR_TIME = primitiveHeader(TIME);
+  static final byte HDR_TIMESTAMP_NANOS_TZ = primitiveHeader(TIMESTAMP_NANOS_TZ);
+  static final byte HDR_TIMESTAMP_NANOS_NTZ = primitiveHeader(TIMESTAMP_NANOS_NTZ);
+  static final byte HDR_FLOAT = primitiveHeader(FLOAT);
+  static final byte HDR_BINARY = primitiveHeader(BINARY);
+  static final byte HDR_UUID = primitiveHeader(UUID);
+
   static byte primitiveHeader(int type) {
     return (byte) (type << 2 | PRIMITIVE);
   }

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
@@ -188,27 +188,27 @@ class VariantUtil {
   static final int UUID_SIZE = 16;
 
   // header bytes
-  static final byte HDR_NULL = primitiveHeader(NULL);
-  static final byte HDR_LONG_STRING = primitiveHeader(LONG_STR);
-  static final byte HDR_TRUE = primitiveHeader(TRUE);
-  static final byte HDR_FALSE = primitiveHeader(FALSE);
-  static final byte HDR_INT8 = primitiveHeader(INT8);
-  static final byte HDR_INT16 = primitiveHeader(INT16);
-  static final byte HDR_INT32 = primitiveHeader(INT32);
-  static final byte HDR_INT64 = primitiveHeader(INT64);
-  static final byte HDR_DOUBLE = primitiveHeader(DOUBLE);
-  static final byte HDR_DECIMAL4 = primitiveHeader(DECIMAL4);
-  static final byte HDR_DECIMAL8 = primitiveHeader(DECIMAL8);
-  static final byte HDR_DECIMAL16 = primitiveHeader(DECIMAL16);
-  static final byte HDR_DATE = primitiveHeader(DATE);
-  static final byte HDR_TIMESTAMP_TZ = primitiveHeader(TIMESTAMP_TZ);
-  static final byte HDR_TIMESTAMP_NTZ = primitiveHeader(TIMESTAMP_NTZ);
-  static final byte HDR_TIME = primitiveHeader(TIME);
-  static final byte HDR_TIMESTAMP_NANOS_TZ = primitiveHeader(TIMESTAMP_NANOS_TZ);
-  static final byte HDR_TIMESTAMP_NANOS_NTZ = primitiveHeader(TIMESTAMP_NANOS_NTZ);
-  static final byte HDR_FLOAT = primitiveHeader(FLOAT);
-  static final byte HDR_BINARY = primitiveHeader(BINARY);
-  static final byte HDR_UUID = primitiveHeader(UUID);
+  static final byte HEADER_NULL = primitiveHeader(NULL);
+  static final byte HEADER_LONG_STRING = primitiveHeader(LONG_STR);
+  static final byte HEADER_TRUE = primitiveHeader(TRUE);
+  static final byte HEADER_FALSE = primitiveHeader(FALSE);
+  static final byte HEADER_INT8 = primitiveHeader(INT8);
+  static final byte HEADER_INT16 = primitiveHeader(INT16);
+  static final byte HEADER_INT32 = primitiveHeader(INT32);
+  static final byte HEADER_INT64 = primitiveHeader(INT64);
+  static final byte HEADER_DOUBLE = primitiveHeader(DOUBLE);
+  static final byte HEADER_DECIMAL4 = primitiveHeader(DECIMAL4);
+  static final byte HEADER_DECIMAL8 = primitiveHeader(DECIMAL8);
+  static final byte HEADER_DECIMAL16 = primitiveHeader(DECIMAL16);
+  static final byte HEADER_DATE = primitiveHeader(DATE);
+  static final byte HEADER_TIMESTAMP_TZ = primitiveHeader(TIMESTAMP_TZ);
+  static final byte HEADER_TIMESTAMP_NTZ = primitiveHeader(TIMESTAMP_NTZ);
+  static final byte HEADER_TIME = primitiveHeader(TIME);
+  static final byte HEADER_TIMESTAMP_NANOS_TZ = primitiveHeader(TIMESTAMP_NANOS_TZ);
+  static final byte HEADER_TIMESTAMP_NANOS_NTZ = primitiveHeader(TIMESTAMP_NANOS_NTZ);
+  static final byte HEADER_FLOAT = primitiveHeader(FLOAT);
+  static final byte HEADER_BINARY = primitiveHeader(BINARY);
+  static final byte HEADER_UUID = primitiveHeader(UUID);
 
   static byte primitiveHeader(int type) {
     return (byte) (type << 2 | PRIMITIVE);
@@ -359,75 +359,6 @@ class VariantUtil {
             return Variant.Type.TIMESTAMP_NANOS_NTZ;
           case UUID:
             return Variant.Type.UUID;
-          default:
-            throw new UnsupportedOperationException(
-                String.format("Unknown type in Variant. primitive type: %d", typeInfo));
-        }
-    }
-  }
-
-  /**
-   * Computes the actual size (in bytes) of the Variant value at `value[pos...]`
-   * @param value The Variant value
-   * @param pos The starting index of the Variant value
-   * @return The size (in bytes) of the Variant value
-   */
-  public static int valueSize(ByteBuffer value, int pos) {
-    checkIndex(pos, value.limit());
-    int basicType = value.get(pos) & BASIC_TYPE_MASK;
-    int typeInfo = (value.get(pos) >> BASIC_TYPE_BITS) & PRIMITIVE_TYPE_MASK;
-    switch (basicType) {
-      case SHORT_STR:
-        return 1 + typeInfo;
-      case OBJECT: {
-        VariantUtil.ObjectInfo info = VariantUtil.getObjectInfo(slice(value, pos));
-        return info.dataStartOffset
-            + readUnsigned(
-                value,
-                pos + info.offsetStartOffset + info.numElements * info.offsetSize,
-                info.offsetSize);
-      }
-      case ARRAY: {
-        VariantUtil.ArrayInfo info = VariantUtil.getArrayInfo(slice(value, pos));
-        return info.dataStartOffset
-            + readUnsigned(
-                value,
-                pos + info.offsetStartOffset + info.numElements * info.offsetSize,
-                info.offsetSize);
-      }
-      default:
-        switch (typeInfo) {
-          case NULL:
-          case TRUE:
-          case FALSE:
-            return 1;
-          case INT8:
-            return 2;
-          case INT16:
-            return 3;
-          case INT32:
-          case DATE:
-          case FLOAT:
-            return 5;
-          case INT64:
-          case DOUBLE:
-          case TIMESTAMP_TZ:
-          case TIMESTAMP_NTZ:
-          case TIME:
-          case TIMESTAMP_NANOS_TZ:
-          case TIMESTAMP_NANOS_NTZ:
-            return 9;
-          case DECIMAL4:
-            return 6;
-          case DECIMAL8:
-            return 10;
-          case DECIMAL16:
-            return 18;
-          case BINARY:
-          case LONG_STR:
-            return 1 + U32_SIZE + readUnsigned(value, pos + 1, U32_SIZE);
-          case UUID:
-            return 1 + UUID_SIZE;
           default:
             throw new UnsupportedOperationException(
                 String.format("Unknown type in Variant. primitive type: %d", typeInfo));

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
@@ -92,17 +92,6 @@ public class TestVariantArray {
   }
 
   @Test
-  public void testEmptyArrayBuilder() {
-    VariantBuilder b = new VariantBuilder(true);
-    VariantArrayBuilder a = b.startArray();
-    b.endArray(a);
-    VariantTestUtil.testVariant(b.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(0, v.numArrayElements());
-    });
-  }
-
-  @Test
   public void testLargeArraySize() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {0b10011, (byte) 0xFF, (byte) 0x01, 0x00, 0x00}),
@@ -110,25 +99,6 @@ public class TestVariantArray {
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
       Assert.assertEquals(511, v.numArrayElements());
-    });
-  }
-
-  @Test
-  public void testLargeArraySizeBuilder() {
-    VariantBuilder b = new VariantBuilder(true);
-    VariantArrayBuilder a = b.startArray();
-    for (int i = 0; i < 511; i++) {
-      b.startArrayElement(a);
-      b.appendInt(i);
-    }
-    b.endArray(a);
-    VariantTestUtil.testVariant(b.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(511, v.numArrayElements());
-      for (int i = 0; i < 511; i++) {
-        VariantTestUtil.checkType(v.getElementAtIndex(i), VariantUtil.PRIMITIVE, Variant.Type.INT);
-        Assert.assertEquals(i, v.getElementAtIndex(i).getInt());
-      }
     });
   }
 
@@ -161,45 +131,6 @@ public class TestVariantArray {
       VariantTestUtil.checkType(nestedV.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.NULL);
       VariantTestUtil.checkType(nestedV.getElementAtIndex(2), VariantUtil.SHORT_STR, Variant.Type.STRING);
       Assert.assertEquals("c", nestedV.getElementAtIndex(2).getString());
-    });
-  }
-
-  @Test
-  public void testMixedArrayBuilder() {
-    VariantBuilder b = new VariantBuilder(true);
-    VariantArrayBuilder arrBuilder = b.startArray();
-    b.startArrayElement(arrBuilder);
-    b.appendBoolean(true);
-    b.startArrayElement(arrBuilder);
-    b.appendLong(1234567890);
-    b.startArrayElement(arrBuilder);
-    {
-      // build a nested array
-      VariantArrayBuilder nestedBuilder = b.startArray();
-      b.startArrayElement(nestedBuilder);
-      {
-        // build a nested empty array
-        VariantArrayBuilder emptyBuilder = b.startArray();
-        b.endArray(emptyBuilder);
-      }
-      b.startArrayElement(nestedBuilder);
-      b.appendString("variant");
-      b.endArray(nestedBuilder);
-    }
-    b.endArray(arrBuilder);
-
-    VariantTestUtil.testVariant(b.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(3, v.numArrayElements());
-      Assert.assertTrue(v.getElementAtIndex(0).getBoolean());
-      Assert.assertEquals(1234567890, v.getElementAtIndex(1).getLong());
-      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.ARRAY, Variant.Type.ARRAY);
-
-      Variant nested = v.getElementAtIndex(2);
-      Assert.assertEquals(2, nested.numArrayElements());
-      VariantTestUtil.checkType(nested.getElementAtIndex(0), VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(0, nested.getElementAtIndex(0).numArrayElements());
-      Assert.assertEquals("variant", nested.getElementAtIndex(1).getString());
     });
   }
 
@@ -236,47 +167,6 @@ public class TestVariantArray {
   public void testArrayFourByteOffset() {
     // a string larger than 16777215 bytes to push the value offset size above 3 bytes
     testArrayOffsetSize(VariantTestUtil.randomString(16_800_000));
-  }
-
-  private void testArrayOffsetSizeBuilder(String randomString) {
-    VariantBuilder b = new VariantBuilder(true);
-    VariantArrayBuilder arrBuilder = b.startArray();
-    b.startArrayElement(arrBuilder);
-    b.appendString(randomString);
-    b.startArrayElement(arrBuilder);
-    b.appendBoolean(true);
-    b.startArrayElement(arrBuilder);
-    b.appendLong(1234567890);
-    b.endArray(arrBuilder);
-
-    VariantTestUtil.testVariant(b.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(3, v.numArrayElements());
-      VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals(randomString, v.getElementAtIndex(0).getString());
-      VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
-      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getLong());
-    });
-  }
-
-  @Test
-  public void testArrayTwoByteOffsetBuilder() {
-    // a string larger than 255 bytes to push the value offset size above 1 byte
-    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(300));
-  }
-
-  @Test
-  public void testArrayThreeByteOffsetBuilder() {
-    // a string larger than 65535 bytes to push the value offset size above 2 bytes
-    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(70_000));
-  }
-
-  @Test
-  public void testArrayFourByteOffsetBuilder() {
-    // a string larger than 16777215 bytes to push the value offset size above 3 bytes
-    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(16_800_000));
   }
 
   @Test

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
@@ -20,11 +20,7 @@ package org.apache.parquet.variant;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.time.LocalDate;
-import java.util.*;
-import java.util.function.Consumer;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -32,83 +28,15 @@ import org.slf4j.LoggerFactory;
 
 public class TestVariantArray {
   private static final Logger LOG = LoggerFactory.getLogger(TestVariantArray.class);
-  private static final String RANDOM_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-  /** Random number generator for generating random strings */
-  private static SecureRandom random = new SecureRandom(new byte[] {1, 2, 3, 4, 5});
-
-  private static final ByteBuffer EMPTY_METADATA = ByteBuffer.wrap(new byte[] {0b1});
-
-  private static final byte[] VALUE_NULL = new byte[] {primitiveHeader(0)};
-  private static final byte[] VALUE_BOOL = new byte[] {primitiveHeader(1)};
-  private static final byte[] VALUE_INT = new byte[] {primitiveHeader(5), (byte) 0xD2, 0x02, (byte) 0x96, 0x49};
+  private static final byte[] VALUE_NULL = new byte[] {VariantTestUtil.primitiveHeader(0)};
+  private static final byte[] VALUE_BOOL = new byte[] {VariantTestUtil.primitiveHeader(1)};
+  private static final byte[] VALUE_INT =
+      new byte[] {VariantTestUtil.primitiveHeader(5), (byte) 0xD2, 0x02, (byte) 0x96, 0x49};
   private static final byte[] VALUE_STRING =
-      new byte[] {primitiveHeader(16), 0x07, 0x00, 0x00, 0x00, 'v', 'a', 'r', 'i', 'a', 'n', 't'};
+      new byte[] {VariantTestUtil.primitiveHeader(16), 0x07, 0x00, 0x00, 0x00, 'v', 'a', 'r', 'i', 'a', 'n', 't'};
   private static final byte[] VALUE_SHORT_STRING = new byte[] {0b101, 'c'};
   private static final byte[] VALUE_DATE = new byte[] {0b101100, (byte) 0xE3, 0x4E, 0x00, 0x00};
-
-  private void checkType(Variant v, int expectedBasicType, Variant.Type expectedType) {
-    Assert.assertEquals(expectedBasicType, v.value.get(v.value.position()) & VariantUtil.BASIC_TYPE_MASK);
-    Assert.assertEquals(expectedType, v.getType());
-  }
-
-  private String randomString(int len) {
-    StringBuilder sb = new StringBuilder(len);
-    for (int i = 0; i < len; i++) {
-      sb.append(RANDOM_CHARS.charAt(random.nextInt(RANDOM_CHARS.length())));
-    }
-    return sb.toString();
-  }
-
-  private void testVariant(Variant v, Consumer<Variant> consumer) {
-    consumer.accept(v);
-    // Create new Variant with different byte offsets
-    byte[] newValue = new byte[v.value.capacity() + 50];
-    byte[] newMetadata = new byte[v.metadata.capacity() + 50];
-    Arrays.fill(newValue, (byte) 0xFF);
-    Arrays.fill(newMetadata, (byte) 0xFF);
-    v.value.position(0);
-    v.value.get(newValue, 25, v.value.capacity());
-    v.value.position(0);
-    v.metadata.position(0);
-    v.metadata.get(newMetadata, 25, v.metadata.capacity());
-    v.metadata.position(0);
-    Variant v2 = new Variant(
-        ByteBuffer.wrap(newValue, 25, v.value.capacity()),
-        ByteBuffer.wrap(newMetadata, 25, v.metadata.capacity()));
-    consumer.accept(v2);
-  }
-
-  private static byte primitiveHeader(int type) {
-    return (byte) (type << 2);
-  }
-
-  private static int getMinIntegerSize(int value) {
-    return (value <= 0xFF) ? 1 : (value <= 0xFFFF) ? 2 : (value <= 0xFFFFFF) ? 3 : 4;
-  }
-
-  private static void writeVarlenInt(ByteBuffer buffer, int value, int valueSize) {
-    if (valueSize == 1) {
-      buffer.put((byte) value);
-    } else if (valueSize == 2) {
-      buffer.putShort((short) value);
-    } else if (valueSize == 3) {
-      buffer.put((byte) (value & 0xFF));
-      buffer.put((byte) ((value >> 8) & 0xFF));
-      buffer.put((byte) ((value >> 16) & 0xFF));
-    } else {
-      buffer.putInt(value);
-    }
-  }
-
-  private static byte[] constructString(String value) {
-    return ByteBuffer.allocate(value.length() + 5)
-        .order(ByteOrder.LITTLE_ENDIAN)
-        .put(primitiveHeader(16))
-        .putInt(value.length())
-        .put(value.getBytes(StandardCharsets.UTF_8))
-        .array();
-  }
 
   private static byte[] constructArray(byte[]... elements) {
     int dataSize = 0;
@@ -117,7 +45,7 @@ public class TestVariantArray {
     }
 
     boolean isLarge = elements.length > 0xFF;
-    int offsetSize = getMinIntegerSize(dataSize);
+    int offsetSize = VariantTestUtil.getMinIntegerSize(dataSize);
     int headerSize = 1 + (isLarge ? 4 : 1) + (elements.length + 1) * offsetSize;
 
     ByteBuffer output = ByteBuffer.allocate(headerSize + dataSize).order(ByteOrder.LITTLE_ENDIAN);
@@ -132,10 +60,10 @@ public class TestVariantArray {
 
     int currOffset = 0;
     for (int i = 0; i < elements.length; ++i) {
-      writeVarlenInt(output, currOffset, offsetSize);
+      VariantTestUtil.writeVarlenInt(output, currOffset, offsetSize);
       currOffset += elements[i].length;
     }
-    writeVarlenInt(output, currOffset, offsetSize);
+    VariantTestUtil.writeVarlenInt(output, currOffset, offsetSize);
 
     for (int i = 0; i < elements.length; ++i) {
       output.put(elements[i]);
@@ -146,18 +74,30 @@ public class TestVariantArray {
 
   @Test
   public void testEmptyArray() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b0011, 0x00}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+    Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b0011, 0x00}), VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
       Assert.assertEquals(0, v.numArrayElements());
     });
   }
 
   @Test
   public void testEmptyLargeArray() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10011, 0x00, 0x00, 0x00, 0x00}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {0b10011, 0x00, 0x00, 0x00, 0x00}), VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(0, v.numArrayElements());
+    });
+  }
+
+  @Test
+  public void testEmptyArrayBuilder() {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantArrayBuilder a = b.startArray();
+    b.endArray(a);
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
       Assert.assertEquals(0, v.numArrayElements());
     });
   }
@@ -165,10 +105,29 @@ public class TestVariantArray {
   @Test
   public void testLargeArraySize() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {0b10011, (byte) 0xFF, (byte) 0x01, 0x00, 0x00}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+        ByteBuffer.wrap(new byte[] {0b10011, (byte) 0xFF, (byte) 0x01, 0x00, 0x00}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
       Assert.assertEquals(511, v.numArrayElements());
+    });
+  }
+
+  @Test
+  public void testLargeArraySizeBuilder() {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantArrayBuilder a = b.startArray();
+    for (int i = 0; i < 511; i++) {
+      b.startArrayElement(a);
+      b.appendLong(i);
+    }
+    b.endArray(a);
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(511, v.numArrayElements());
+      for (int i = 0; i < 511; i++) {
+        Assert.assertEquals(i, v.getElementAtIndex(i).getInt());
+      }
     });
   }
 
@@ -177,45 +136,85 @@ public class TestVariantArray {
     byte[] nested = constructArray(VALUE_INT, VALUE_NULL, VALUE_SHORT_STRING);
     Variant value = new Variant(
         ByteBuffer.wrap(constructArray(VALUE_DATE, VALUE_BOOL, VALUE_INT, VALUE_STRING, nested)),
-        EMPTY_METADATA);
+        VariantTestUtil.EMPTY_METADATA);
 
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
       Assert.assertEquals(5, v.numArrayElements());
-      checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.DATE);
+      VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.DATE);
       Assert.assertEquals(
           LocalDate.parse("2025-04-17"),
           LocalDate.ofEpochDay(v.getElementAtIndex(0).getInt()));
-      checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
-      checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getElementAtIndex(2).getInt());
-      checkType(v.getElementAtIndex(3), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+      VariantTestUtil.checkType(v.getElementAtIndex(3), VariantUtil.PRIMITIVE, Variant.Type.STRING);
       Assert.assertEquals("variant", v.getElementAtIndex(3).getString());
-      checkType(v.getElementAtIndex(4), VariantUtil.ARRAY, Variant.Type.ARRAY);
+      VariantTestUtil.checkType(v.getElementAtIndex(4), VariantUtil.ARRAY, Variant.Type.ARRAY);
 
       Variant nestedV = v.getElementAtIndex(4);
       Assert.assertEquals(3, nestedV.numArrayElements());
-      checkType(nestedV.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      VariantTestUtil.checkType(nestedV.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, nestedV.getElementAtIndex(0).getInt());
-      checkType(nestedV.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.NULL);
-      checkType(nestedV.getElementAtIndex(2), VariantUtil.SHORT_STR, Variant.Type.STRING);
+      VariantTestUtil.checkType(nestedV.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.NULL);
+      VariantTestUtil.checkType(nestedV.getElementAtIndex(2), VariantUtil.SHORT_STR, Variant.Type.STRING);
       Assert.assertEquals("c", nestedV.getElementAtIndex(2).getString());
     });
   }
 
-  public void testArrayOffsetSize(String randomString) {
-    Variant value = new Variant(
-        ByteBuffer.wrap(constructArray(constructString(randomString), VALUE_BOOL, VALUE_INT)), EMPTY_METADATA);
+  @Test
+  public void testMixedArrayBuilder() {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantArrayBuilder arrBuilder = b.startArray();
+    b.startArrayElement(arrBuilder);
+    b.appendBoolean(true);
+    b.startArrayElement(arrBuilder);
+    b.appendLong(1234567890);
+    b.startArrayElement(arrBuilder);
+    {
+      // build a nested array
+      VariantArrayBuilder nestedBuilder = b.startArray();
+      b.startArrayElement(nestedBuilder);
+      {
+        // build a nested empty array
+        VariantArrayBuilder emptyBuilder = b.startArray();
+        b.endArray(emptyBuilder);
+      }
+      b.startArrayElement(nestedBuilder);
+      b.appendString("variant");
+      b.endArray(nestedBuilder);
+    }
+    b.endArray(arrBuilder);
 
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
       Assert.assertEquals(3, v.numArrayElements());
-      checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+      Assert.assertTrue(v.getElementAtIndex(0).getBoolean());
+      Assert.assertEquals(1234567890, v.getElementAtIndex(1).getLong());
+      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.ARRAY, Variant.Type.ARRAY);
+
+      Variant nested = v.getElementAtIndex(2);
+      Assert.assertEquals(2, nested.numArrayElements());
+      VariantTestUtil.checkType(nested.getElementAtIndex(0), VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(0, nested.getElementAtIndex(0).numArrayElements());
+      Assert.assertEquals("variant", nested.getElementAtIndex(1).getString());
+    });
+  }
+
+  private void testArrayOffsetSize(String randomString) {
+    Variant value = new Variant(
+        ByteBuffer.wrap(constructArray(VariantTestUtil.constructString(randomString), VALUE_BOOL, VALUE_INT)),
+        VariantTestUtil.EMPTY_METADATA);
+
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(3, v.numArrayElements());
+      VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.STRING);
       Assert.assertEquals(randomString, v.getElementAtIndex(0).getString());
-      checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
-      checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getElementAtIndex(2).getInt());
     });
   }
@@ -223,26 +222,67 @@ public class TestVariantArray {
   @Test
   public void testArrayTwoByteOffset() {
     // a string larger than 255 bytes to push the value offset size above 1 byte
-    testArrayOffsetSize(randomString(300));
+    testArrayOffsetSize(VariantTestUtil.randomString(300));
   }
 
   @Test
   public void testArrayThreeByteOffset() {
     // a string larger than 65535 bytes to push the value offset size above 2 bytes
-    testArrayOffsetSize(randomString(70_000));
+    testArrayOffsetSize(VariantTestUtil.randomString(70_000));
   }
 
   @Test
   public void testArrayFourByteOffset() {
     // a string larger than 16777215 bytes to push the value offset size above 3 bytes
-    testArrayOffsetSize(randomString(16_800_000));
+    testArrayOffsetSize(VariantTestUtil.randomString(16_800_000));
+  }
+
+  private void testArrayOffsetSizeBuilder(String randomString) {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantArrayBuilder arrBuilder = b.startArray();
+    b.startArrayElement(arrBuilder);
+    b.appendString(randomString);
+    b.startArrayElement(arrBuilder);
+    b.appendBoolean(true);
+    b.startArrayElement(arrBuilder);
+    b.appendLong(1234567890);
+    b.endArray(arrBuilder);
+
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(3, v.numArrayElements());
+      VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+      Assert.assertEquals(randomString, v.getElementAtIndex(0).getString());
+      VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
+      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getInt());
+    });
+  }
+
+  @Test
+  public void testArrayTwoByteOffsetBuilder() {
+    // a string larger than 255 bytes to push the value offset size above 1 byte
+    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(300));
+  }
+
+  @Test
+  public void testArrayThreeByteOffsetBuilder() {
+    // a string larger than 65535 bytes to push the value offset size above 2 bytes
+    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(70_000));
+  }
+
+  @Test
+  public void testArrayFourByteOffsetBuilder() {
+    // a string larger than 16777215 bytes to push the value offset size above 3 bytes
+    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(16_800_000));
   }
 
   @Test
   public void testInvalidArray() {
     try {
       // An object header
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b1000010}), EMPTY_METADATA);
+      Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b1000010}), VariantTestUtil.EMPTY_METADATA);
       value.numArrayElements();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
@@ -119,13 +119,14 @@ public class TestVariantArray {
     VariantArrayBuilder a = b.startArray();
     for (int i = 0; i < 511; i++) {
       b.startArrayElement(a);
-      b.appendLong(i);
+      b.appendInt(i);
     }
     b.endArray(a);
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
       Assert.assertEquals(511, v.numArrayElements());
       for (int i = 0; i < 511; i++) {
+        VariantTestUtil.checkType(v.getElementAtIndex(i), VariantUtil.PRIMITIVE, Variant.Type.INT);
         Assert.assertEquals(i, v.getElementAtIndex(i).getInt());
       }
     });
@@ -255,8 +256,8 @@ public class TestVariantArray {
       Assert.assertEquals(randomString, v.getElementAtIndex(0).getString());
       VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
-      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getInt());
+      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getLong());
     });
   }
 

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArrayBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArrayBuilder.java
@@ -221,4 +221,73 @@ public class TestVariantArrayBuilder {
       // expected
     }
   }
+
+  @Test
+  public void testOpenNestedObject() {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder arr = b.startArray();
+    arr.startObject();
+    try {
+      b.endArray();
+      Assert.fail("Expected Exception when calling endArray() with an open nested object");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testOpenNestedObjectWithKey() {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder arr = b.startArray();
+    VariantObjectBuilder nested = arr.startObject();
+    nested.appendKey("nested");
+    try {
+      b.endArray();
+      Assert.fail("Expected Exception when calling endArray() with an open nested object");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testOpenNestedObjectWithKeyValue() {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder arr = b.startArray();
+    VariantObjectBuilder nested = arr.startObject();
+    nested.appendKey("nested");
+    nested.appendInt(1);
+    try {
+      b.endArray();
+      Assert.fail("Expected Exception when calling endArray() with an open nested object");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testOpenNestedArray() {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder arr = b.startArray();
+    arr.startArray();
+    try {
+      b.endArray();
+      Assert.fail("Expected Exception when calling endArray() with an open nested array");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testOpenNestedArrayWithElement() {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder arr = b.startArray();
+    VariantArrayBuilder nested = arr.startArray();
+    nested.appendInt(1);
+    try {
+      b.endArray();
+      Assert.fail("Expected Exception when calling endArray() with an open nested array");
+    } catch (Exception e) {
+      // expected
+    }
+  }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArrayBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArrayBuilder.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.variant;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestVariantArrayBuilder {
+  private static final Logger LOG = LoggerFactory.getLogger(TestVariantArrayBuilder.class);
+
+  private static final byte[] VALUE_NULL = new byte[] {VariantTestUtil.primitiveHeader(0)};
+  private static final byte[] VALUE_BOOL = new byte[] {VariantTestUtil.primitiveHeader(1)};
+  private static final byte[] VALUE_INT =
+      new byte[] {VariantTestUtil.primitiveHeader(5), (byte) 0xD2, 0x02, (byte) 0x96, 0x49};
+  private static final byte[] VALUE_STRING =
+      new byte[] {VariantTestUtil.primitiveHeader(16), 0x07, 0x00, 0x00, 0x00, 'v', 'a', 'r', 'i', 'a', 'n', 't'};
+  private static final byte[] VALUE_SHORT_STRING = new byte[] {0b101, 'c'};
+  private static final byte[] VALUE_DATE = new byte[] {0b101100, (byte) 0xE3, 0x4E, 0x00, 0x00};
+
+  @Test
+  public void testEmptyArrayBuilder() {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder a = b.startArray();
+    b.endArray(a);
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(0, v.numArrayElements());
+    });
+  }
+
+  @Test
+  public void testLargeArraySizeBuilder() {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder a = b.startArray();
+    for (int i = 0; i < 511; i++) {
+      b.startArrayElement(a);
+      b.appendInt(i);
+    }
+    b.endArray(a);
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(511, v.numArrayElements());
+      for (int i = 0; i < 511; i++) {
+        VariantTestUtil.checkType(v.getElementAtIndex(i), VariantUtil.PRIMITIVE, Variant.Type.INT);
+        Assert.assertEquals(i, v.getElementAtIndex(i).getInt());
+      }
+    });
+  }
+
+  @Test
+  public void testMixedArrayBuilder() {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder arrBuilder = b.startArray();
+    b.startArrayElement(arrBuilder);
+    b.appendBoolean(true);
+    b.startArrayElement(arrBuilder);
+    b.appendLong(1234567890);
+    b.startArrayElement(arrBuilder);
+    {
+      // build a nested array
+      VariantArrayBuilder nestedBuilder = b.startArray();
+      b.startArrayElement(nestedBuilder);
+      {
+        // build a nested empty array
+        VariantArrayBuilder emptyBuilder = b.startArray();
+        b.endArray(emptyBuilder);
+      }
+      b.startArrayElement(nestedBuilder);
+      b.appendString("variant");
+      b.endArray(nestedBuilder);
+    }
+    b.endArray(arrBuilder);
+
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(3, v.numArrayElements());
+      Assert.assertTrue(v.getElementAtIndex(0).getBoolean());
+      Assert.assertEquals(1234567890, v.getElementAtIndex(1).getLong());
+      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.ARRAY, Variant.Type.ARRAY);
+
+      Variant nested = v.getElementAtIndex(2);
+      Assert.assertEquals(2, nested.numArrayElements());
+      VariantTestUtil.checkType(nested.getElementAtIndex(0), VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(0, nested.getElementAtIndex(0).numArrayElements());
+      Assert.assertEquals("variant", nested.getElementAtIndex(1).getString());
+    });
+  }
+
+  private void testArrayOffsetSizeBuilder(String randomString) {
+    VariantBuilder b = new VariantBuilder();
+    VariantArrayBuilder arrBuilder = b.startArray();
+    b.startArrayElement(arrBuilder);
+    b.appendString(randomString);
+    b.startArrayElement(arrBuilder);
+    b.appendBoolean(true);
+    b.startArrayElement(arrBuilder);
+    b.appendLong(1234567890);
+    b.endArray(arrBuilder);
+
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
+      Assert.assertEquals(3, v.numArrayElements());
+      VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+      Assert.assertEquals(randomString, v.getElementAtIndex(0).getString());
+      VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
+      VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getLong());
+    });
+  }
+
+  @Test
+  public void testArrayTwoByteOffsetBuilder() {
+    // a string larger than 255 bytes to push the value offset size above 1 byte
+    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(300));
+  }
+
+  @Test
+  public void testArrayThreeByteOffsetBuilder() {
+    // a string larger than 65535 bytes to push the value offset size above 2 bytes
+    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(70_000));
+  }
+
+  @Test
+  public void testArrayFourByteOffsetBuilder() {
+    // a string larger than 16777215 bytes to push the value offset size above 3 bytes
+    testArrayOffsetSizeBuilder(VariantTestUtil.randomString(16_800_000));
+  }
+}

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
@@ -388,8 +388,8 @@ public class TestVariantObject {
     Assert.assertEquals(randomString, v.getFieldByKey("key1").getString());
     VariantTestUtil.checkType(v.getFieldByKey("key2"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
     Assert.assertTrue(v.getFieldByKey("key2").getBoolean());
-    VariantTestUtil.checkType(v.getFieldByKey("key3"), VariantUtil.PRIMITIVE, Variant.Type.INT);
-    Assert.assertEquals(1234567890, v.getFieldByKey("key3").getInt());
+    VariantTestUtil.checkType(v.getFieldByKey("key3"), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+    Assert.assertEquals(1234567890, v.getFieldByKey("key3").getLong());
   }
 
   @Test

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
@@ -380,16 +380,15 @@ public class TestVariantObject {
     b.appendLong(1234567890);
     b.endObject(objBuilder);
 
-    VariantTestUtil.testVariant(b.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
-      VariantTestUtil.checkType(v.getFieldByKey("key1"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals(randomString, v.getFieldByKey("key1").getString());
-      VariantTestUtil.checkType(v.getFieldByKey("key2"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getFieldByKey("key2").getBoolean());
-      VariantTestUtil.checkType(v.getFieldByKey("key3"), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getFieldByKey("key3").getInt());
-    });
+    Variant v = b.build();
+    VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    Assert.assertEquals(3, v.numObjectElements());
+    VariantTestUtil.checkType(v.getFieldByKey("key1"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+    Assert.assertEquals(randomString, v.getFieldByKey("key1").getString());
+    VariantTestUtil.checkType(v.getFieldByKey("key2"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+    Assert.assertTrue(v.getFieldByKey("key2").getBoolean());
+    VariantTestUtil.checkType(v.getFieldByKey("key3"), VariantUtil.PRIMITIVE, Variant.Type.INT);
+    Assert.assertEquals(1234567890, v.getFieldByKey("key3").getInt());
   }
 
   @Test
@@ -419,14 +418,12 @@ public class TestVariantObject {
     }
     b.endObject(objBuilder);
 
-    VariantTestUtil.testVariant(b.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(numKeys, v.numObjectElements());
-      // Only check a few keys, to avoid slowing down the test
-      Assert.assertEquals(0, v.getFieldByKey("k" + 0).getLong());
-      Assert.assertEquals(
-          numKeys - 1, v.getFieldByKey("k" + (numKeys - 1)).getLong());
-    });
+    Variant v = b.build();
+    VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    Assert.assertEquals(numKeys, v.numObjectElements());
+    // Only check a few keys, to avoid slowing down the test
+    Assert.assertEquals(0, v.getFieldByKey("k" + 0).getLong());
+    Assert.assertEquals(numKeys - 1, v.getFieldByKey("k" + (numKeys - 1)).getLong());
   }
 
   @Test

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -439,6 +440,7 @@ public class TestVariantObject {
   }
 
   @Test
+  @Ignore("Test uses too much memory")
   public void testObjectFourByteFieldIdBuilder() {
     // need more than 16777215 dictionary entries to push field id size above 3 bytes
     testObjectFieldIdSizeBuilder(16_800_000);

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
@@ -23,10 +23,13 @@ import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
 import java.time.LocalDate;
-import java.util.*;
-import java.util.function.Consumer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -34,86 +37,14 @@ import org.slf4j.LoggerFactory;
 
 public class TestVariantObject {
   private static final Logger LOG = LoggerFactory.getLogger(TestVariantObject.class);
-  private static final String RANDOM_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
-  /** Random number generator for generating random strings */
-  private static SecureRandom random = new SecureRandom(new byte[] {1, 2, 3, 4, 5});
-
-  private static final ByteBuffer EMPTY_METADATA = ByteBuffer.wrap(new byte[] {0b1});
-
-  private static final byte[] VALUE_NULL = new byte[] {primitiveHeader(0)};
-  private static final byte[] VALUE_BOOL = new byte[] {primitiveHeader(1)};
-  private static final byte[] VALUE_INT = new byte[] {primitiveHeader(5), (byte) 0xD2, 0x02, (byte) 0x96, 0x49};
+  private static final byte[] VALUE_NULL = new byte[] {VariantTestUtil.primitiveHeader(0)};
+  private static final byte[] VALUE_BOOL = new byte[] {VariantTestUtil.primitiveHeader(1)};
+  private static final byte[] VALUE_INT =
+      new byte[] {VariantTestUtil.primitiveHeader(5), (byte) 0xD2, 0x02, (byte) 0x96, 0x49};
   private static final byte[] VALUE_STRING =
-      new byte[] {primitiveHeader(16), 0x07, 0x00, 0x00, 0x00, 'v', 'a', 'r', 'i', 'a', 'n', 't'};
+      new byte[] {VariantTestUtil.primitiveHeader(16), 0x07, 0x00, 0x00, 0x00, 'v', 'a', 'r', 'i', 'a', 'n', 't'};
   private static final byte[] VALUE_DATE = new byte[] {0b101100, (byte) 0xE3, 0x4E, 0x00, 0x00};
-
-  private void checkType(Variant v, int expectedBasicType, Variant.Type expectedType) {
-    Assert.assertEquals(expectedBasicType, v.value.get(v.value.position()) & VariantUtil.BASIC_TYPE_MASK);
-    Assert.assertEquals(expectedType, v.getType());
-  }
-
-  private String randomString(int len) {
-    StringBuilder sb = new StringBuilder(len);
-    for (int i = 0; i < len; i++) {
-      sb.append(RANDOM_CHARS.charAt(random.nextInt(RANDOM_CHARS.length())));
-    }
-    return sb.toString();
-  }
-
-  private void testVariant(Variant v, Consumer<Variant> consumer) {
-    consumer.accept(v);
-    // Create new Variant with different byte offsets
-    byte[] newValue = new byte[v.value.capacity() + 50];
-    byte[] newMetadata = new byte[v.metadata.capacity() + 50];
-    Arrays.fill(newValue, (byte) 0xFF);
-    Arrays.fill(newMetadata, (byte) 0xFF);
-    v.value.position(0);
-    v.value.get(newValue, 25, v.value.capacity());
-    v.value.position(0);
-    v.metadata.position(0);
-    v.metadata.get(newMetadata, 25, v.metadata.capacity());
-    v.metadata.position(0);
-    Variant v2 = new Variant(
-        ByteBuffer.wrap(newValue, 25, v.value.capacity()),
-        ByteBuffer.wrap(newMetadata, 25, v.metadata.capacity()));
-    consumer.accept(v2);
-  }
-
-  private static byte primitiveHeader(int type) {
-    return (byte) (type << 2);
-  }
-
-  private static byte metadataHeader(boolean isSorted, int offsetSize) {
-    return (byte) (((offsetSize - 1) << 6) | (isSorted ? 0b10000 : 0) | 0b0001);
-  }
-
-  private static int getMinIntegerSize(int value) {
-    return (value <= 0xFF) ? 1 : (value <= 0xFFFF) ? 2 : (value <= 0xFFFFFF) ? 3 : 4;
-  }
-
-  private static void writeVarlenInt(ByteBuffer buffer, int value, int valueSize) {
-    if (valueSize == 1) {
-      buffer.put((byte) value);
-    } else if (valueSize == 2) {
-      buffer.putShort((short) value);
-    } else if (valueSize == 3) {
-      buffer.put((byte) (value & 0xFF));
-      buffer.put((byte) ((value >> 8) & 0xFF));
-      buffer.put((byte) ((value >> 16) & 0xFF));
-    } else {
-      buffer.putInt(value);
-    }
-  }
-
-  private static byte[] constructString(String value) {
-    return ByteBuffer.allocate(value.length() + 5)
-        .order(ByteOrder.LITTLE_ENDIAN)
-        .put(primitiveHeader(16))
-        .putInt(value.length())
-        .put(value.getBytes(StandardCharsets.UTF_8))
-        .array();
-  }
 
   private static byte[] constructObject(Map<String, Integer> keys, Map<String, byte[]> fields, boolean orderedData) {
     int dataSize = 0;
@@ -124,8 +55,8 @@ public class TestVariantObject {
     }
 
     boolean isLarge = fields.size() > 0xFF;
-    int fieldIdSize = getMinIntegerSize(maxId);
-    int offsetSize = getMinIntegerSize(dataSize);
+    int fieldIdSize = VariantTestUtil.getMinIntegerSize(maxId);
+    int offsetSize = VariantTestUtil.getMinIntegerSize(dataSize);
     // The space for header byte, object size, id list, and offset list.
     int headerSize = 1 + (isLarge ? 4 : 1) + fields.size() * fieldIdSize + (fields.size() + 1) * offsetSize;
 
@@ -145,17 +76,17 @@ public class TestVariantObject {
     // write field ids
     for (String fieldName : sortedFieldNames) {
       int fieldId = keys.get(fieldName);
-      writeVarlenInt(output, fieldId, fieldIdSize);
+      VariantTestUtil.writeVarlenInt(output, fieldId, fieldIdSize);
     }
 
     // write offsets
     int currOffset = 0;
     for (String fieldName : sortedFieldNames) {
       int offsetToWrite = orderedData ? currOffset : dataSize - currOffset - fields.get(fieldName).length;
-      writeVarlenInt(output, offsetToWrite, offsetSize);
+      VariantTestUtil.writeVarlenInt(output, offsetToWrite, offsetSize);
       currOffset += fields.get(fieldName).length;
     }
-    writeVarlenInt(output, orderedData ? currOffset : 0, offsetSize);
+    VariantTestUtil.writeVarlenInt(output, orderedData ? currOffset : 0, offsetSize);
 
     // write data
     for (int i = 0; i < sortedFieldNames.length; ++i) {
@@ -168,7 +99,7 @@ public class TestVariantObject {
 
   private static ByteBuffer constructMetadata(Boolean isSorted, List<String> fieldNames) {
     if (fieldNames.isEmpty()) {
-      return EMPTY_METADATA;
+      return VariantTestUtil.EMPTY_METADATA;
     }
 
     int dataSize = 0;
@@ -176,23 +107,23 @@ public class TestVariantObject {
       dataSize += fieldName.length();
     }
 
-    int offsetSize = getMinIntegerSize(dataSize);
+    int offsetSize = VariantTestUtil.getMinIntegerSize(dataSize);
     int offsetListStart = 1 + offsetSize;
     int stringStart = offsetListStart + (fieldNames.size() + 1) * offsetSize;
     int metadataSize = stringStart + dataSize;
 
     ByteBuffer output = ByteBuffer.allocate(metadataSize).order(ByteOrder.LITTLE_ENDIAN);
 
-    output.put(metadataHeader(isSorted, offsetSize));
-    writeVarlenInt(output, fieldNames.size(), offsetSize);
+    output.put(VariantTestUtil.metadataHeader(isSorted, offsetSize));
+    VariantTestUtil.writeVarlenInt(output, fieldNames.size(), offsetSize);
 
     // write offsets
     int currentOffset = 0;
     for (String fieldName : fieldNames) {
-      writeVarlenInt(output, currentOffset, offsetSize);
+      VariantTestUtil.writeVarlenInt(output, currentOffset, offsetSize);
       currentOffset += fieldName.length();
     }
-    writeVarlenInt(output, currentOffset, offsetSize);
+    VariantTestUtil.writeVarlenInt(output, currentOffset, offsetSize);
 
     // write strings
     for (String fieldName : fieldNames) {
@@ -205,19 +136,49 @@ public class TestVariantObject {
 
   @Test
   public void testEmptyObject() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10, 0x00}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10, 0x00}), VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(0, v.numObjectElements());
+    });
+  }
+
+  @Test
+  public void testEmptyObjectBuilder() {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantObjectBuilder o = b.startObject();
+    b.endObject(o);
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
       Assert.assertEquals(0, v.numObjectElements());
     });
   }
 
   @Test
   public void testEmptyLargeObject() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b1000010, 0x00, 0x00, 0x00, 0x00}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {0b1000010, 0x00, 0x00, 0x00, 0x00}), VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
       Assert.assertEquals(0, v.numObjectElements());
+    });
+  }
+
+  @Test
+  public void testLargeObjectBuilder() {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantObjectBuilder o = b.startObject();
+    for (int i = 0; i < 1234; i++) {
+      b.appendObjectKey(o, "a" + i);
+      b.appendLong(i);
+    }
+    b.endObject(o);
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(1234, v.numObjectElements());
+      for (int i = 0; i < 1234; i++) {
+        Assert.assertEquals(i, v.getFieldByKey("a" + i).getLong());
+      }
     });
   }
 
@@ -229,14 +190,14 @@ public class TestVariantObject {
     Variant value = new Variant(
         ByteBuffer.wrap(constructObject(keys, fields, true)),
         constructMetadata(false, ImmutableList.of("c", "b", "a")));
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
       Assert.assertEquals(3, v.numObjectElements());
-      checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
-      checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getFieldByKey("b").getBoolean());
-      checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+      VariantTestUtil.checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
       Assert.assertEquals("variant", v.getFieldByKey("c").getString());
     });
   }
@@ -250,22 +211,61 @@ public class TestVariantObject {
     Variant value = new Variant(
         ByteBuffer.wrap(constructObject(keys, fields, true)),
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
       Assert.assertEquals(3, v.numObjectElements());
-      checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
-      checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getFieldByKey("b").getBoolean());
-      checkType(v.getFieldByKey("c"), VariantUtil.OBJECT, Variant.Type.OBJECT);
+      VariantTestUtil.checkType(v.getFieldByKey("c"), VariantUtil.OBJECT, Variant.Type.OBJECT);
 
       Variant nestedV = v.getFieldByKey("c");
       Assert.assertEquals(2, nestedV.numObjectElements());
-      checkType(nestedV.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.DATE);
+      VariantTestUtil.checkType(nestedV.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.DATE);
       Assert.assertEquals(
           LocalDate.parse("2025-04-17"),
           LocalDate.ofEpochDay(nestedV.getFieldByKey("a").getInt()));
-      checkType(nestedV.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.NULL);
+      VariantTestUtil.checkType(nestedV.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.NULL);
+    });
+  }
+
+  @Test
+  public void testMixedObjectBuilder() {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantObjectBuilder objBuilder = b.startObject();
+    b.appendObjectKey(objBuilder, "outer 1");
+    b.appendBoolean(true);
+    b.appendObjectKey(objBuilder, "outer 2");
+    b.appendLong(1234567890);
+    b.appendObjectKey(objBuilder, "outer 3");
+    {
+      // build a nested obj
+      VariantObjectBuilder nestedBuilder = b.startObject();
+      b.appendObjectKey(nestedBuilder, "nested 1");
+      {
+        // build a nested empty obj
+        VariantObjectBuilder emptyBuilder = b.startObject();
+        b.endObject(emptyBuilder);
+      }
+      b.appendObjectKey(nestedBuilder, "nested 2");
+      b.appendString("variant");
+      b.endObject(nestedBuilder);
+    }
+    b.endObject(objBuilder);
+
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(3, v.numObjectElements());
+      Assert.assertTrue(v.getFieldByKey("outer 1").getBoolean());
+      Assert.assertEquals(1234567890, v.getFieldByKey("outer 2").getLong());
+      VariantTestUtil.checkType(v.getFieldByKey("outer 3"), VariantUtil.OBJECT, Variant.Type.OBJECT);
+
+      Variant nested = v.getFieldByKey("outer 3");
+      Assert.assertEquals(2, nested.numObjectElements());
+      VariantTestUtil.checkType(nested.getFieldByKey("nested 1"), VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(0, nested.getFieldByKey("nested 1").numObjectElements());
+      Assert.assertEquals("variant", nested.getFieldByKey("nested 2").getString());
     });
   }
 
@@ -277,14 +277,14 @@ public class TestVariantObject {
     Variant value = new Variant(
         ByteBuffer.wrap(constructObject(keys, fields, false)),
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
       Assert.assertEquals(3, v.numObjectElements());
-      checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
-      checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getFieldByKey("b").getBoolean());
-      checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+      VariantTestUtil.checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
       Assert.assertEquals("variant", v.getFieldByKey("c").getString());
     });
   }
@@ -293,17 +293,18 @@ public class TestVariantObject {
     Variant value = new Variant(
         ByteBuffer.wrap(constructObject(
             ImmutableMap.of("a", 0, "b", 1, "c", 2),
-            ImmutableMap.of("a", constructString(randomString), "b", VALUE_BOOL, "c", VALUE_INT),
+            ImmutableMap.of(
+                "a", VariantTestUtil.constructString(randomString), "b", VALUE_BOOL, "c", VALUE_INT),
             true)),
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
       Assert.assertEquals(3, v.numObjectElements());
-      checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+      VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
       Assert.assertEquals(randomString, v.getFieldByKey("a").getString());
-      checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getFieldByKey("b").getBoolean());
-      checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      VariantTestUtil.checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getFieldByKey("c").getInt());
     });
   }
@@ -311,19 +312,19 @@ public class TestVariantObject {
   @Test
   public void testObjectTwoByteOffset() {
     // a string larger than 255 bytes to push the offset size above 1 byte
-    testObjectOffsetSize(randomString(300));
+    testObjectOffsetSize(VariantTestUtil.randomString(300));
   }
 
   @Test
   public void testObjectThreeByteOffset() {
     // a string larger than 65535 bytes to push the offset size above 2 bytes
-    testObjectOffsetSize(randomString(70_000));
+    testObjectOffsetSize(VariantTestUtil.randomString(70_000));
   }
 
   @Test
   public void testObjectFourByteOffset() {
     // a string larger than 16777215 bytes to push the offset size above 3 bytes
-    testObjectOffsetSize(randomString(16_800_000));
+    testObjectOffsetSize(VariantTestUtil.randomString(16_800_000));
   }
 
   private void testObjectFieldIdSize(int numExtraKeys) {
@@ -340,12 +341,12 @@ public class TestVariantObject {
             ImmutableMap.of("z1", VALUE_BOOL, "z2", VALUE_INT),
             true)),
         constructMetadata(true, fieldNames));
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
       Assert.assertEquals(2, v.numObjectElements());
-      checkType(v.getFieldByKey("z1"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      VariantTestUtil.checkType(v.getFieldByKey("z1"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getFieldByKey("z1").getBoolean());
-      checkType(v.getFieldByKey("z2"), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      VariantTestUtil.checkType(v.getFieldByKey("z2"), VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getFieldByKey("z2").getInt());
     });
   }
@@ -368,6 +369,84 @@ public class TestVariantObject {
     testObjectFieldIdSize(16_800_000);
   }
 
+  private void testObjectOffsetSizeBuilder(String randomString) {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantObjectBuilder objBuilder = b.startObject();
+    b.appendObjectKey(objBuilder, "key1");
+    b.appendString(randomString);
+    b.appendObjectKey(objBuilder, "key2");
+    b.appendBoolean(true);
+    b.appendObjectKey(objBuilder, "key3");
+    b.appendLong(1234567890);
+    b.endObject(objBuilder);
+
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(3, v.numObjectElements());
+      VariantTestUtil.checkType(v.getFieldByKey("key1"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+      Assert.assertEquals(randomString, v.getFieldByKey("key1").getString());
+      VariantTestUtil.checkType(v.getFieldByKey("key2"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      Assert.assertTrue(v.getFieldByKey("key2").getBoolean());
+      VariantTestUtil.checkType(v.getFieldByKey("key3"), VariantUtil.PRIMITIVE, Variant.Type.INT);
+      Assert.assertEquals(1234567890, v.getFieldByKey("key3").getInt());
+    });
+  }
+
+  @Test
+  public void testObjectTwoByteOffsetBuilder() {
+    // a string larger than 255 bytes to push the offset size above 1 byte
+    testObjectOffsetSizeBuilder(VariantTestUtil.randomString(300));
+  }
+
+  @Test
+  public void testObjectThreeByteOffsetBuilder() {
+    // a string larger than 65535 bytes to push the offset size above 2 bytes
+    testObjectOffsetSizeBuilder(VariantTestUtil.randomString(70_000));
+  }
+
+  @Test
+  public void testObjectFourByteOffsetBuilder() {
+    // a string larger than 16777215 bytes to push the offset size above 3 bytes
+    testObjectOffsetSizeBuilder(VariantTestUtil.randomString(16_800_000));
+  }
+
+  private void testObjectFieldIdSizeBuilder(int numKeys) {
+    VariantBuilder b = new VariantBuilder(true);
+    VariantObjectBuilder objBuilder = b.startObject();
+    for (int i = 0; i < numKeys; i++) {
+      b.appendObjectKey(objBuilder, "k" + i);
+      b.appendLong(i);
+    }
+    b.endObject(objBuilder);
+
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(numKeys, v.numObjectElements());
+      // Only check a few keys, to avoid slowing down the test
+      Assert.assertEquals(0, v.getFieldByKey("k" + 0).getLong());
+      Assert.assertEquals(
+          numKeys - 1, v.getFieldByKey("k" + (numKeys - 1)).getLong());
+    });
+  }
+
+  @Test
+  public void testObjectTwoByteFieldIdBuilder() {
+    // need more than 255 dictionary entries to push field id size above 1 byte
+    testObjectFieldIdSizeBuilder(300);
+  }
+
+  @Test
+  public void testObjectThreeByteFieldIdBuilder() {
+    // need more than 65535 dictionary entries to push field id size above 2 bytes
+    testObjectFieldIdSizeBuilder(70_000);
+  }
+
+  @Test
+  public void testObjectFourByteFieldIdBuilder() {
+    // need more than 16777215 dictionary entries to push field id size above 3 bytes
+    testObjectFieldIdSizeBuilder(16_800_000);
+  }
+
   @Test
   public void testLargeObject() {
     Map<String, Integer> keys = new HashMap<>();
@@ -375,7 +454,7 @@ public class TestVariantObject {
     for (int i = 0; i < 1000; i++) {
       String name = String.format("a%04d", i);
       keys.put(name, i);
-      fields.put(name, constructString(randomString(5)));
+      fields.put(name, VariantTestUtil.constructString(VariantTestUtil.randomString(5)));
     }
 
     List<String> sortedKeys = new ArrayList<>(keys.keySet());
@@ -383,13 +462,13 @@ public class TestVariantObject {
 
     Variant value =
         new Variant(ByteBuffer.wrap(constructObject(keys, fields, false)), constructMetadata(true, sortedKeys));
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
       Assert.assertEquals(1000, v.numObjectElements());
 
       for (int i = 0; i < 1000; i++) {
         String name = String.format("a%04d", i);
-        checkType(v.getFieldByKey(name), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+        VariantTestUtil.checkType(v.getFieldByKey(name), VariantUtil.PRIMITIVE, Variant.Type.STRING);
         Assert.assertEquals(
             new String(fields.get(name), 5, fields.get(name).length - 5),
             v.getFieldByKey(name).getString());
@@ -401,11 +480,46 @@ public class TestVariantObject {
   public void testInvalidObject() {
     try {
       // An array header
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10011}), EMPTY_METADATA);
+      Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10011}), VariantTestUtil.EMPTY_METADATA);
       value.numObjectElements();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
       Assert.assertEquals("Cannot read ARRAY value as OBJECT", e.getMessage());
+    }
+  }
+
+  @Test
+  public void testDuplicateKeys() {
+    // disallow duplicate keys
+    try {
+      VariantBuilder b = new VariantBuilder(false);
+      VariantObjectBuilder objBuilder = b.startObject();
+      b.appendObjectKey(objBuilder, "duplicate");
+      b.appendLong(0);
+      b.appendObjectKey(objBuilder, "duplicate");
+      b.appendLong(1);
+      b.endObject(objBuilder);
+      b.build();
+      Assert.fail("Expected VariantDuplicateKeyException with duplicate keys");
+    } catch (Exception e) {
+      // Expected
+      Assert.assertEquals("Failed to build Variant because of duplicate object key: duplicate", e.getMessage());
+    }
+
+    // allow duplicate keys
+    try {
+      VariantBuilder b = new VariantBuilder(true);
+      VariantObjectBuilder objBuilder = b.startObject();
+      b.appendObjectKey(objBuilder, "duplicate");
+      b.appendLong(0);
+      b.appendObjectKey(objBuilder, "duplicate");
+      b.appendLong(1);
+      b.endObject(objBuilder);
+      Variant v = b.build();
+      Assert.assertEquals(1, v.numObjectElements());
+      Assert.assertEquals(1, v.getFieldByKey("duplicate").getLong());
+    } catch (Exception e) {
+      Assert.fail("Unexpected exception: " + e);
     }
   }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.variant;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestVariantObjectBuilder {
+  private static final Logger LOG = LoggerFactory.getLogger(TestVariantObjectBuilder.class);
+
+  @Test
+  public void testEmptyObjectBuilder() {
+    VariantBuilder b = new VariantBuilder();
+    b.startObject();
+    b.endObject();
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(0, v.numObjectElements());
+    });
+  }
+
+  @Test
+  public void testLargeObjectBuilder() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder o = b.startObject();
+    for (int i = 0; i < 1234; i++) {
+      o.appendKey("a" + i);
+      o.appendLong(i);
+    }
+    b.endObject();
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(1234, v.numObjectElements());
+      for (int i = 0; i < 1234; i++) {
+        VariantTestUtil.checkType(v.getFieldByKey("a" + i), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+        Assert.assertEquals(i, v.getFieldByKey("a" + i).getLong());
+      }
+    });
+  }
+
+  @Test
+  public void testMixedObjectBuilder() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    objBuilder.appendKey("outer 2");
+    objBuilder.appendLong(1234567890);
+    objBuilder.appendKey("outer 1");
+    objBuilder.appendBoolean(true);
+    objBuilder.appendKey("outer 3");
+    {
+      // build a nested obj
+      VariantObjectBuilder nestedBuilder = objBuilder.startObject();
+      nestedBuilder.appendKey("nested 1");
+      {
+        // build a nested empty obj
+        nestedBuilder.startObject();
+        nestedBuilder.endObject();
+      }
+      nestedBuilder.appendKey("nested 2");
+      nestedBuilder.appendString("variant");
+      objBuilder.endObject();
+    }
+    b.endObject();
+
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(3, v.numObjectElements());
+      VariantTestUtil.checkType(v.getFieldByKey("outer 1"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+      Assert.assertTrue(v.getFieldByKey("outer 1").getBoolean());
+      VariantTestUtil.checkType(v.getFieldByKey("outer 2"), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+      Assert.assertEquals(1234567890, v.getFieldByKey("outer 2").getLong());
+      VariantTestUtil.checkType(v.getFieldByKey("outer 3"), VariantUtil.OBJECT, Variant.Type.OBJECT);
+
+      Variant nested = v.getFieldByKey("outer 3");
+      Assert.assertEquals(2, nested.numObjectElements());
+      VariantTestUtil.checkType(nested.getFieldByKey("nested 1"), VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(0, nested.getFieldByKey("nested 1").numObjectElements());
+      VariantTestUtil.checkType(nested.getFieldByKey("nested 2"), VariantUtil.SHORT_STR, Variant.Type.STRING);
+      Assert.assertEquals("variant", nested.getFieldByKey("nested 2").getString());
+    });
+  }
+
+  @Test
+  public void testNestedBuilder() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    objBuilder.appendKey("b");
+    objBuilder.appendString("123");
+    objBuilder.appendKey("a");
+    {
+      // build a nested obj
+      VariantObjectBuilder nested1 = objBuilder.startObject();
+      nested1.appendKey("a");
+      {
+        // build a nested obj
+        VariantObjectBuilder nested2 = nested1.startObject();
+        nested2.appendKey("a");
+        {
+          // build a nested obj
+          VariantObjectBuilder nested3 = nested2.startObject();
+          nested3.appendKey("a");
+          nested3.appendString("variant");
+          nested2.endObject();
+        }
+        nested1.endObject();
+      }
+      objBuilder.endObject();
+    }
+    b.endObject();
+
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(2, v.numObjectElements());
+      VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.SHORT_STR, Variant.Type.STRING);
+      Assert.assertEquals("123", v.getFieldByKey("b").getString());
+      VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.OBJECT, Variant.Type.OBJECT);
+
+      Variant nested1 = v.getFieldByKey("a");
+      Assert.assertEquals(1, nested1.numObjectElements());
+      VariantTestUtil.checkType(nested1.getFieldByKey("a"), VariantUtil.OBJECT, Variant.Type.OBJECT);
+
+      Variant nested2 = nested1.getFieldByKey("a");
+      Assert.assertEquals(1, nested2.numObjectElements());
+      VariantTestUtil.checkType(nested2.getFieldByKey("a"), VariantUtil.OBJECT, Variant.Type.OBJECT);
+
+      Variant nested3 = nested2.getFieldByKey("a");
+      Assert.assertEquals(1, nested3.numObjectElements());
+      VariantTestUtil.checkType(nested3.getFieldByKey("a"), VariantUtil.SHORT_STR, Variant.Type.STRING);
+      Assert.assertEquals("variant", nested3.getFieldByKey("a").getString());
+    });
+  }
+
+  private void testObjectOffsetSizeBuilder(String randomString) {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    objBuilder.appendKey("key1");
+    objBuilder.appendString(randomString);
+    objBuilder.appendKey("key2");
+    objBuilder.appendBoolean(true);
+    objBuilder.appendKey("key3");
+    objBuilder.appendLong(1234567890);
+    b.endObject();
+
+    Variant v = b.build();
+    VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    Assert.assertEquals(3, v.numObjectElements());
+    VariantTestUtil.checkType(v.getFieldByKey("key1"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
+    Assert.assertEquals(randomString, v.getFieldByKey("key1").getString());
+    VariantTestUtil.checkType(v.getFieldByKey("key2"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+    Assert.assertTrue(v.getFieldByKey("key2").getBoolean());
+    VariantTestUtil.checkType(v.getFieldByKey("key3"), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+    Assert.assertEquals(1234567890, v.getFieldByKey("key3").getLong());
+  }
+
+  @Test
+  public void testObjectTwoByteOffsetBuilder() {
+    // a string larger than 255 bytes to push the offset size above 1 byte
+    testObjectOffsetSizeBuilder(VariantTestUtil.randomString(300));
+  }
+
+  @Test
+  public void testObjectThreeByteOffsetBuilder() {
+    // a string larger than 65535 bytes to push the offset size above 2 bytes
+    testObjectOffsetSizeBuilder(VariantTestUtil.randomString(70_000));
+  }
+
+  @Test
+  public void testObjectFourByteOffsetBuilder() {
+    // a string larger than 16777215 bytes to push the offset size above 3 bytes
+    testObjectOffsetSizeBuilder(VariantTestUtil.randomString(16_800_000));
+  }
+
+  private void testObjectFieldIdSizeBuilder(int numKeys) {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    for (int i = 0; i < numKeys; i++) {
+      objBuilder.appendKey("k" + i);
+      objBuilder.appendLong(i);
+    }
+    b.endObject();
+
+    Variant v = b.build();
+    VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+    Assert.assertEquals(numKeys, v.numObjectElements());
+    // Only check a few keys, to avoid slowing down the test
+    VariantTestUtil.checkType(v.getFieldByKey("k" + 0), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+    Assert.assertEquals(0, v.getFieldByKey("k" + 0).getLong());
+    VariantTestUtil.checkType(v.getFieldByKey("k" + (numKeys - 1)), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+    Assert.assertEquals(numKeys - 1, v.getFieldByKey("k" + (numKeys - 1)).getLong());
+  }
+
+  @Test
+  public void testObjectTwoByteFieldIdBuilder() {
+    // need more than 255 dictionary entries to push field id size above 1 byte
+    testObjectFieldIdSizeBuilder(300);
+  }
+
+  @Test
+  public void testObjectThreeByteFieldIdBuilder() {
+    // need more than 65535 dictionary entries to push field id size above 2 bytes
+    testObjectFieldIdSizeBuilder(70_000);
+  }
+
+  @Test
+  @Ignore("Test uses too much memory")
+  public void testObjectFourByteFieldIdBuilder() {
+    // need more than 16777215 dictionary entries to push field id size above 3 bytes
+    testObjectFieldIdSizeBuilder(16_800_000);
+  }
+
+  @Test
+  public void testDuplicateKeys() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    objBuilder.appendKey("duplicate");
+    objBuilder.appendLong(0);
+    objBuilder.appendKey("duplicate");
+    objBuilder.appendLong(1);
+    b.endObject();
+    Variant v = b.build();
+    Assert.assertEquals(1, v.numObjectElements());
+    VariantTestUtil.checkType(v.getFieldByKey("duplicate"), VariantUtil.PRIMITIVE, Variant.Type.LONG);
+    Assert.assertEquals(1, v.getFieldByKey("duplicate").getLong());
+  }
+
+  @Test
+  public void testSortingKeys() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    objBuilder.appendKey("1");
+    objBuilder.appendString("1");
+    objBuilder.appendKey("0");
+    objBuilder.appendString("");
+    objBuilder.appendKey("3");
+    objBuilder.appendString("333");
+    objBuilder.appendKey("2");
+    objBuilder.appendString("22");
+    b.endObject();
+    Variant v = b.build();
+    Assert.assertEquals(4, v.numObjectElements());
+    VariantTestUtil.checkType(v.getFieldByKey("0"), VariantUtil.SHORT_STR, Variant.Type.STRING);
+    Assert.assertEquals("", v.getFieldByKey("0").getString());
+    VariantTestUtil.checkType(v.getFieldByKey("1"), VariantUtil.SHORT_STR, Variant.Type.STRING);
+    Assert.assertEquals("1", v.getFieldByKey("1").getString());
+    VariantTestUtil.checkType(v.getFieldByKey("2"), VariantUtil.SHORT_STR, Variant.Type.STRING);
+    Assert.assertEquals("22", v.getFieldByKey("2").getString());
+    VariantTestUtil.checkType(v.getFieldByKey("3"), VariantUtil.SHORT_STR, Variant.Type.STRING);
+    Assert.assertEquals("333", v.getFieldByKey("3").getString());
+  }
+
+  @Test
+  public void testMissingEndObject() {
+    VariantBuilder b = new VariantBuilder();
+    b.startObject();
+    try {
+      b.build();
+      Assert.fail("Expected Exception when calling build() without endObject()");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testMissingStartObject() {
+    VariantBuilder b = new VariantBuilder();
+    try {
+      b.endObject();
+      Assert.fail("Expected Exception when calling endObject() without startObject()");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testMissingValue() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    obj.appendKey("a");
+    try {
+      b.endObject();
+      Assert.fail("Expected Exception when calling endObject() with mismatched keys and values");
+    } catch (Exception e) {
+      // expected
+    }
+
+    obj.appendInt(1);
+    obj.appendKey("b");
+    try {
+      b.endObject();
+      Assert.fail("Expected Exception when calling endObject() with mismatched keys and values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testInvalidAppendDuringObjectAppend() {
+    VariantBuilder b = new VariantBuilder();
+    b.startObject();
+    try {
+      b.appendInt(1);
+      Assert.fail("Expected Exception when calling append() before endObject()");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testMultipleAppendKey() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    obj.appendKey("a");
+    try {
+      obj.appendKey("a");
+      Assert.fail("Expected Exception when calling appendKey() multiple times without appending a value");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testNoAppendKey() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    try {
+      obj.appendInt(1);
+      Assert.fail("Expected Exception when appending a value, before appending a key");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testMultipleAppendValue() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    obj.appendKey("a");
+    obj.appendInt(1);
+    try {
+      obj.appendInt(1);
+      Assert.fail("Expected Exception when appending a value, before appending a key");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+}

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
@@ -373,4 +373,78 @@ public class TestVariantObjectBuilder {
       // expected
     }
   }
+
+  @Test
+  public void testOpenNestedObject() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    obj.appendKey("outer");
+    obj.startObject();
+    try {
+      b.endObject();
+      Assert.fail("Expected Exception when calling endObject() with an open nested object");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testOpenNestedObjectWithKey() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    obj.appendKey("outer");
+    VariantObjectBuilder nested = obj.startObject();
+    nested.appendKey("nested");
+    try {
+      b.endObject();
+      Assert.fail("Expected Exception when calling endObject() with an open nested object");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testOpenNestedObjectWithKeyValue() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    obj.appendKey("outer");
+    VariantObjectBuilder nested = obj.startObject();
+    nested.appendKey("nested");
+    nested.appendInt(1);
+    try {
+      b.endObject();
+      Assert.fail("Expected Exception when calling endObject() with an open nested object");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testOpenNestedArray() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    obj.appendKey("outer");
+    obj.startArray();
+    try {
+      b.endObject();
+      Assert.fail("Expected Exception when calling endObject() with an open nested array");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testOpenNestedArrayWithElement() {
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder obj = b.startObject();
+    obj.appendKey("outer");
+    VariantArrayBuilder nested = obj.startArray();
+    nested.appendInt(1);
+    try {
+      b.endObject();
+      Assert.fail("Expected Exception when calling endObject() with an open nested array");
+    } catch (Exception e) {
+      // expected
+    }
+  }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
@@ -193,7 +193,7 @@ public class TestVariantScalar {
   }
 
   @Test
-  public void testIntegerBuilder() {
+  public void testLongBuilder() {
     Arrays.asList(
             0L,
             (long) Byte.MIN_VALUE,
@@ -208,19 +208,14 @@ public class TestVariantScalar {
           VariantBuilder vb2 = new VariantBuilder(false);
           vb2.appendLong(l);
           VariantTestUtil.testVariant(vb2.build(), v -> {
-            if (Byte.MIN_VALUE <= l && l <= Byte.MAX_VALUE) {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
-            } else if (Short.MIN_VALUE <= l && l <= Short.MAX_VALUE) {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
-            } else if (Integer.MIN_VALUE <= l && l <= Integer.MAX_VALUE) {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
-            } else {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
-            }
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
             Assert.assertEquals((long) l, v.getLong());
           });
         });
+  }
 
+  @Test
+  public void testIntBuilder() {
     Arrays.asList(
             0,
             (int) Byte.MIN_VALUE,
@@ -231,36 +226,32 @@ public class TestVariantScalar {
             Integer.MAX_VALUE)
         .forEach(i -> {
           VariantBuilder vb2 = new VariantBuilder(false);
-          vb2.appendLong((long) i);
+          vb2.appendInt(i);
           VariantTestUtil.testVariant(vb2.build(), v -> {
-            if (Byte.MIN_VALUE <= i && i <= Byte.MAX_VALUE) {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
-            } else if (Short.MIN_VALUE <= i && i <= Short.MAX_VALUE) {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
-            } else {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
-            }
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
             Assert.assertEquals((int) i, v.getInt());
           });
         });
+  }
 
+  @Test
+  public void testShortBuilder() {
     Arrays.asList((short) 0, (short) Byte.MIN_VALUE, (short) Byte.MAX_VALUE, Short.MIN_VALUE, Short.MAX_VALUE)
         .forEach(s -> {
           VariantBuilder vb2 = new VariantBuilder(false);
-          vb2.appendLong(s);
+          vb2.appendShort(s);
           VariantTestUtil.testVariant(vb2.build(), v -> {
-            if (Byte.MIN_VALUE <= s && s <= Byte.MAX_VALUE) {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
-            } else {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
-            }
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
             Assert.assertEquals((short) s, v.getShort());
           });
         });
+  }
 
+  @Test
+  public void testByteBuilder() {
     Arrays.asList((byte) 0, Byte.MIN_VALUE, Byte.MAX_VALUE).forEach(b -> {
       VariantBuilder vb2 = new VariantBuilder(false);
-      vb2.appendLong(b);
+      vb2.appendByte(b);
       VariantTestUtil.testVariant(vb2.build(), v -> {
         VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
         Assert.assertEquals((byte) b, v.getByte());

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
@@ -20,15 +20,11 @@ package org.apache.parquet.variant;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.UUID;
-import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -42,13 +38,6 @@ public class TestVariantScalar {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(0)}), VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> VariantTestUtil.checkType(v, VariantUtil.NULL, Variant.Type.NULL));
-  }
-
-  @Test
-  public void testNullBuilder() {
-    VariantBuilder vb = new VariantBuilder(false);
-    vb.appendNull();
-    VariantTestUtil.testVariant(vb.build(), v -> VariantTestUtil.checkType(v, VariantUtil.NULL, Variant.Type.NULL));
   }
 
   @Test
@@ -68,18 +57,6 @@ public class TestVariantScalar {
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertFalse(v.getBoolean());
-    });
-  }
-
-  @Test
-  public void testBooleanBuilder() {
-    Arrays.asList(true, false).forEach(b -> {
-      VariantBuilder vb = new VariantBuilder(false);
-      vb.appendBoolean(b);
-      VariantTestUtil.testVariant(vb.build(), v -> {
-        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-        Assert.assertEquals(b, v.getBoolean());
-      });
     });
   }
 
@@ -193,73 +170,6 @@ public class TestVariantScalar {
   }
 
   @Test
-  public void testLongBuilder() {
-    Arrays.asList(
-            0L,
-            (long) Byte.MIN_VALUE,
-            (long) Byte.MAX_VALUE,
-            (long) Short.MIN_VALUE,
-            (long) Short.MAX_VALUE,
-            (long) Integer.MIN_VALUE,
-            (long) Integer.MAX_VALUE,
-            Long.MIN_VALUE,
-            Long.MAX_VALUE)
-        .forEach(l -> {
-          VariantBuilder vb2 = new VariantBuilder(false);
-          vb2.appendLong(l);
-          VariantTestUtil.testVariant(vb2.build(), v -> {
-            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
-            Assert.assertEquals((long) l, v.getLong());
-          });
-        });
-  }
-
-  @Test
-  public void testIntBuilder() {
-    Arrays.asList(
-            0,
-            (int) Byte.MIN_VALUE,
-            (int) Byte.MAX_VALUE,
-            (int) Short.MIN_VALUE,
-            (int) Short.MAX_VALUE,
-            Integer.MIN_VALUE,
-            Integer.MAX_VALUE)
-        .forEach(i -> {
-          VariantBuilder vb2 = new VariantBuilder(false);
-          vb2.appendInt(i);
-          VariantTestUtil.testVariant(vb2.build(), v -> {
-            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
-            Assert.assertEquals((int) i, v.getInt());
-          });
-        });
-  }
-
-  @Test
-  public void testShortBuilder() {
-    Arrays.asList((short) 0, (short) Byte.MIN_VALUE, (short) Byte.MAX_VALUE, Short.MIN_VALUE, Short.MAX_VALUE)
-        .forEach(s -> {
-          VariantBuilder vb2 = new VariantBuilder(false);
-          vb2.appendShort(s);
-          VariantTestUtil.testVariant(vb2.build(), v -> {
-            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
-            Assert.assertEquals((short) s, v.getShort());
-          });
-        });
-  }
-
-  @Test
-  public void testByteBuilder() {
-    Arrays.asList((byte) 0, Byte.MIN_VALUE, Byte.MAX_VALUE).forEach(b -> {
-      VariantBuilder vb2 = new VariantBuilder(false);
-      vb2.appendByte(b);
-      VariantTestUtil.testVariant(vb2.build(), v -> {
-        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
-        Assert.assertEquals((byte) b, v.getByte());
-      });
-    });
-  }
-
-  @Test
   public void testFloat() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(14), (byte) 0xD2, 0x02, (byte) 0x96, 0x49}),
@@ -278,18 +188,6 @@ public class TestVariantScalar {
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
       Assert.assertEquals(-0.0F, v.getFloat(), 0);
-    });
-  }
-
-  @Test
-  public void testFloatBuilder() {
-    Arrays.asList(Float.MIN_VALUE, 0f, Float.MAX_VALUE).forEach(f -> {
-      VariantBuilder vb2 = new VariantBuilder(false);
-      vb2.appendFloat(f);
-      VariantTestUtil.testVariant(vb2.build(), v -> {
-        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
-        Assert.assertEquals(f, v.getFloat(), 0);
-      });
     });
   }
 
@@ -324,18 +222,6 @@ public class TestVariantScalar {
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
       Assert.assertEquals(-0.0D, v.getDouble(), 0);
-    });
-  }
-
-  @Test
-  public void testDoubleBuilder() {
-    Arrays.asList(Double.MIN_VALUE, 0d, Double.MAX_VALUE).forEach(d -> {
-      VariantBuilder vb2 = new VariantBuilder(false);
-      vb2.appendDouble(d);
-      VariantTestUtil.testVariant(vb2.build(), v -> {
-        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
-        Assert.assertEquals(d, v.getDouble(), 0);
-      });
     });
   }
 
@@ -469,41 +355,6 @@ public class TestVariantScalar {
   }
 
   @Test
-  public void testDecimalBuilder() {
-    // decimal4
-    Arrays.asList(new BigDecimal("123.456"), new BigDecimal("-987.654")).forEach(d -> {
-      VariantBuilder vb2 = new VariantBuilder(false);
-      vb2.appendDecimal(d);
-      VariantTestUtil.testVariant(vb2.build(), v -> {
-        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
-        Assert.assertEquals(d, v.getDecimal());
-      });
-    });
-
-    // decimal8
-    Arrays.asList(new BigDecimal("10.2147483647"), new BigDecimal("-1021474836.47"))
-        .forEach(d -> {
-          VariantBuilder vb2 = new VariantBuilder(false);
-          vb2.appendDecimal(d);
-          VariantTestUtil.testVariant(vb2.build(), v -> {
-            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
-            Assert.assertEquals(d, v.getDecimal());
-          });
-        });
-
-    // decimal16
-    Arrays.asList(new BigDecimal("109223372036854775.807"), new BigDecimal("-109.223372036854775807"))
-        .forEach(d -> {
-          VariantBuilder vb2 = new VariantBuilder(false);
-          vb2.appendDecimal(d);
-          VariantTestUtil.testVariant(vb2.build(), v -> {
-            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
-            Assert.assertEquals(d, v.getDecimal());
-          });
-        });
-  }
-
-  @Test
   public void testDate() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(11), (byte) 0xE3, 0x4E, 0x00, 0x00}),
@@ -524,17 +375,6 @@ public class TestVariantScalar {
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
       Assert.assertEquals(LocalDate.parse("1969-12-31"), LocalDate.ofEpochDay(v.getInt()));
-    });
-  }
-
-  @Test
-  public void testDateBuilder() {
-    VariantBuilder vb = new VariantBuilder(false);
-    int days = Math.toIntExact(LocalDate.of(2024, 12, 16).toEpochDay());
-    vb.appendDate(days);
-    VariantTestUtil.testVariant(vb.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
-      Assert.assertEquals(days, v.getInt());
     });
   }
 
@@ -583,18 +423,6 @@ public class TestVariantScalar {
   }
 
   @Test
-  public void testTimestampTzBuilder() {
-    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
-    VariantBuilder vb = new VariantBuilder(false);
-    long micros = VariantTestUtil.microsSinceEpoch(Instant.from(dtf.parse("2024-12-16T10:23:45.321456-08:00")));
-    vb.appendTimestampTz(micros);
-    VariantTestUtil.testVariant(vb.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
-      Assert.assertEquals(micros, v.getLong());
-    });
-  }
-
-  @Test
   public void testTimestampNtz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
@@ -639,18 +467,6 @@ public class TestVariantScalar {
   }
 
   @Test
-  public void testTimestampNtzBuilder() {
-    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
-    VariantBuilder vb = new VariantBuilder(false);
-    long micros = VariantTestUtil.microsSinceEpoch(Instant.from(dtf.parse("2024-01-01T23:00:00.000001Z")));
-    vb.appendTimestampNtz(micros);
-    VariantTestUtil.testVariant(vb.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
-      Assert.assertEquals(micros, v.getLong());
-    });
-  }
-
-  @Test
   public void testBinary() {
     Variant value = new Variant(
         ByteBuffer.wrap(
@@ -660,17 +476,6 @@ public class TestVariantScalar {
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BINARY);
       Assert.assertEquals(ByteBuffer.wrap(new byte[] {'a', 'b', 'c', 'd', 'e'}), v.getBinary());
-    });
-  }
-
-  @Test
-  public void testBinaryBuilder() {
-    VariantBuilder vb = new VariantBuilder(false);
-    byte[] binary = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    vb.appendBinary(binary);
-    VariantTestUtil.testVariant(vb.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BINARY);
-      Assert.assertEquals(ByteBuffer.wrap(binary), v.getBinary());
     });
   }
 
@@ -699,24 +504,6 @@ public class TestVariantScalar {
   }
 
   @Test
-  public void testStringBuilder() {
-    IntStream.range(VariantUtil.MAX_SHORT_STR_SIZE - 3, VariantUtil.MAX_SHORT_STR_SIZE + 3)
-        .forEach(len -> {
-          VariantBuilder vb2 = new VariantBuilder(false);
-          String s = VariantTestUtil.randomString(len);
-          vb2.appendString(s);
-          VariantTestUtil.testVariant(vb2.build(), v -> {
-            if (len <= VariantUtil.MAX_SHORT_STR_SIZE) {
-              VariantTestUtil.checkType(v, VariantUtil.SHORT_STR, Variant.Type.STRING);
-            } else {
-              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.STRING);
-            }
-            Assert.assertEquals(s, v.getString());
-          });
-        });
-  }
-
-  @Test
   public void testTime() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
@@ -735,20 +522,6 @@ public class TestVariantScalar {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIME);
       Assert.assertEquals(LocalTime.parse("23:59:59.123456"), LocalTime.ofNanoOfDay(v.getLong() * 1_000));
     });
-  }
-
-  @Test
-  public void testTimeBuilder() {
-    for (String timeStr : Arrays.asList(
-        "00:00:00.000000", "00:00:00.000120", "12:00:00.000000", "12:00:00.002300", "23:59:59.999999")) {
-      VariantBuilder vb = new VariantBuilder(false);
-      long micros = LocalTime.parse(timeStr).toNanoOfDay() / 1_000;
-      vb.appendTime(micros);
-      VariantTestUtil.testVariant(vb.build(), v -> {
-        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIME);
-        Assert.assertEquals(micros, v.getLong());
-      });
-    }
   }
 
   @Test
@@ -792,18 +565,6 @@ public class TestVariantScalar {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
       Assert.assertEquals(
           Instant.parse("1969-12-31T23:59:59.999999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
-    });
-  }
-
-  @Test
-  public void testTimestampNanosBuilder() {
-    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
-    VariantBuilder vb = new VariantBuilder(false);
-    long nanos = VariantTestUtil.nanosSinceEpoch(Instant.from(dtf.parse("2024-12-16T10:23:45.321456987-08:00")));
-    vb.appendTimestampNanosTz(nanos);
-    VariantTestUtil.testVariant(vb.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
-      Assert.assertEquals(nanos, v.getLong());
     });
   }
 
@@ -852,18 +613,6 @@ public class TestVariantScalar {
   }
 
   @Test
-  public void testTimestampNanosNtzBuilder() {
-    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
-    VariantBuilder vb = new VariantBuilder(false);
-    long nanos = VariantTestUtil.nanosSinceEpoch(Instant.from(dtf.parse("2024-01-01T23:00:00.839280983Z")));
-    vb.appendTimestampNanosNtz(nanos);
-    VariantTestUtil.testVariant(vb.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
-      Assert.assertEquals(nanos, v.getLong());
-    });
-  }
-
-  @Test
   public void testUUID() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
@@ -889,21 +638,6 @@ public class TestVariantScalar {
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
       Assert.assertEquals(UUID.fromString("00112233-4455-6677-8899-aabbccddeeff"), v.getUUID());
-    });
-  }
-
-  @Test
-  public void testUUIDBuilder() {
-    VariantBuilder vb = new VariantBuilder(false);
-    byte[] uuid = new byte[] {0, 17, 34, 51, 68, 85, 102, 119, -120, -103, -86, -69, -52, -35, -18, -1};
-    long msb = ByteBuffer.wrap(uuid, 0, 8).order(ByteOrder.BIG_ENDIAN).getLong();
-    long lsb = ByteBuffer.wrap(uuid, 8, 8).order(ByteOrder.BIG_ENDIAN).getLong();
-    UUID expected = new UUID(msb, lsb);
-
-    vb.appendUUID(expected);
-    VariantTestUtil.testVariant(vb.build(), v -> {
-      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
-      Assert.assertEquals(expected, v.getUUID());
     });
   }
 

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
@@ -20,12 +20,15 @@ package org.apache.parquet.variant;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
-import java.util.function.Consumer;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.IntStream;
 import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -34,79 +37,49 @@ import org.slf4j.LoggerFactory;
 public class TestVariantScalar {
   private static final Logger LOG = LoggerFactory.getLogger(TestVariantScalar.class);
 
-  private static final ByteBuffer EMPTY_METADATA = ByteBuffer.wrap(new byte[] {0b1});
-
-  private void checkType(Variant v, int expectedBasicType, Variant.Type expectedType) {
-    Assert.assertEquals(expectedBasicType, v.value.get(v.value.position()) & VariantUtil.BASIC_TYPE_MASK);
-    Assert.assertEquals(expectedType, v.getType());
-  }
-
-  private void testVariant(Variant v, Consumer<Variant> consumer) {
-    consumer.accept(v);
-    // Create new Variant with different byte offsets
-    byte[] newValue = new byte[v.value.capacity() + 50];
-    byte[] newMetadata = new byte[v.metadata.capacity() + 50];
-    Arrays.fill(newValue, (byte) 0xFF);
-    Arrays.fill(newMetadata, (byte) 0xFF);
-    v.value.position(0);
-    v.value.get(newValue, 25, v.value.capacity());
-    v.value.position(0);
-    v.metadata.position(0);
-    v.metadata.get(newMetadata, 25, v.metadata.capacity());
-    v.metadata.position(0);
-    Variant v2 = new Variant(
-        ByteBuffer.wrap(newValue, 25, v.value.capacity()),
-        ByteBuffer.wrap(newMetadata, 25, v.metadata.capacity()));
-    consumer.accept(v2);
-  }
-
-  private static byte primitiveHeader(int type) {
-    return (byte) (type << 2);
-  }
-
-  private static byte metadataHeader(boolean isSorted, int offsetSize) {
-    return (byte) (((offsetSize - 1) << 6) | (isSorted ? 0b10000 : 0) | 0b0001);
-  }
-
-  private static int getMinIntegerSize(int value) {
-    return (value <= 0xFF) ? 1 : (value <= 0xFFFF) ? 2 : (value <= 0xFFFFFF) ? 3 : 4;
-  }
-
-  private static void writeVarlenInt(ByteBuffer buffer, int value, int valueSize) {
-    if (valueSize == 1) {
-      buffer.put((byte) value);
-    } else if (valueSize == 2) {
-      buffer.putShort((short) value);
-    } else if (valueSize == 3) {
-      buffer.put((byte) (value & 0xFF));
-      buffer.put((byte) ((value >> 8) & 0xFF));
-      buffer.put((byte) ((value >> 16) & 0xFF));
-    } else {
-      buffer.putInt(value);
-    }
+  @Test
+  public void testNull() {
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(0)}), VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> VariantTestUtil.checkType(v, VariantUtil.NULL, Variant.Type.NULL));
   }
 
   @Test
-  public void testNull() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(0)}), EMPTY_METADATA);
-    testVariant(value, v -> checkType(v, VariantUtil.NULL, Variant.Type.NULL));
+  public void testNullBuilder() {
+    VariantBuilder vb = new VariantBuilder(false);
+    vb.appendNull();
+    VariantTestUtil.testVariant(vb.build(), v -> VariantTestUtil.checkType(v, VariantUtil.NULL, Variant.Type.NULL));
   }
 
   @Test
   public void testTrue() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(1)}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(1)}), VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertTrue(v.getBoolean());
     });
   }
 
   @Test
   public void testFalse() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(2)}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(2)}), VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
       Assert.assertFalse(v.getBoolean());
+    });
+  }
+
+  @Test
+  public void testBooleanBuilder() {
+    Arrays.asList(true, false).forEach(b -> {
+      VariantBuilder vb = new VariantBuilder(false);
+      vb.appendBoolean(b);
+      VariantTestUtil.testVariant(vb.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+        Assert.assertEquals(b, v.getBoolean());
+      });
     });
   }
 
@@ -114,11 +87,19 @@ public class TestVariantScalar {
   public void testLong() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(6), (byte) 0xB1, 0x1C, 0x6C, (byte) 0xB1, (byte) 0xF4, 0x10, 0x22, 0x11
+          VariantTestUtil.primitiveHeader(6),
+          (byte) 0xB1,
+          0x1C,
+          0x6C,
+          (byte) 0xB1,
+          (byte) 0xF4,
+          0x10,
+          0x22,
+          0x11
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
       Assert.assertEquals(1234567890987654321L, v.getLong());
     });
   }
@@ -127,7 +108,7 @@ public class TestVariantScalar {
   public void testNegativeLong() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(6),
+          VariantTestUtil.primitiveHeader(6),
           (byte) 0xFF,
           (byte) 0xFF,
           (byte) 0xFF,
@@ -137,9 +118,9 @@ public class TestVariantScalar {
           (byte) 0xFF,
           (byte) 0xFF
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
       Assert.assertEquals(-1L, v.getLong());
     });
   }
@@ -147,9 +128,10 @@ public class TestVariantScalar {
   @Test
   public void testInt() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(5), (byte) 0xD2, 0x02, (byte) 0x96, 0x49}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(5), (byte) 0xD2, 0x02, (byte) 0x96, 0x49}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(1234567890, v.getInt());
     });
   }
@@ -157,59 +139,142 @@ public class TestVariantScalar {
   @Test
   public void testNegativeInt() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(5), (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
+        ByteBuffer.wrap(new byte[] {
+          VariantTestUtil.primitiveHeader(5), (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        }),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
       Assert.assertEquals(-1, v.getInt());
     });
   }
 
   @Test
   public void testShort() {
-    Variant value =
-        new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(4), (byte) 0xD2, 0x04}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(4), (byte) 0xD2, 0x04}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
       Assert.assertEquals((short) 1234, v.getShort());
     });
   }
 
   @Test
   public void testNegativeShort() {
-    Variant value =
-        new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(4), (byte) 0xFF, (byte) 0xFF}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(4), (byte) 0xFF, (byte) 0xFF}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
       Assert.assertEquals((short) -1, v.getShort());
     });
   }
 
   @Test
   public void testByte() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(3), 34}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(3), 34}), VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
       Assert.assertEquals((byte) 34, v.getByte());
     });
   }
 
   @Test
   public void testNegativeByte() {
-    Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(3), (byte) 0xFF}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(3), (byte) 0xFF}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
       Assert.assertEquals((byte) -1, v.getByte());
+    });
+  }
+
+  @Test
+  public void testIntegerBuilder() {
+    Arrays.asList(
+            0L,
+            (long) Byte.MIN_VALUE,
+            (long) Byte.MAX_VALUE,
+            (long) Short.MIN_VALUE,
+            (long) Short.MAX_VALUE,
+            (long) Integer.MIN_VALUE,
+            (long) Integer.MAX_VALUE,
+            Long.MIN_VALUE,
+            Long.MAX_VALUE)
+        .forEach(l -> {
+          VariantBuilder vb2 = new VariantBuilder(false);
+          vb2.appendLong(l);
+          VariantTestUtil.testVariant(vb2.build(), v -> {
+            if (Byte.MIN_VALUE <= l && l <= Byte.MAX_VALUE) {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
+            } else if (Short.MIN_VALUE <= l && l <= Short.MAX_VALUE) {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
+            } else if (Integer.MIN_VALUE <= l && l <= Integer.MAX_VALUE) {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
+            } else {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
+            }
+            Assert.assertEquals((long) l, v.getLong());
+          });
+        });
+
+    Arrays.asList(
+            0,
+            (int) Byte.MIN_VALUE,
+            (int) Byte.MAX_VALUE,
+            (int) Short.MIN_VALUE,
+            (int) Short.MAX_VALUE,
+            Integer.MIN_VALUE,
+            Integer.MAX_VALUE)
+        .forEach(i -> {
+          VariantBuilder vb2 = new VariantBuilder(false);
+          vb2.appendLong((long) i);
+          VariantTestUtil.testVariant(vb2.build(), v -> {
+            if (Byte.MIN_VALUE <= i && i <= Byte.MAX_VALUE) {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
+            } else if (Short.MIN_VALUE <= i && i <= Short.MAX_VALUE) {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
+            } else {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
+            }
+            Assert.assertEquals((int) i, v.getInt());
+          });
+        });
+
+    Arrays.asList((short) 0, (short) Byte.MIN_VALUE, (short) Byte.MAX_VALUE, Short.MIN_VALUE, Short.MAX_VALUE)
+        .forEach(s -> {
+          VariantBuilder vb2 = new VariantBuilder(false);
+          vb2.appendLong(s);
+          VariantTestUtil.testVariant(vb2.build(), v -> {
+            if (Byte.MIN_VALUE <= s && s <= Byte.MAX_VALUE) {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
+            } else {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
+            }
+            Assert.assertEquals((short) s, v.getShort());
+          });
+        });
+
+    Arrays.asList((byte) 0, Byte.MIN_VALUE, Byte.MAX_VALUE).forEach(b -> {
+      VariantBuilder vb2 = new VariantBuilder(false);
+      vb2.appendLong(b);
+      VariantTestUtil.testVariant(vb2.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
+        Assert.assertEquals((byte) b, v.getByte());
+      });
     });
   }
 
   @Test
   public void testFloat() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(14), (byte) 0xD2, 0x02, (byte) 0x96, 0x49}),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(14), (byte) 0xD2, 0x02, (byte) 0x96, 0x49}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
       Assert.assertEquals(Float.intBitsToFloat(1234567890), v.getFloat(), 0);
     });
   }
@@ -217,10 +282,23 @@ public class TestVariantScalar {
   @Test
   public void testNegativeFloat() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(14), 0x00, 0x00, 0x00, (byte) 0x80}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(14), 0x00, 0x00, 0x00, (byte) 0x80}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
       Assert.assertEquals(-0.0F, v.getFloat(), 0);
+    });
+  }
+
+  @Test
+  public void testFloatBuilder() {
+    Arrays.asList(Float.MIN_VALUE, 0f, Float.MAX_VALUE).forEach(f -> {
+      VariantBuilder vb2 = new VariantBuilder(false);
+      vb2.appendFloat(f);
+      VariantTestUtil.testVariant(vb2.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
+        Assert.assertEquals(f, v.getFloat(), 0);
+      });
     });
   }
 
@@ -228,11 +306,19 @@ public class TestVariantScalar {
   public void testDouble() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(7), (byte) 0xB1, 0x1C, 0x6C, (byte) 0xB1, (byte) 0xF4, 0x10, 0x22, 0x11
+          VariantTestUtil.primitiveHeader(7),
+          (byte) 0xB1,
+          0x1C,
+          0x6C,
+          (byte) 0xB1,
+          (byte) 0xF4,
+          0x10,
+          0x22,
+          0x11
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
       Assert.assertEquals(Double.longBitsToDouble(1234567890987654321L), v.getDouble(), 0);
     });
   }
@@ -240,21 +326,36 @@ public class TestVariantScalar {
   @Test
   public void testNegativeDouble() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(7), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0x80}),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
+        ByteBuffer.wrap(new byte[] {
+          VariantTestUtil.primitiveHeader(7), 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0x80
+        }),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
       Assert.assertEquals(-0.0D, v.getDouble(), 0);
+    });
+  }
+
+  @Test
+  public void testDoubleBuilder() {
+    Arrays.asList(Double.MIN_VALUE, 0d, Double.MAX_VALUE).forEach(d -> {
+      VariantBuilder vb2 = new VariantBuilder(false);
+      vb2.appendDouble(d);
+      VariantTestUtil.testVariant(vb2.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
+        Assert.assertEquals(d, v.getDouble(), 0);
+      });
     });
   }
 
   @Test
   public void testDecimal4() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(8), 0x04, (byte) 0xD2, 0x02, (byte) 0x96, 0x49}),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
+        ByteBuffer.wrap(
+            new byte[] {VariantTestUtil.primitiveHeader(8), 0x04, (byte) 0xD2, 0x02, (byte) 0x96, 0x49}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
       Assert.assertEquals(new BigDecimal("123456.7890"), v.getDecimal());
     });
   }
@@ -262,11 +363,12 @@ public class TestVariantScalar {
   @Test
   public void testNegativeDecimal4() {
     Variant value = new Variant(
-        ByteBuffer.wrap(
-            new byte[] {primitiveHeader(8), 0x04, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
+        ByteBuffer.wrap(new byte[] {
+          VariantTestUtil.primitiveHeader(8), 0x04, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        }),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
       Assert.assertEquals(new BigDecimal("-0.0001"), v.getDecimal());
     });
   }
@@ -275,11 +377,20 @@ public class TestVariantScalar {
   public void testDecimal8() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(9), 0x09, (byte) 0xB1, 0x1C, 0x6C, (byte) 0xB1, (byte) 0xF4, 0x10, 0x22, 0x11
+          VariantTestUtil.primitiveHeader(9),
+          0x09,
+          (byte) 0xB1,
+          0x1C,
+          0x6C,
+          (byte) 0xB1,
+          (byte) 0xF4,
+          0x10,
+          0x22,
+          0x11
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
       Assert.assertEquals(new BigDecimal("1234567890.987654321"), v.getDecimal());
     });
   }
@@ -288,7 +399,7 @@ public class TestVariantScalar {
   public void testNegativeDecimal8() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(9),
+          VariantTestUtil.primitiveHeader(9),
           0x09,
           (byte) 0xFF,
           (byte) 0xFF,
@@ -299,9 +410,9 @@ public class TestVariantScalar {
           (byte) 0xFF,
           (byte) 0xFF
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
       Assert.assertEquals(new BigDecimal("-0.000000001"), v.getDecimal());
     });
   }
@@ -310,7 +421,7 @@ public class TestVariantScalar {
   public void testDecimal16() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(10),
+          VariantTestUtil.primitiveHeader(10),
           0x09,
           0x15,
           0x71,
@@ -329,9 +440,9 @@ public class TestVariantScalar {
           0x00,
           0x00
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
       Assert.assertEquals(new BigDecimal("9876543210.123456789"), v.getDecimal());
     });
   }
@@ -340,7 +451,7 @@ public class TestVariantScalar {
   public void testNegativeDecimal16() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(10),
+          VariantTestUtil.primitiveHeader(10),
           0x09,
           (byte) 0xEB,
           (byte) 0x8E,
@@ -359,19 +470,55 @@ public class TestVariantScalar {
           (byte) 0xFF,
           (byte) 0xFF
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
       Assert.assertEquals(new BigDecimal("-9876543210.123456789"), v.getDecimal());
     });
   }
 
   @Test
+  public void testDecimalBuilder() {
+    // decimal4
+    Arrays.asList(new BigDecimal("123.456"), new BigDecimal("-987.654")).forEach(d -> {
+      VariantBuilder vb2 = new VariantBuilder(false);
+      vb2.appendDecimal(d);
+      VariantTestUtil.testVariant(vb2.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
+        Assert.assertEquals(d, v.getDecimal());
+      });
+    });
+
+    // decimal8
+    Arrays.asList(new BigDecimal("10.2147483647"), new BigDecimal("-1021474836.47"))
+        .forEach(d -> {
+          VariantBuilder vb2 = new VariantBuilder(false);
+          vb2.appendDecimal(d);
+          VariantTestUtil.testVariant(vb2.build(), v -> {
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
+            Assert.assertEquals(d, v.getDecimal());
+          });
+        });
+
+    // decimal16
+    Arrays.asList(new BigDecimal("109223372036854775.807"), new BigDecimal("-109.223372036854775807"))
+        .forEach(d -> {
+          VariantBuilder vb2 = new VariantBuilder(false);
+          vb2.appendDecimal(d);
+          VariantTestUtil.testVariant(vb2.build(), v -> {
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
+            Assert.assertEquals(d, v.getDecimal());
+          });
+        });
+  }
+
+  @Test
   public void testDate() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(11), (byte) 0xE3, 0x4E, 0x00, 0x00}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(11), (byte) 0xE3, 0x4E, 0x00, 0x00}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
       Assert.assertEquals(LocalDate.parse("2025-04-17"), LocalDate.ofEpochDay(v.getInt()));
     });
   }
@@ -379,33 +526,54 @@ public class TestVariantScalar {
   @Test
   public void testNegativeDate() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(11), (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
+        ByteBuffer.wrap(new byte[] {
+          VariantTestUtil.primitiveHeader(11), (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF
+        }),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
       Assert.assertEquals(LocalDate.parse("1969-12-31"), LocalDate.ofEpochDay(v.getInt()));
     });
   }
 
   @Test
-  public void testTimestamp() {
+  public void testDateBuilder() {
+    VariantBuilder vb = new VariantBuilder(false);
+    int days = Math.toIntExact(LocalDate.of(2024, 12, 16).toEpochDay());
+    vb.appendDate(days);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
+      Assert.assertEquals(days, v.getInt());
+    });
+  }
+
+  @Test
+  public void testTimestampTz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(12), (byte) 0xC0, 0x77, (byte) 0xA1, (byte) 0xEA, (byte) 0xF4, 0x32, 0x06, 0x00
+          VariantTestUtil.primitiveHeader(12),
+          (byte) 0xC0,
+          0x77,
+          (byte) 0xA1,
+          (byte) 0xEA,
+          (byte) 0xF4,
+          0x32,
+          0x06,
+          0x00
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
       Assert.assertEquals(
           Instant.parse("2025-04-17T08:09:10.123456Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS));
     });
   }
 
   @Test
-  public void testNegativeTimestamp() {
+  public void testNegativeTimestampTz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(12),
+          VariantTestUtil.primitiveHeader(12),
           (byte) 0xFF,
           (byte) 0xFF,
           (byte) 0xFF,
@@ -415,11 +583,23 @@ public class TestVariantScalar {
           (byte) 0xFF,
           (byte) 0xFF
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
       Assert.assertEquals(
           Instant.parse("1969-12-31T23:59:59.999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS));
+    });
+  }
+
+  @Test
+  public void testTimestampTzBuilder() {
+    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
+    VariantBuilder vb = new VariantBuilder(false);
+    long micros = VariantTestUtil.microsSinceEpoch(Instant.from(dtf.parse("2024-12-16T10:23:45.321456-08:00")));
+    vb.appendTimestampTz(micros);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
+      Assert.assertEquals(micros, v.getLong());
     });
   }
 
@@ -427,11 +607,19 @@ public class TestVariantScalar {
   public void testTimestampNtz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(13), (byte) 0xC0, 0x77, (byte) 0xA1, (byte) 0xEA, (byte) 0xF4, 0x32, 0x06, 0x00
+          VariantTestUtil.primitiveHeader(13),
+          (byte) 0xC0,
+          0x77,
+          (byte) 0xA1,
+          (byte) 0xEA,
+          (byte) 0xF4,
+          0x32,
+          0x06,
+          0x00
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
       Assert.assertEquals(
           Instant.parse("2025-04-17T08:09:10.123456Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS));
     });
@@ -441,7 +629,7 @@ public class TestVariantScalar {
   public void testNegativeTimestampNtz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(13),
+          VariantTestUtil.primitiveHeader(13),
           (byte) 0xFF,
           (byte) 0xFF,
           (byte) 0xFF,
@@ -451,52 +639,97 @@ public class TestVariantScalar {
           (byte) 0xFF,
           (byte) 0xFF
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
       Assert.assertEquals(
           Instant.parse("1969-12-31T23:59:59.999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS));
     });
   }
 
   @Test
+  public void testTimestampNtzBuilder() {
+    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
+    VariantBuilder vb = new VariantBuilder(false);
+    long micros = VariantTestUtil.microsSinceEpoch(Instant.from(dtf.parse("2024-01-01T23:00:00.000001Z")));
+    vb.appendTimestampNtz(micros);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
+      Assert.assertEquals(micros, v.getLong());
+    });
+  }
+
+  @Test
   public void testBinary() {
     Variant value = new Variant(
-        ByteBuffer.wrap(new byte[] {primitiveHeader(15), 0x05, 0x00, 0x00, 0x00, 'a', 'b', 'c', 'd', 'e'}),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BINARY);
+        ByteBuffer.wrap(
+            new byte[] {VariantTestUtil.primitiveHeader(15), 0x05, 0x00, 0x00, 0x00, 'a', 'b', 'c', 'd', 'e'
+            }),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BINARY);
       Assert.assertEquals(ByteBuffer.wrap(new byte[] {'a', 'b', 'c', 'd', 'e'}), v.getBinary());
+    });
+  }
+
+  @Test
+  public void testBinaryBuilder() {
+    VariantBuilder vb = new VariantBuilder(false);
+    byte[] binary = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    vb.appendBinary(binary);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BINARY);
+      Assert.assertEquals(ByteBuffer.wrap(binary), v.getBinary());
     });
   }
 
   @Test
   public void testString() {
     Variant value = new Variant(
-        ByteBuffer.wrap(
-            new byte[] {primitiveHeader(16), 0x07, 0x00, 0x00, 0x00, 'v', 'a', 'r', 'i', 'a', 'n', 't'}),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.STRING);
+        ByteBuffer.wrap(new byte[] {
+          VariantTestUtil.primitiveHeader(16), 0x07, 0x00, 0x00, 0x00, 'v', 'a', 'r', 'i', 'a', 'n', 't'
+        }),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.STRING);
       Assert.assertEquals("variant", v.getString());
     });
   }
 
   @Test
   public void testShortString() {
-    Variant value =
-        new Variant(ByteBuffer.wrap(new byte[] {0b11101, 'v', 'a', 'r', 'i', 'a', 'n', 't'}), EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.SHORT_STR, Variant.Type.STRING);
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {0b11101, 'v', 'a', 'r', 'i', 'a', 'n', 't'}),
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.SHORT_STR, Variant.Type.STRING);
       Assert.assertEquals("variant", v.getString());
     });
+  }
+
+  @Test
+  public void testStringBuilder() {
+    IntStream.range(VariantUtil.MAX_SHORT_STR_SIZE - 3, VariantUtil.MAX_SHORT_STR_SIZE + 3)
+        .forEach(len -> {
+          VariantBuilder vb2 = new VariantBuilder(false);
+          String s = VariantTestUtil.randomString(len);
+          vb2.appendString(s);
+          VariantTestUtil.testVariant(vb2.build(), v -> {
+            if (len <= VariantUtil.MAX_SHORT_STR_SIZE) {
+              VariantTestUtil.checkType(v, VariantUtil.SHORT_STR, Variant.Type.STRING);
+            } else {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.STRING);
+            }
+            Assert.assertEquals(s, v.getString());
+          });
+        });
   }
 
   @Test
   public void testTime() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(17),
+          VariantTestUtil.primitiveHeader(17),
           (byte) 0x00,
           (byte) 0x00,
           (byte) 0xCA,
@@ -506,32 +739,54 @@ public class TestVariantScalar {
           (byte) 0x00,
           (byte) 0x00
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIME);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIME);
       Assert.assertEquals(LocalTime.parse("23:59:59.123456"), LocalTime.ofNanoOfDay(v.getLong() * 1_000));
     });
   }
 
   @Test
-  public void testTimestampNanos() {
+  public void testTimeBuilder() {
+    for (String timeStr : Arrays.asList(
+        "00:00:00.000000", "00:00:00.000120", "12:00:00.000000", "12:00:00.002300", "23:59:59.999999")) {
+      VariantBuilder vb = new VariantBuilder(false);
+      long micros = LocalTime.parse(timeStr).toNanoOfDay() / 1_000;
+      vb.appendTime(micros);
+      VariantTestUtil.testVariant(vb.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIME);
+        Assert.assertEquals(micros, v.getLong());
+      });
+    }
+  }
+
+  @Test
+  public void testTimestampNanosTz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(18), 0x15, (byte) 0xC9, (byte) 0xBB, (byte) 0x86, (byte) 0xB4, 0x0C, 0x37, 0x18
+          VariantTestUtil.primitiveHeader(18),
+          0x15,
+          (byte) 0xC9,
+          (byte) 0xBB,
+          (byte) 0x86,
+          (byte) 0xB4,
+          0x0C,
+          0x37,
+          0x18
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
       Assert.assertEquals(
           Instant.parse("2025-04-17T08:09:10.123456789Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
     });
   }
 
   @Test
-  public void testNegativeTimestampNanos() {
+  public void testNegativeTimestampNanosTz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(18),
+          VariantTestUtil.primitiveHeader(18),
           (byte) 0xFF,
           (byte) 0xFF,
           (byte) 0xFF,
@@ -541,11 +796,23 @@ public class TestVariantScalar {
           (byte) 0xFF,
           (byte) 0xFF
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
       Assert.assertEquals(
           Instant.parse("1969-12-31T23:59:59.999999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
+    });
+  }
+
+  @Test
+  public void testTimestampNanosBuilder() {
+    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
+    VariantBuilder vb = new VariantBuilder(false);
+    long nanos = VariantTestUtil.nanosSinceEpoch(Instant.from(dtf.parse("2024-12-16T10:23:45.321456987-08:00")));
+    vb.appendTimestampNanosTz(nanos);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
+      Assert.assertEquals(nanos, v.getLong());
     });
   }
 
@@ -553,11 +820,19 @@ public class TestVariantScalar {
   public void testTimestampNanosNtz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(19), 0x15, (byte) 0xC9, (byte) 0xBB, (byte) 0x86, (byte) 0xB4, 0x0C, 0x37, 0x18
+          VariantTestUtil.primitiveHeader(19),
+          0x15,
+          (byte) 0xC9,
+          (byte) 0xBB,
+          (byte) 0x86,
+          (byte) 0xB4,
+          0x0C,
+          0x37,
+          0x18
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
       Assert.assertEquals(
           Instant.parse("2025-04-17T08:09:10.123456789Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
     });
@@ -567,7 +842,7 @@ public class TestVariantScalar {
   public void testNegativeTimestampNanosNtz() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(19),
+          VariantTestUtil.primitiveHeader(19),
           (byte) 0xFF,
           (byte) 0xFF,
           (byte) 0xFF,
@@ -577,11 +852,23 @@ public class TestVariantScalar {
           (byte) 0xFF,
           (byte) 0xFF
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
       Assert.assertEquals(
           Instant.parse("1969-12-31T23:59:59.999999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
+    });
+  }
+
+  @Test
+  public void testTimestampNanosNtzBuilder() {
+    DateTimeFormatter dtf = DateTimeFormatter.ISO_DATE_TIME;
+    VariantBuilder vb = new VariantBuilder(false);
+    long nanos = VariantTestUtil.nanosSinceEpoch(Instant.from(dtf.parse("2024-01-01T23:00:00.839280983Z")));
+    vb.appendTimestampNanosNtz(nanos);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
+      Assert.assertEquals(nanos, v.getLong());
     });
   }
 
@@ -589,7 +876,7 @@ public class TestVariantScalar {
   public void testUUID() {
     Variant value = new Variant(
         ByteBuffer.wrap(new byte[] {
-          primitiveHeader(20),
+          VariantTestUtil.primitiveHeader(20),
           0x00,
           0x11,
           0x22,
@@ -607,17 +894,32 @@ public class TestVariantScalar {
           (byte) 0xEE,
           (byte) 0xFF
         }),
-        EMPTY_METADATA);
-    testVariant(value, v -> {
-      checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
+        VariantTestUtil.EMPTY_METADATA);
+    VariantTestUtil.testVariant(value, v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
       Assert.assertEquals(UUID.fromString("00112233-4455-6677-8899-aabbccddeeff"), v.getUUID());
+    });
+  }
+
+  @Test
+  public void testUUIDBuilder() {
+    VariantBuilder vb = new VariantBuilder(false);
+    byte[] uuid = new byte[] {0, 17, 34, 51, 68, 85, 102, 119, -120, -103, -86, -69, -52, -35, -18, -1};
+    long msb = ByteBuffer.wrap(uuid, 0, 8).order(ByteOrder.BIG_ENDIAN).getLong();
+    long lsb = ByteBuffer.wrap(uuid, 8, 8).order(ByteOrder.BIG_ENDIAN).getLong();
+    UUID expected = new UUID(msb, lsb);
+
+    vb.appendUUID(expected);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
+      Assert.assertEquals(expected, v.getUUID());
     });
   }
 
   @Test
   public void testInvalidType() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {(byte) 0xFC}), EMPTY_METADATA);
+      Variant value = new Variant(ByteBuffer.wrap(new byte[] {(byte) 0xFC}), VariantTestUtil.EMPTY_METADATA);
       value.getBoolean();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -629,7 +931,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidBoolean() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getBoolean();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -640,7 +943,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidLong() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(16)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(16)}), VariantTestUtil.EMPTY_METADATA);
       value.getLong();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -653,7 +957,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidInt() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getInt();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -664,7 +969,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidShort() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getShort();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -675,7 +981,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidByte() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getByte();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -686,7 +993,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidFloat() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getFloat();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -697,7 +1005,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidDouble() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getDouble();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -708,7 +1017,9 @@ public class TestVariantScalar {
   @Test
   public void testInvalidDecimal() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6), 0}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6), 0}),
+          VariantTestUtil.EMPTY_METADATA);
       value.getDecimal();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -719,7 +1030,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidUUID() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getUUID();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -730,7 +1042,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidString() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getString();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {
@@ -741,7 +1054,8 @@ public class TestVariantScalar {
   @Test
   public void testInvalidBinary() {
     try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {primitiveHeader(6)}), EMPTY_METADATA);
+      Variant value = new Variant(
+          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
       value.getBinary();
       Assert.fail("Expected exception not thrown");
     } catch (Exception e) {

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalarBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalarBuilder.java
@@ -1,0 +1,430 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.variant;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestVariantScalarBuilder {
+  private static final Logger LOG = LoggerFactory.getLogger(TestVariantScalarBuilder.class);
+
+  @Test
+  public void testNullBuilder() {
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendNull();
+    VariantTestUtil.testVariant(vb.build(), v -> VariantTestUtil.checkType(v, VariantUtil.NULL, Variant.Type.NULL));
+
+    try {
+      vb.appendNull();
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testBooleanBuilder() {
+    Arrays.asList(true, false).forEach(b -> {
+      VariantBuilder vb = new VariantBuilder();
+      vb.appendBoolean(b);
+      VariantTestUtil.testVariant(vb.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
+        Assert.assertEquals(b, v.getBoolean());
+      });
+
+      try {
+        vb.appendBoolean(true);
+        Assert.fail("Expected Exception when appending multiple values");
+      } catch (Exception e) {
+        // expected
+      }
+    });
+  }
+
+  @Test
+  public void testLongBuilder() {
+    Arrays.asList(
+            0L,
+            (long) Byte.MIN_VALUE,
+            (long) Byte.MAX_VALUE,
+            (long) Short.MIN_VALUE,
+            (long) Short.MAX_VALUE,
+            (long) Integer.MIN_VALUE,
+            (long) Integer.MAX_VALUE,
+            Long.MIN_VALUE,
+            Long.MAX_VALUE)
+        .forEach(l -> {
+          VariantBuilder vb = new VariantBuilder();
+          vb.appendLong(l);
+          VariantTestUtil.testVariant(vb.build(), v -> {
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
+            Assert.assertEquals((long) l, v.getLong());
+          });
+
+          try {
+            vb.appendLong(1L);
+            Assert.fail("Expected Exception when appending multiple values");
+          } catch (Exception e) {
+            // expected
+          }
+        });
+  }
+
+  @Test
+  public void testIntBuilder() {
+    Arrays.asList(
+            0,
+            (int) Byte.MIN_VALUE,
+            (int) Byte.MAX_VALUE,
+            (int) Short.MIN_VALUE,
+            (int) Short.MAX_VALUE,
+            Integer.MIN_VALUE,
+            Integer.MAX_VALUE)
+        .forEach(i -> {
+          VariantBuilder vb = new VariantBuilder();
+          vb.appendInt(i);
+          VariantTestUtil.testVariant(vb.build(), v -> {
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
+            Assert.assertEquals((int) i, v.getInt());
+          });
+
+          try {
+            vb.appendInt(1);
+            Assert.fail("Expected Exception when appending multiple values");
+          } catch (Exception e) {
+            // expected
+          }
+        });
+  }
+
+  @Test
+  public void testShortBuilder() {
+    Arrays.asList((short) 0, (short) Byte.MIN_VALUE, (short) Byte.MAX_VALUE, Short.MIN_VALUE, Short.MAX_VALUE)
+        .forEach(s -> {
+          VariantBuilder vb = new VariantBuilder();
+          vb.appendShort(s);
+          VariantTestUtil.testVariant(vb.build(), v -> {
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
+            Assert.assertEquals((short) s, v.getShort());
+          });
+
+          try {
+            vb.appendShort((short) 1);
+            Assert.fail("Expected Exception when appending multiple values");
+          } catch (Exception e) {
+            // expected
+          }
+        });
+  }
+
+  @Test
+  public void testByteBuilder() {
+    Arrays.asList((byte) 0, Byte.MIN_VALUE, Byte.MAX_VALUE).forEach(b -> {
+      VariantBuilder vb = new VariantBuilder();
+      vb.appendByte(b);
+      VariantTestUtil.testVariant(vb.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
+        Assert.assertEquals((byte) b, v.getByte());
+      });
+
+      try {
+        vb.appendByte((byte) 1);
+        Assert.fail("Expected Exception when appending multiple values");
+      } catch (Exception e) {
+        // expected
+      }
+    });
+  }
+
+  @Test
+  public void testFloatBuilder() {
+    Arrays.asList(Float.MIN_VALUE, 0f, -0f, Float.MAX_VALUE).forEach(f -> {
+      VariantBuilder vb = new VariantBuilder();
+      vb.appendFloat(f);
+      VariantTestUtil.testVariant(vb.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
+        Assert.assertEquals(f, v.getFloat(), 0);
+      });
+
+      try {
+        vb.appendFloat(1.2f);
+        Assert.fail("Expected Exception when appending multiple values");
+      } catch (Exception e) {
+        // expected
+      }
+    });
+  }
+
+  @Test
+  public void testDoubleBuilder() {
+    Arrays.asList(Double.MIN_VALUE, 0d, -0d, Double.MAX_VALUE).forEach(d -> {
+      VariantBuilder vb = new VariantBuilder();
+      vb.appendDouble(d);
+      VariantTestUtil.testVariant(vb.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
+        Assert.assertEquals(d, v.getDouble(), 0);
+      });
+
+      try {
+        vb.appendDouble(1.2);
+        Assert.fail("Expected Exception when appending multiple values");
+      } catch (Exception e) {
+        // expected
+      }
+    });
+  }
+
+  @Test
+  public void testDecimalBuilder() {
+    // decimal4
+    Arrays.asList(new BigDecimal("123.456"), new BigDecimal("-987.654")).forEach(d -> {
+      VariantBuilder vb = new VariantBuilder();
+      vb.appendDecimal(d);
+      VariantTestUtil.testVariant(vb.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
+        Assert.assertEquals(d, v.getDecimal());
+      });
+    });
+
+    // decimal8
+    Arrays.asList(new BigDecimal("10.2147483647"), new BigDecimal("-1021474836.47"))
+        .forEach(d -> {
+          VariantBuilder vb = new VariantBuilder();
+          vb.appendDecimal(d);
+          VariantTestUtil.testVariant(vb.build(), v -> {
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
+            Assert.assertEquals(d, v.getDecimal());
+          });
+        });
+
+    // decimal16
+    Arrays.asList(new BigDecimal("109223372036854775.807"), new BigDecimal("-109.223372036854775807"))
+        .forEach(d -> {
+          VariantBuilder vb = new VariantBuilder();
+          vb.appendDecimal(d);
+          VariantTestUtil.testVariant(vb.build(), v -> {
+            VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
+            Assert.assertEquals(d, v.getDecimal());
+          });
+        });
+
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendDecimal(new BigDecimal("10.2147483647"));
+    try {
+      vb.appendDecimal(new BigDecimal("10.2147483647"));
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testDateBuilder() {
+    VariantBuilder vb = new VariantBuilder();
+    int days = Math.toIntExact(LocalDate.of(2024, 12, 16).toEpochDay());
+    vb.appendDate(days);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
+      Assert.assertEquals(days, v.getInt());
+    });
+
+    try {
+      vb.appendDate(123);
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testTimestampTzBuilder() {
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendTimestampTz(1734373425321456L);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
+      Assert.assertEquals(1734373425321456L, v.getLong());
+    });
+
+    try {
+      vb.appendTimestampTz(1734373425321456L);
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testTimestampNtzBuilder() {
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendTimestampNtz(1734373425321456L);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
+      Assert.assertEquals(1734373425321456L, v.getLong());
+    });
+
+    try {
+      vb.appendTimestampNtz(1734373425321456L);
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testBinaryBuilder() {
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendBinary(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BINARY);
+      Assert.assertEquals(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}), v.getBinary());
+    });
+
+    try {
+      vb.appendBinary(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testStringBuilder() {
+    IntStream.range(VariantUtil.MAX_SHORT_STR_SIZE - 3, VariantUtil.MAX_SHORT_STR_SIZE + 3)
+        .forEach(len -> {
+          VariantBuilder vb = new VariantBuilder();
+          String s = VariantTestUtil.randomString(len);
+          vb.appendString(s);
+          VariantTestUtil.testVariant(vb.build(), v -> {
+            if (len <= VariantUtil.MAX_SHORT_STR_SIZE) {
+              VariantTestUtil.checkType(v, VariantUtil.SHORT_STR, Variant.Type.STRING);
+            } else {
+              VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.STRING);
+            }
+            Assert.assertEquals(s, v.getString());
+          });
+        });
+
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendString(VariantTestUtil.randomString(10));
+    try {
+      vb.appendString(VariantTestUtil.randomString(10));
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testTimeBuilder() {
+    for (String timeStr : Arrays.asList(
+        "00:00:00.000000", "00:00:00.000120", "12:00:00.000000", "12:00:00.002300", "23:59:59.999999")) {
+      VariantBuilder vb = new VariantBuilder();
+      long micros = LocalTime.parse(timeStr).toNanoOfDay() / 1_000;
+      vb.appendTime(micros);
+      VariantTestUtil.testVariant(vb.build(), v -> {
+        VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIME);
+        Assert.assertEquals(micros, v.getLong());
+      });
+    }
+
+    // test negative time
+    try {
+      VariantBuilder vb = new VariantBuilder();
+      vb.appendTime(-1);
+      Assert.fail("Expected Exception when adding a negative time value");
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendTime(123456);
+    try {
+      vb.appendTime(123456);
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testTimestampNanosBuilder() {
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendTimestampNanosTz(1734373425321456987L);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
+      Assert.assertEquals(1734373425321456987L, v.getLong());
+    });
+
+    try {
+      vb.appendTimestampNanosTz(1734373425321456987L);
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testTimestampNanosNtzBuilder() {
+    VariantBuilder vb = new VariantBuilder();
+    vb.appendTimestampNanosNtz(1734373425321456987L);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
+      Assert.assertEquals(1734373425321456987L, v.getLong());
+    });
+
+    try {
+      vb.appendTimestampNanosNtz(1734373425321456987L);
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+
+  @Test
+  public void testUUIDBuilder() {
+    VariantBuilder vb = new VariantBuilder();
+    byte[] uuid = new byte[] {0, 17, 34, 51, 68, 85, 102, 119, -120, -103, -86, -69, -52, -35, -18, -1};
+    long msb = ByteBuffer.wrap(uuid, 0, 8).order(ByteOrder.BIG_ENDIAN).getLong();
+    long lsb = ByteBuffer.wrap(uuid, 8, 8).order(ByteOrder.BIG_ENDIAN).getLong();
+    UUID expected = new UUID(msb, lsb);
+
+    vb.appendUUID(expected);
+    VariantTestUtil.testVariant(vb.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
+      Assert.assertEquals(expected, v.getUUID());
+    });
+
+    try {
+      vb.appendUUID(expected);
+      Assert.fail("Expected Exception when appending multiple values");
+    } catch (Exception e) {
+      // expected
+    }
+  }
+}

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/VariantTestUtil.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/VariantTestUtil.java
@@ -22,9 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import java.time.Instant;
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.junit.Assert;
 import org.slf4j.Logger;
@@ -42,14 +40,6 @@ public class VariantTestUtil {
   static void checkType(Variant v, int expectedBasicType, Variant.Type expectedType) {
     Assert.assertEquals(expectedBasicType, v.value.get(v.value.position()) & VariantUtil.BASIC_TYPE_MASK);
     Assert.assertEquals(expectedType, v.getType());
-  }
-
-  static long microsSinceEpoch(Instant instant) {
-    return TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) + instant.getNano() / 1000;
-  }
-
-  static long nanosSinceEpoch(Instant instant) {
-    return TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
   }
 
   static String randomString(int len) {

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/VariantTestUtil.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/VariantTestUtil.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.variant;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class VariantTestUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(VariantTestUtil.class);
+  private static final String RANDOM_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+
+  /** Random number generator for generating random strings */
+  private static SecureRandom random = new SecureRandom(new byte[] {1, 2, 3, 4, 5});
+
+  static final ByteBuffer EMPTY_METADATA = ByteBuffer.wrap(new byte[] {0b1});
+
+  static void checkType(Variant v, int expectedBasicType, Variant.Type expectedType) {
+    Assert.assertEquals(expectedBasicType, v.value.get(v.value.position()) & VariantUtil.BASIC_TYPE_MASK);
+    Assert.assertEquals(expectedType, v.getType());
+  }
+
+  static long microsSinceEpoch(Instant instant) {
+    return TimeUnit.SECONDS.toMicros(instant.getEpochSecond()) + instant.getNano() / 1000;
+  }
+
+  static long nanosSinceEpoch(Instant instant) {
+    return TimeUnit.SECONDS.toNanos(instant.getEpochSecond()) + instant.getNano();
+  }
+
+  static String randomString(int len) {
+    StringBuilder sb = new StringBuilder(len);
+    for (int i = 0; i < len; i++) {
+      sb.append(RANDOM_CHARS.charAt(random.nextInt(RANDOM_CHARS.length())));
+    }
+    return sb.toString();
+  }
+
+  static void testVariant(Variant v, Consumer<Variant> consumer) {
+    consumer.accept(v);
+    // Create new Variant with different byte offsets
+    byte[] newValue = new byte[v.value.capacity() + 50];
+    byte[] newMetadata = new byte[v.metadata.capacity() + 50];
+    Arrays.fill(newValue, (byte) 0xFF);
+    Arrays.fill(newMetadata, (byte) 0xFF);
+    v.value.position(0);
+    v.value.get(newValue, 25, v.value.capacity());
+    v.value.position(0);
+    v.metadata.position(0);
+    v.metadata.get(newMetadata, 25, v.metadata.capacity());
+    v.metadata.position(0);
+    Variant v2 = new Variant(
+        ByteBuffer.wrap(newValue, 25, v.value.capacity()),
+        ByteBuffer.wrap(newMetadata, 25, v.metadata.capacity()));
+    consumer.accept(v2);
+  }
+
+  static byte primitiveHeader(int type) {
+    return (byte) (type << 2);
+  }
+
+  static byte metadataHeader(boolean isSorted, int offsetSize) {
+    return (byte) (((offsetSize - 1) << 6) | (isSorted ? 0b10000 : 0) | 0b0001);
+  }
+
+  static byte[] constructString(String value) {
+    return ByteBuffer.allocate(value.length() + 5)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .put(primitiveHeader(16))
+        .putInt(value.length())
+        .put(value.getBytes(StandardCharsets.UTF_8))
+        .array();
+  }
+
+  static int getMinIntegerSize(int value) {
+    return (value <= 0xFF) ? 1 : (value <= 0xFFFF) ? 2 : (value <= 0xFFFFFF) ? 3 : 4;
+  }
+
+  static void writeVarlenInt(ByteBuffer buffer, int value, int valueSize) {
+    if (valueSize == 1) {
+      buffer.put((byte) value);
+    } else if (valueSize == 2) {
+      buffer.putShort((short) value);
+    } else if (valueSize == 3) {
+      buffer.put((byte) (value & 0xFF));
+      buffer.put((byte) ((value >> 8) & 0xFF));
+      buffer.put((byte) ((value >> 16) & 0xFF));
+    } else {
+      buffer.putInt(value);
+    }
+  }
+}


### PR DESCRIPTION
### Rationale for this change

We need a way to build/encode Variant values. This builder allows users to create Variant values according to the [Variant binary encoding spec](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md).

### What changes are included in this PR?

A builder class for building Variant values.

### Are these changes tested?

Yes, added unit tests.

### Are there any user-facing changes?

A new public class to build Variant vlues.

Closes #3201