### PR TITLE
 GH-3203: HadoopPositionOutputStream.close() to call FSDataOutputStream.flush()

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopPositionOutputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopPositionOutputStream.java
@@ -62,7 +62,7 @@ public class HadoopPositionOutputStream extends PositionOutputStream {
   @Override
   public void close() throws IOException {
     try (FSDataOutputStream fdos = wrapped) {
-      fdos.hflush();
+      fdos.flush();
     }
   }
 }


### PR DESCRIPTION
Downgrade flush in HadoopPositionOutputStream.close() from Syncable.hflush() to a basic flush() operation.

### Rationale for this change

calling Syncable.sync() is time-consuming overkill just before a close() operation, and trouble on other stores (s3a will log at warn, when not configured to fail fast)

### What changes are included in this PR?

Switches to classic OutputStream.flush()

### Are these changes tested?

Expecting test runner to do this.


### Are there any user-facing changes?

No

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #3203
