### PR TITLE
GH-3205: Make HadoopPositionOutputStream.close() safe to call even if closed

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopPositionOutputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopPositionOutputStream.java
@@ -25,6 +25,7 @@ import org.apache.parquet.io.PositionOutputStream;
 
 public class HadoopPositionOutputStream extends PositionOutputStream {
   private final FSDataOutputStream wrapped;
+  private boolean closed;
 
   HadoopPositionOutputStream(FSDataOutputStream wrapped) {
     this.wrapped = wrapped;
@@ -61,8 +62,13 @@ public class HadoopPositionOutputStream extends PositionOutputStream {
 
   @Override
   public void close() throws IOException {
+    if (closed) {
+      return;
+    }
     try (FSDataOutputStream fdos = wrapped) {
       fdos.flush();
+    } finally {
+      closed = true;
     }
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopPositionOutputStream.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopPositionOutputStream.java
@@ -20,12 +20,13 @@
 package org.apache.parquet.hadoop.util;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.parquet.io.PositionOutputStream;
 
 public class HadoopPositionOutputStream extends PositionOutputStream {
   private final FSDataOutputStream wrapped;
-  private boolean closed;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   HadoopPositionOutputStream(FSDataOutputStream wrapped) {
     this.wrapped = wrapped;
@@ -62,13 +63,11 @@ public class HadoopPositionOutputStream extends PositionOutputStream {
 
   @Override
   public void close() throws IOException {
-    if (closed) {
+    if (closed.getAndSet(true)) {
       return;
     }
     try (FSDataOutputStream fdos = wrapped) {
       fdos.flush();
-    } finally {
-      closed = true;
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->


### Rationale for this change
HadoopPositionOutputStream implements Closable, so its close method should have no effect if already closed.

### What changes are included in this PR?
Add code to HadoopPositionOutputStream.close() to check if already closed. If yes, do nothing.

### Are these changes tested?
Expecting test runner to do this.

### Are there any user-facing changes?
No

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
 Closes #3205
