### PR TITLE
GH-3207: ParquetFileReader supports detachFileInputStream

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -1743,8 +1743,12 @@ public class ParquetFileReader implements Closeable {
 
   @Override
   public void close() throws IOException {
+    close(true);
+  }
+
+  public void close(boolean closeFileInputStream) throws IOException {
     try {
-      if (f != null) {
+      if (closeFileInputStream && f != null) {
         f.close();
       }
     } finally {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -729,7 +729,7 @@ public class ParquetFileReader implements Closeable {
     return new ParquetFileReader(file, options, f);
   }
 
-  protected final SeekableInputStream f;
+  protected SeekableInputStream f;
   private final InputFile file;
   private final ParquetReadOptions options;
   private final Map<ColumnPath, ColumnDescriptor> paths = new HashMap<>();
@@ -1741,14 +1741,18 @@ public class ParquetFileReader implements Closeable {
         Util.readOffsetIndex(f, offsetIndexDecryptor, offsetIndexAAD));
   }
 
-  @Override
-  public void close() throws IOException {
-    close(true);
+  /**
+   * Explicitly detach the the input stream for the file to avoid being closed via
+   * {@link ParquetFileReader#close()}.
+   */
+  public void detachFileInputStream() {
+    f = null;
   }
 
-  public void close(boolean closeFileInputStream) throws IOException {
+  @Override
+  public void close() throws IOException {
     try {
-      if (closeFileInputStream && f != null) {
+      if (f != null) {
         f.close();
       }
     } finally {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

This allows the caller to reuse the `SeekableInputStream` across `ParquetFileReader`s, for example, in Spark Parquet vectorized reading code path, it opens two times for each Parquet file:

1. the first time opens and reads the footer, do some pruning and push down stuff.
2. the second time opens and reads the row groups

it's possible to reuse the `SeekableInputStream` to reduce the NameNode RPC

### What changes are included in this PR?

Providing a `detachFileInputStream ` method for `ParquetFileReader` to allow detaching file input stream before closing the `ParquetFileReader`

### Are these changes tested?

N/A

### Are there any user-facing changes?

No.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #3207
