### PR TITLE
GH-3213: Add the configuration for ByteStreamSplit encoding

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -671,6 +671,11 @@ public class ParquetWriter<T> implements Closeable {
       return self();
     }
 
+    public SELF withByteStreamSplitEncoding(String columnPath, boolean enableByteStreamSplit) {
+      encodingPropsBuilder.withByteStreamSplitEncoding(columnPath, enableByteStreamSplit);
+      return self();
+    }
+
     /**
      * Enable or disable dictionary encoding of the specified column for the constructed writer.
      *


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Add the configuration for ByteStreamSplit encoding for a specific column when building `ParquetWriter`

### What changes are included in this PR?
A new config method

### Are these changes tested?
No

### Are there any user-facing changes?
Yes when building `ParquetWriter` e.g.
```
ParquetWriter<Group> writer =
            ExampleParquetWriter.builder(...)
                .withByteStreamSplitEncoding("int32_field", true)
                ...
```


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #3213
