### PR TITLE
GH-3215: Make the order of encodings in column metadata deterministic

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -665,11 +665,13 @@ public class ParquetMetadataConverter {
     rowGroups.add(rowGroup);
   }
 
-  private List<Encoding> toFormatEncodings(Set<org.apache.parquet.column.Encoding> encodings) {
+  // Visible for testing
+  List<Encoding> toFormatEncodings(Set<org.apache.parquet.column.Encoding> encodings) {
     List<Encoding> converted = new ArrayList<Encoding>(encodings.size());
     for (org.apache.parquet.column.Encoding encoding : encodings) {
       converted.add(getEncoding(encoding));
     }
+    Collections.sort(converted);
     return converted;
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -757,6 +757,20 @@ public class TestParquetMetadataConverter {
   }
 
   @Test
+  public void testEncodingsOrder() {
+    ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
+
+    Set<org.apache.parquet.column.Encoding> columnEncodings =
+        new HashSet<>(Arrays.asList(org.apache.parquet.column.Encoding.values()));
+
+    // Assert that the encodings are returned in ascending ordinal order
+    List<org.apache.parquet.format.Encoding> formatEncodings = parquetMetadataConverter.toFormatEncodings(columnEncodings);
+    for (int i=1; i<formatEncodings.size(); i++) {
+      assertTrue(formatEncodings.get(i - 1).ordinal() < formatEncodings.get(i).ordinal());
+    }
+  }
+
+  @Test
   public void testBinaryStatsV1() {
     testBinaryStats(StatsHelper.V1);
   }


### PR DESCRIPTION
### Rationale for this change

Two processes running the same version of parquet-java and having identical writer configurations can still produce files that are different at the binary level for the exact same written data.

### What changes are included in this PR?

A single line added to `org.apache.parquet.format.converter.ParquetMetadataConverter::toFormatEncodings`

### Are these changes tested?

A unit test is provided. I have tested this in a custom built parquet-java with our production code for several months.

### Are there any user-facing changes?

No

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #${3215}
