### PR TITLE
PARQUET-570: Added support to write to stdout

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCommand.java
@@ -32,7 +32,6 @@ import com.google.common.io.Closeables;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
-
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.fs.FileSystem;

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/ConvertCommand.java
@@ -32,6 +32,7 @@ import com.google.common.io.Closeables;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.fs.FileSystem;
@@ -42,6 +43,7 @@ import org.apache.parquet.cli.util.Codecs;
 import org.apache.parquet.cli.util.Schemas;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.io.StandardOutputFile;
 import org.slf4j.Logger;
 
 @Parameters(commandDescription = "Create a Parquet file from a data file")
@@ -56,8 +58,8 @@ public class ConvertCommand extends BaseCommand {
 
   @Parameter(
       names = {"-o", "--output"},
-      description = "Output file path",
-      required = true)
+      description = "Output file path, if not given writes to stdout",
+      required = false)
   String outputPath = null;
 
   @Parameter(
@@ -112,18 +114,11 @@ public class ConvertCommand extends BaseCommand {
     }
     Schema projection = filterSchema(schema, columns);
 
-    Path outPath = qualifiedPath(outputPath);
-    FileSystem outFS = outPath.getFileSystem(getConf());
-    if (overwrite && outFS.exists(outPath)) {
-      console.debug("Deleting output file {} (already exists)", outPath);
-      outFS.delete(outPath);
-    }
-
     Iterable<Record> reader = openDataFile(source, projection);
     boolean threw = true;
     long count = 0;
     try {
-      try (ParquetWriter<Record> writer = AvroParquetWriter.<Record>builder(qualifiedPath(outputPath))
+      try (ParquetWriter<Record> writer = createBuilder()
           .withWriterVersion(v2 ? PARQUET_2_0 : PARQUET_1_0)
           .withConf(getConf())
           .withCompressionCodec(codec)
@@ -149,6 +144,19 @@ public class ConvertCommand extends BaseCommand {
     }
 
     return 0;
+  }
+
+  private AvroParquetWriter.Builder<Record> createBuilder() throws IOException {
+    if (outputPath != null) {
+      Path outPath = qualifiedPath(outputPath);
+      FileSystem outFS = outPath.getFileSystem(getConf());
+      if (overwrite && outFS.exists(outPath)) {
+        console.debug("Deleting output file {} (already exists)", outPath);
+        outFS.delete(outPath);
+      }
+      return AvroParquetWriter.<Record>builder(outPath);
+    }
+    return AvroParquetWriter.<Record>builder(new StandardOutputFile());
   }
 
   @Override

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/commands/RewriteCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/commands/RewriteCommand.java
@@ -92,9 +92,7 @@ public class RewriteCommand extends BaseCommand {
   }
 
   private RewriteOptions buildOptionsOrFail() throws IOException {
-    Preconditions.checkArgument(
-        inputs != null && !inputs.isEmpty(),
-        "Input parquet file paths are required.");
+    Preconditions.checkArgument(inputs != null && !inputs.isEmpty(), "Input parquet file paths are required.");
 
     // The builder below takes the job to validate all input parameters.
     RewriteOptions.Builder builder = createBuilder();

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.parquet.cli.commands;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
@@ -37,4 +39,17 @@ public class ConvertCommandTest extends AvroFileTest {
     Assert.assertEquals(0, command.run());
     Assert.assertTrue(output.exists());
   }
+
+  @Test
+  public void testConvertCommandToStdOut() throws IOException {
+    File file = toAvro(parquetFile());
+    ConvertCommand command = new ConvertCommand(createLogger());
+    command.targets = Arrays.asList(file.getAbsolutePath());
+    command.setConf(new Configuration());
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(baos));
+    Assert.assertEquals(0, command.run());
+    Assert.assertTrue(baos.size() > 0);
+  }
+
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
@@ -51,5 +51,4 @@ public class ConvertCommandTest extends AvroFileTest {
     Assert.assertEquals(0, command.run());
     Assert.assertTrue(baos.size() > 0);
   }
-
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.parquet.cli.commands;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
@@ -95,4 +97,19 @@ public class RewriteCommandTest extends ParquetFileTest {
     Assert.assertEquals(0, command.run());
     Assert.assertTrue(output.exists());
   }
+
+  @Test
+  public void testRewriteCommandToStdOut() throws IOException {
+    File file = parquetFile();
+    RewriteCommand command = new RewriteCommand(createLogger());
+    command.inputs = Arrays.asList(file.getAbsolutePath());
+    command.codec = "gzip";
+    command.setConf(new Configuration());
+
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(baos));
+    Assert.assertEquals(0, command.run());
+    Assert.assertTrue(baos.size() > 0);
+  }
+
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
@@ -111,5 +111,4 @@ public class RewriteCommandTest extends ParquetFileTest {
     Assert.assertEquals(0, command.run());
     Assert.assertTrue(baos.size() > 0);
   }
-
 }

--- a/parquet-common/src/main/java/org/apache/parquet/io/StandardOutputFile.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/StandardOutputFile.java
@@ -26,61 +26,59 @@ import java.io.IOException;
  */
 public class StandardOutputFile implements OutputFile {
 
-    /**
-     * @implNote we don't want to close the standard output (it's up to the process lifecycle to handle that)
-     */
-    public class RawPositionOutputStream extends PositionOutputStream {
+  /**
+   * @implNote we don't want to close the standard output (it's up to the process lifecycle to handle that)
+   */
+  public class RawPositionOutputStream extends PositionOutputStream {
 
-        private long pos = 0;
+    private long pos = 0;
 
-        @Override
-        public long getPos() throws IOException {
-            return this.pos;
-        }
-
-        @Override
-        public void write(int b) throws IOException {
-            this.pos++;
-            System.out.write(b);
-        }
-
-        @Override
-        public void write(byte[] b) throws IOException {
-            this.pos += b.length;
-            System.out.write(b);
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            this.pos += len;
-            System.out.write(b, off, len);
-        }
-
-        @Override
-        public void flush() throws IOException {
-            System.out.flush();
-        }
-
+    @Override
+    public long getPos() throws IOException {
+      return this.pos;
     }
 
     @Override
-    public PositionOutputStream create(long blockSizeHint) throws IOException {
-        return new RawPositionOutputStream();
+    public void write(int b) throws IOException {
+      this.pos++;
+      System.out.write(b);
     }
 
     @Override
-    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
-        return new RawPositionOutputStream();
+    public void write(byte[] b) throws IOException {
+      this.pos += b.length;
+      System.out.write(b);
     }
 
     @Override
-    public boolean supportsBlockSize() {
-        return false;
+    public void write(byte[] b, int off, int len) throws IOException {
+      this.pos += len;
+      System.out.write(b, off, len);
     }
 
     @Override
-    public long defaultBlockSize() {
-        return -1;
+    public void flush() throws IOException {
+      System.out.flush();
     }
+  }
 
+  @Override
+  public PositionOutputStream create(long blockSizeHint) throws IOException {
+    return new RawPositionOutputStream();
+  }
+
+  @Override
+  public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+    return new RawPositionOutputStream();
+  }
+
+  @Override
+  public boolean supportsBlockSize() {
+    return false;
+  }
+
+  @Override
+  public long defaultBlockSize() {
+    return -1;
+  }
 }

--- a/parquet-common/src/main/java/org/apache/parquet/io/StandardOutputFile.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/StandardOutputFile.java
@@ -26,9 +26,6 @@ import java.io.IOException;
  */
 public class StandardOutputFile implements OutputFile {
 
-  /**
-   * @implNote we don't want to close the standard output (it's up to the process lifecycle to handle that)
-   */
   public class RawPositionOutputStream extends PositionOutputStream {
 
     private long pos = 0;

--- a/parquet-common/src/main/java/org/apache/parquet/io/StandardOutputFile.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/StandardOutputFile.java
@@ -1,0 +1,86 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.apache.parquet.io;
+
+import java.io.IOException;
+
+/**
+ * An {@link OutputFile} implementation that allows Parquet to write to {@link System#out}
+ */
+public class StandardOutputFile implements OutputFile {
+
+    /**
+     * @implNote we don't want to close the standard output (it's up to the process lifecycle to handle that)
+     */
+    public class RawPositionOutputStream extends PositionOutputStream {
+
+        private long pos = 0;
+
+        @Override
+        public long getPos() throws IOException {
+            return this.pos;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            this.pos++;
+            System.out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+            this.pos += b.length;
+            System.out.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            this.pos += len;
+            System.out.write(b, off, len);
+        }
+
+        @Override
+        public void flush() throws IOException {
+            System.out.flush();
+        }
+
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) throws IOException {
+        return new RawPositionOutputStream();
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) throws IOException {
+        return new RawPositionOutputStream();
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+        return false;
+    }
+
+    @Override
+    public long defaultBlockSize() {
+        return -1;
+    }
+
+}

--- a/parquet-common/src/test/java/org/apache/parquet/io/TestStandardOutputFile.java
+++ b/parquet-common/src/test/java/org/apache/parquet/io/TestStandardOutputFile.java
@@ -1,0 +1,69 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.apache.parquet.io;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+public class TestStandardOutputFile {
+
+  private static final String TEST = "this is a test";
+
+  @Test
+  public void outputFileWriteByteToStdOut() throws IOException, InterruptedException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(baos));
+    final PositionOutputStream stdOut = new StandardOutputFile().create(1);
+    final byte test = 7;
+    stdOut.write(test);
+    assertEquals(1, stdOut.getPos());
+    assertEquals(1, baos.toByteArray().length);
+    assertEquals(7, baos.toByteArray()[0]);
+  }
+
+  @Test
+  public void outputFileWriteArrayToStdOut() throws IOException, InterruptedException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(baos));
+    final PositionOutputStream stdOut = new StandardOutputFile().create(1);
+    final byte[] test = TEST.getBytes();
+    stdOut.write(test);
+    assertEquals(test.length, stdOut.getPos());
+    assertEquals(test.length, baos.toByteArray().length);
+    assertEquals(TEST, new String(baos.toByteArray()));
+  }
+
+  @Test
+  public void outputFileWriteArrayOffsetToStdOut() throws IOException, InterruptedException {
+    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(baos));
+    final PositionOutputStream stdOut = new StandardOutputFile().create(1);
+    final byte[] test = TEST.getBytes();
+    stdOut.write(test, 1, 4);
+    assertEquals(4, stdOut.getPos());
+    assertEquals(4, baos.toByteArray().length);
+    assertEquals(TEST.substring(1, 5), new String(baos.toByteArray()));
+  }
+
+}

--- a/parquet-common/src/test/java/org/apache/parquet/io/TestStandardOutputFile.java
+++ b/parquet-common/src/test/java/org/apache/parquet/io/TestStandardOutputFile.java
@@ -20,11 +20,10 @@ package org.apache.parquet.io;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Test;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import org.junit.Test;
 
 public class TestStandardOutputFile {
 
@@ -65,5 +64,4 @@ public class TestStandardOutputFile {
     assertEquals(4, baos.toByteArray().length);
     assertEquals(TEST.substring(1, 5), new String(baos.toByteArray()));
   }
-
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
https://issues.apache.org/jira/browse/PARQUET-570

### What changes are included in this PR?
Commands can now write to stdout rather than a fixed location

### Are these changes tested?
There are tests for each affected files

### Are there any user-facing changes?
The cli now do no require the output parameter as it writes to stdout by default

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
