### PR TITLE
MINOR: Bump thrift to 0.22.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,19 @@ Parquet-Java uses Maven to build and depends on the thrift compiler (protoc is n
 To build and install the thrift compiler, run:
 
 ```
-wget -nv https://archive.apache.org/dist/thrift/0.21.0/thrift-0.21.0.tar.gz
-tar xzf thrift-0.21.0.tar.gz
-cd thrift-0.21.0
+wget -nv https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz
+tar xzf thrift-0.22.0.tar.gz
+cd thrift-0.22.0
 chmod +x ./configure
 ./configure --disable-libs
 sudo make install -j
 ```
 
-If you're on OSX and use homebrew, you can instead install Thrift 0.21.0 with `brew` and ensure that it comes first in your `PATH`.
+If you're on OSX and use homebrew, you can instead install Thrift 0.22.0 with `brew` and ensure that it comes first in your `PATH`.
 
 ```
 brew install thrift
-export PATH="/usr/local/opt/thrift@0.21.0/bin:$PATH"
+export PATH="/usr/local/opt/thrift@0.22.0/bin:$PATH"
 ```
 
 ### Build Parquet with Maven

--- a/dev/ci-before_install.sh
+++ b/dev/ci-before_install.sh
@@ -20,7 +20,7 @@
 # This script gets invoked by the CI system in a "before install" step
 ################################################################################
 
-export THRIFT_VERSION=0.21.0
+export THRIFT_VERSION=0.22.0
 
 set -e
 date

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
     <pig.version>0.16.0</pig.version>
     <pig.classifier>h2</pig.classifier>
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
-    <thrift.version>0.21.0</thrift.version>
+    <thrift.version>0.22.0</thrift.version>
     <format.thrift.version>${thrift.version}</format.thrift.version>
     <fastutil.version>8.5.15</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>


### PR DESCRIPTION
Following this PR: https://github.com/apache/parquet-format/pull/495. Homebrew has updated too: https://github.com/Homebrew/homebrew-core/commit/f5c7fcdbf61df2a746b7382204ed6cc8bb80ff56