### PR TITLE
GH-3233: Parquet CLI supports version command

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
@@ -87,6 +87,7 @@ public class Main extends Configured implements Tool {
     this.help = new Help(jc, console);
     jc.setProgramName(DEFAULT_PROGRAM_NAME);
     jc.addCommand("help", help, "-h", "-help", "--help");
+    jc.addCommand("version", new ShowVersionCommand(console));
     jc.addCommand("meta", new ParquetMetadataCommand(console));
     jc.addCommand("pages", new ShowPagesCommand(console));
     jc.addCommand("dictionary", new ShowDictionaryCommand(console));

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/ShowVersionCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/ShowVersionCommand.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli;
+
+import com.beust.jcommander.*;
+import java.util.List;
+import org.apache.parquet.Version;
+import org.slf4j.Logger;
+
+@Parameters(commandDescription = "Print version of the Parquet CLI tool")
+public class ShowVersionCommand implements Command {
+
+  private final Logger console;
+
+  public ShowVersionCommand(Logger console) {
+    this.console = console;
+  }
+
+  @Override
+  public int run() {
+    console.info(Version.FULL_VERSION);
+    return 0;
+  }
+
+  @Override
+  public List<String> getExamples() {
+    return null;
+  }
+}

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowVersionCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowVersionCommandTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.cli.commands;
+
+import java.util.Queue;
+import org.apache.parquet.Version;
+import org.apache.parquet.cli.ShowVersionCommand;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.event.LoggingEvent;
+
+public class ShowVersionCommandTest extends FileTest {
+
+  @Test
+  public void testVersionCommand() {
+    withLogger(this::testVersionCommand0);
+  }
+
+  private void testVersionCommand0(Logger console, Queue<? extends LoggingEvent> loggingEvents) {
+    ShowVersionCommand command = new ShowVersionCommand(console);
+    Assert.assertEquals(0, command.run());
+    Assert.assertEquals(1, loggingEvents.size());
+    LoggingEvent loggingEvent = loggingEvents.remove();
+    Assert.assertEquals(Version.FULL_VERSION, loggingEvent.getMessage());
+    loggingEvents.clear();
+  }
+}


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Follow the convention for the CLI tools to add a `version` command.

### What changes are included in this PR?

As title.

### Are these changes tested?

UT added, also tested manually

```
$ java -cp 'target/parquet-cli-1.16.0-SNAPSHOT.jar:target/dependency/*' org.apache.parquet.cli.Main version     
parquet-mr version 1.16.0-SNAPSHOT (build eb65987333a6bb2ae729b88eef0d6f941a7c1867)
```

### Are there any user-facing changes?

Yes.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #3233
