### PR TITLE
MINOR: replace avro test configuration

### DIFF
--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
@@ -962,9 +962,9 @@ public class TestReadWrite {
           writerBuilder.withCodecFactory(HadoopCodecs.newFactory(ParquetProperties.DEFAULT_PAGE_SIZE));
     }
     if (conf == ConfigurationType.PLAIN_PARQUET_INTERFACE) {
-      return writerBuilder.withConf(hadoopConfWithInterface).build();
-    } else if (conf == ConfigurationType.HADOOP_PARQUET_INTERFACE) {
       return writerBuilder.withConf(plainParquetConf).build();
+    } else if (conf == ConfigurationType.HADOOP_PARQUET_INTERFACE) {
+      return writerBuilder.withConf(hadoopConfWithInterface).build();
     } else {
       return writerBuilder.withConf(testConf).build();
     }
@@ -983,9 +983,9 @@ public class TestReadWrite {
           readerBuilder.withCodecFactory(HadoopCodecs.newFactory(ParquetProperties.DEFAULT_PAGE_SIZE));
     }
     if (conf == ConfigurationType.PLAIN_PARQUET_INTERFACE) {
-      return readerBuilder.withConf(hadoopConfWithInterface).build();
-    } else if (conf == ConfigurationType.HADOOP_PARQUET_INTERFACE) {
       return readerBuilder.withConf(plainParquetConf).build();
+    } else if (conf == ConfigurationType.HADOOP_PARQUET_INTERFACE) {
+      return readerBuilder.withConf(hadoopConfWithInterface).build();
     } else {
       return readerBuilder.withConf(testConf).build();
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
The test configurations for hadoop and plain parquet appears to be placed under the wrong branches.  This patch replaces these configurations in their intended branch.

### What changes are included in this PR?
Placed plain parquet or hadoop configuration in their corresponding branch.

### Are these changes tested?
Re-run `./mvnw test` passed.

### Are there any user-facing changes?
No.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
