### PR TITLE
GH-3141: Add constructor to `ParquetFileReader` to allow passing in parquet footer and expose setRequestedSchema that accepts `List<ColumnDescriptor>`

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -570,7 +570,7 @@ public class ParquetFileReader implements Closeable {
     return readFooter(file, options, f, /*closeStreamOnFailure*/ false);
   }
 
-  public static final ParquetMetadata readFooter(
+  private static final ParquetMetadata readFooter(
       InputFile file, ParquetReadOptions options, SeekableInputStream f, boolean closeStreamOnFailure)
       throws IOException {
     ParquetMetadataConverter converter = new ParquetMetadataConverter(options);

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -1121,11 +1121,15 @@ public class ParquetFileReader implements Closeable {
     return blocks;
   }
 
-  public void setRequestedSchema(MessageType projection) {
+  public void setRequestedSchema(List<ColumnDescriptor> columns) {
     paths.clear();
-    for (ColumnDescriptor col : projection.getColumns()) {
+    for (ColumnDescriptor col : columns) {
       paths.put(ColumnPath.get(col.getPath()), col);
     }
+  }
+
+  public void setRequestedSchema(MessageType projection) {
+    setRequestedSchema(projection.getColumns());
   }
 
   public void appendTo(ParquetFileWriter writer) throws IOException {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -739,7 +739,8 @@ public class ParquetFileReader implements Closeable {
    * @return an open ParquetFileReader
    * @throws IOException if there is an error while opening the file
    */
-  public static ParquetFileReader open(InputFile file, ParquetMetadata footer, ParquetReadOptions options, SeekableInputStream f)
+  public static ParquetFileReader open(
+      InputFile file, ParquetMetadata footer, ParquetReadOptions options, SeekableInputStream f)
       throws IOException {
     return new ParquetFileReader(file, footer, options, f);
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

Co-authored-by: David Zhu <david@alluxio.com>

### Rationale for this change

This PR takes over #3165 as the author is silent for a while.

The proposed API allows the caller to reuse Footer/InputStream to save HDFS NameNode RPCs, https://github.com/apache/spark/pull/50765 demonstrates how this PR benefits Spark.

### What changes are included in this PR?

- Add constructor to `ParquetFileReader` to allow passing in parquet footer
- Add new method `setRequestedSchema(List<ColumnDescriptor>)` to `ParquetFileReader`
- UT is modified to use the newly added API.

### Are these changes tested?

Yes, UT is tuned.

### Are there any user-facing changes?

It exposes new public APIs for `ParquetFileReader`.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Close #3141
Close #3165

