### PR TITLE
GH-3263: Add DictionaryPage.decode to allow dictionary reuse in the ColumnReaderBase ctor

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
@@ -453,7 +453,7 @@ abstract class ColumnReaderBase implements ColumnReader {
     this.writerVersion = writerVersion;
     this.maxDefinitionLevel = path.getMaxDefinitionLevel();
     DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
-    this.dictionary = dictionaryPage == null ? null : dictionaryPage.getDictionary(path);
+    this.dictionary = dictionaryPage == null ? null : dictionaryPage.decode(path);
     if (dictionary != null && converter.hasDictionarySupport()) {
       converter.setDictionary(dictionary);
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
@@ -37,7 +37,6 @@ import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
-import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.RequiresPreviousReader;
 import org.apache.parquet.column.values.ValuesReader;

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
@@ -37,6 +37,7 @@ import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.page.DataPage;
 import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
+import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.values.RequiresPreviousReader;
 import org.apache.parquet.column.values.ValuesReader;
@@ -451,7 +452,8 @@ abstract class ColumnReaderBase implements ColumnReader {
     this.converter = Objects.requireNonNull(converter, "converter cannot be null");
     this.writerVersion = writerVersion;
     this.maxDefinitionLevel = path.getMaxDefinitionLevel();
-    this.dictionary = pageReader.getDictionary(path);
+    DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
+    this.dictionary = dictionaryPage == null ? null : dictionaryPage.getDictionary(path);
     if (dictionary != null && converter.hasDictionarySupport()) {
       converter.setDictionary(dictionary);
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
@@ -445,30 +445,39 @@ abstract class ColumnReaderBase implements ColumnReader {
    * @param converter     a converter that materializes the values in this column in the current record
    * @param writerVersion writer version string from the Parquet file being read
    */
-  ColumnReaderBase(
+  protected ColumnReaderBase(
       ColumnDescriptor path, PageReader pageReader, PrimitiveConverter converter, ParsedVersion writerVersion) {
+    this(path, readDict(path, pageReader), pageReader, converter, writerVersion);
+  }
+
+  protected ColumnReaderBase(
+        ColumnDescriptor path, Dictionary dictionary, PageReader dataPageReader, PrimitiveConverter converter, ParsedVersion writerVersion) {
     this.path = Objects.requireNonNull(path, "path cannot be null");
-    this.pageReader = Objects.requireNonNull(pageReader, "pageReader cannot be null");
+    this.pageReader = Objects.requireNonNull(dataPageReader, "pageReader cannot be null");
     this.converter = Objects.requireNonNull(converter, "converter cannot be null");
     this.writerVersion = writerVersion;
     this.maxDefinitionLevel = path.getMaxDefinitionLevel();
-    DictionaryPage dictionaryPage = pageReader.readDictionaryPage();
-    if (dictionaryPage != null) {
-      try {
-        this.dictionary = dictionaryPage.getEncoding().initDictionary(path, dictionaryPage);
-        if (converter.hasDictionarySupport()) {
-          converter.setDictionary(dictionary);
-        }
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not decode the dictionary for " + path, e);
-      }
-    } else {
-      this.dictionary = null;
+    this.dictionary = dictionary;
+    if (dictionary != null && converter.hasDictionarySupport()) {
+      converter.setDictionary(dictionary);
     }
     this.totalValueCount = pageReader.getTotalValueCount();
     if (totalValueCount <= 0) {
       throw new ParquetDecodingException("totalValueCount '" + totalValueCount + "' <= 0");
     }
+  }
+
+  private static Dictionary readDict(ColumnDescriptor path, PageReader pageReader) {
+    Dictionary dictionary = null;
+    DictionaryPage dictionaryPage = Objects.requireNonNull(pageReader,"Page reader cannot be null").readDictionaryPage();
+    if (dictionaryPage != null) {
+      try {
+        dictionary = dictionaryPage.getEncoding().initDictionary(path, dictionaryPage);
+      } catch (IOException e) {
+        throw new ParquetDecodingException("could not decode the dictionary for " + path, e);
+      }
+    }
+    return dictionary;
   }
 
   boolean isFullyConsumed() {

--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/ColumnReaderBase.java
@@ -452,6 +452,9 @@ abstract class ColumnReaderBase implements ColumnReader {
     this.writerVersion = writerVersion;
     this.maxDefinitionLevel = path.getMaxDefinitionLevel();
     this.dictionary = pageReader.getDictionary(path);
+    if (dictionary != null && converter.hasDictionarySupport()) {
+      converter.setDictionary(dictionary);
+    }
     this.totalValueCount = pageReader.getTotalValueCount();
     if (totalValueCount <= 0) {
       throw new ParquetDecodingException("totalValueCount '" + totalValueCount + "' <= 0");

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/DictionaryPage.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/DictionaryPage.java
@@ -80,7 +80,7 @@ public class DictionaryPage extends Page {
   /**
    * @return the decoded dictionary
    */
-  public Dictionary getDictionary(ColumnDescriptor path) {
+  public Dictionary decode(ColumnDescriptor path) {
     try {
       return getEncoding().initDictionary(path, this);
     } catch (IOException e) {

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/DictionaryPage.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/DictionaryPage.java
@@ -21,7 +21,10 @@ package org.apache.parquet.column.page;
 import java.io.IOException;
 import java.util.Objects;
 import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.io.ParquetDecodingException;
 
 /**
  * Data for a dictionary page
@@ -72,6 +75,17 @@ public class DictionaryPage extends Page {
 
   public DictionaryPage copy() throws IOException {
     return new DictionaryPage(BytesInput.copy(bytes), getUncompressedSize(), dictionarySize, encoding);
+  }
+
+  /**
+   * @return the decoded dictionary
+   */
+  public Dictionary getDictionary(ColumnDescriptor path) {
+    try {
+      return getEncoding().initDictionary(path, this);
+    } catch (IOException e) {
+      throw new ParquetDecodingException("could not decode the dictionary for " + path, e);
+    }
   }
 
   @Override

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
@@ -18,11 +18,6 @@
  */
 package org.apache.parquet.column.page;
 
-import java.io.IOException;
-import org.apache.parquet.column.ColumnDescriptor;
-import org.apache.parquet.column.Dictionary;
-import org.apache.parquet.io.ParquetDecodingException;
-
 /**
  * Reader for a sequence a page from a given column chunk
  */
@@ -32,22 +27,6 @@ public interface PageReader {
    * @return the dictionary page in that chunk or null if none
    */
   DictionaryPage readDictionaryPage();
-
-  /**
-   * @return the dictionary in this page or null if none
-   */
-  default Dictionary getDictionary(ColumnDescriptor path) {
-    Dictionary dictionary = null;
-    DictionaryPage dictionaryPage = readDictionaryPage();
-    if (dictionaryPage != null) {
-      try {
-        dictionary = dictionaryPage.getEncoding().initDictionary(path, dictionaryPage);
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not decode the dictionary for " + path, e);
-      }
-    }
-    return dictionary;
-  }
 
   /**
    * @return the total number of values in the column chunk

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
@@ -18,6 +18,12 @@
  */
 package org.apache.parquet.column.page;
 
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.io.ParquetDecodingException;
+import java.io.IOException;
+import java.util.Objects;
+
 /**
  * Reader for a sequence a page from a given column chunk
  */
@@ -27,6 +33,22 @@ public interface PageReader {
    * @return the dictionary page in that chunk or null if none
    */
   DictionaryPage readDictionaryPage();
+
+  /**
+   * @return the dictionary in this page or null if none
+   */
+  default Dictionary getDictionary(ColumnDescriptor path) {
+    Dictionary dictionary = null;
+    DictionaryPage dictionaryPage = readDictionaryPage();
+    if (dictionaryPage != null) {
+      try {
+        dictionary = dictionaryPage.getEncoding().initDictionary(path, dictionaryPage);
+      } catch (IOException e) {
+        throw new ParquetDecodingException("could not decode the dictionary for " + path, e);
+      }
+    }
+    return dictionary;
+  }
 
   /**
    * @return the total number of values in the column chunk

--- a/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
@@ -18,11 +18,10 @@
  */
 package org.apache.parquet.column.page;
 
+import java.io.IOException;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.io.ParquetDecodingException;
-import java.io.IOException;
-import java.util.Objects;
 
 /**
  * Reader for a sequence a page from a given column chunk


### PR DESCRIPTION
### Rationale for this change
I wrote a driver for reading/writing flat parquet files column by column. ColumnReaderBase is used to read column values. In some use cases, multiple threads read the same ColumnChunk concurrently. In this scenario I want to avoid needless duplication of the immutable Dictionary object which in many cases copies the DictionaryPage into a primitive array store.

In order to accomplish without upstream code changes, I abused Java reflection to set this field in a very roundabout way. See:
https://github.com/Earnix/parquetforge/blob/74073acb4642a9dc9afd114e7151ae4f8288fdcf/parquetforge-base/src/main/java/com/earnix/parquet/columnar/reader/chunk/internal/HackyParquetExtendedColumnReader.java#L15

With a minor visibility change to the base class c-tor, and Dictionary as a c-tor parameter, this can be avoided

### What changes are included in this PR?
ColumnReaderBase c-tor is changed to protected to support this integration. An additional c-tor is added that receives the Dictionary object.

### Are these changes tested?
Yes. Existing tests cover these flows already.

### Are there any user-facing changes?
No.

Closes #3263
