### PR TITLE
GH-3246: Clarify the behaviour of big decimal for BYTE_ARRAY

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/BinaryPlainValuesReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/BinaryPlainValuesReader.java
@@ -27,6 +27,14 @@ import org.apache.parquet.io.api.Binary;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * ValuesReader for variable-length {@code BYTE_ARRAY} columns.
+ *
+ * <p>When the column carries the logical type {@code DECIMAL}, the bytes read
+ * here are the big-endian two's-complement form of the un-scaled integer.
+ * It slices the requested number of bytes without flipping and
+ * returns them as a {@link org.apache.parquet.io.api.Binary}.
+ */
 public class BinaryPlainValuesReader extends ValuesReader {
   private static final Logger LOG = LoggerFactory.getLogger(BinaryPlainValuesReader.class);
   private ByteBufferInputStream in;

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
@@ -32,7 +32,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Plain encoding except for booleans
+ * Plain encoding except for booleans.
+ *
+ * <p>Endianness note for DECIMAL: when a DECIMAL value is stored in a
+ * BYTE_ARRAY column, the {@link org.apache.parquet.io.api.Binary}
+ * passed to this writer already contains the big-endian two's-complement bytes
+ * of the un-scaled integer (the same bytes produced by
+ * {@link java.math.BigInteger#toByteArray()}).  This writer keeps those bytes
+ * exactly as they are and only adds the 4-byte little-endian length prefix
+ * required by the PLAIN encoding.  Bytes are not re-ordered..</p>
  */
 public class PlainValuesWriter extends ValuesWriter {
   private static final Logger LOG = LoggerFactory.getLogger(PlainValuesWriter.class);

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  * of the un-scaled integer (the same bytes produced by
  * {@link java.math.BigInteger#toByteArray()}).  This writer keeps those bytes
  * exactly as they are and only adds the 4-byte little-endian length prefix
- * required by the PLAIN encoding.  Bytes are not re-ordered..</p>
+ * required by the PLAIN encoding.  Bytes are not re-ordered.</p>
  */
 public class PlainValuesWriter extends ValuesWriter {
   private static final Logger LOG = LoggerFactory.getLogger(PlainValuesWriter.class);


### PR DESCRIPTION
 - The behaviour of BYTE_ARRAY or FIXED_LEN_BYTE_ARRAY for big decimals is not clear from the docs.
 - Added code comments at the read/writer to make the behaviour more clear for the reader.
 - Fixes #3246 