### PR TITLE
GH-3142: Add strict validation for unsigned types in ExampleParquetWriter

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/MessageColumnIO.java
@@ -61,11 +61,18 @@ public class MessageColumnIO extends GroupColumnIO {
   private List<PrimitiveColumnIO> leaves;
 
   private final boolean validating;
+  private final boolean strictUnsignedIntegerValidation;
   private final String createdBy;
 
   MessageColumnIO(MessageType messageType, boolean validating, String createdBy) {
+    this(messageType, validating, false, createdBy);
+  }
+
+  MessageColumnIO(
+      MessageType messageType, boolean validating, boolean strictUnsignedIntegerValidation, String createdBy) {
     super(messageType, null, 0);
     this.validating = validating;
+    this.strictUnsignedIntegerValidation = strictUnsignedIntegerValidation;
     this.createdBy = createdBy;
   }
 
@@ -508,7 +515,9 @@ public class MessageColumnIO extends GroupColumnIO {
   public RecordConsumer getRecordWriter(ColumnWriteStore columns) {
     RecordConsumer recordWriter = new MessageColumnIORecordConsumer(columns);
     if (DEBUG) recordWriter = new RecordConsumerLoggingWrapper(recordWriter);
-    return validating ? new ValidatingRecordConsumer(recordWriter, getType()) : recordWriter;
+    return validating
+        ? new ValidatingRecordConsumer(recordWriter, getType(), strictUnsignedIntegerValidation)
+        : recordWriter;
   }
 
   void setLevels() {

--- a/parquet-column/src/main/java/org/apache/parquet/io/ValidatingRecordConsumer.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/ValidatingRecordConsumer.java
@@ -48,6 +48,9 @@ import org.slf4j.LoggerFactory;
 public class ValidatingRecordConsumer extends RecordConsumer {
   private static final Logger LOG = LoggerFactory.getLogger(ValidatingRecordConsumer.class);
 
+  private static final int UINT_8_MAX_VALUE = 255;
+  private static final int UINT_16_MAX_VALUE = 65535;
+
   private final RecordConsumer delegate;
 
   private Deque<Type> types = new ArrayDeque<>();
@@ -265,16 +268,16 @@ public class ValidatingRecordConsumer extends RecordConsumer {
             if (!intType.isSigned()) {
               switch (intType.getBitWidth()) {
                 case 8:
-                  if (value < 0 || value > 255) {
+                  if (value < 0 || value > UINT_8_MAX_VALUE) {
                     throw new InvalidRecordException("Value " + value
-                        + " is out of range for UINT_8 (0-255) in field "
+                        + " is out of range for UINT_8 (0-" + UINT_8_MAX_VALUE + ") in field "
                         + currentType.getName());
                   }
                   break;
                 case 16:
-                  if (value < 0 || value > 65535) {
+                  if (value < 0 || value > UINT_16_MAX_VALUE) {
                     throw new InvalidRecordException("Value " + value
-                        + " is out of range for UINT_16 (0-65535) in field "
+                        + " is out of range for UINT_16 (0-" + UINT_16_MAX_VALUE + ") in field "
                         + currentType.getName());
                   }
                   break;

--- a/parquet-column/src/main/java/org/apache/parquet/io/ValidatingRecordConsumer.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/ValidatingRecordConsumer.java
@@ -52,6 +52,7 @@ public class ValidatingRecordConsumer extends RecordConsumer {
   private static final int UINT_16_MAX_VALUE = 65535;
 
   private final RecordConsumer delegate;
+  private final boolean strictUnsignedIntegerValidation;
 
   private Deque<Type> types = new ArrayDeque<>();
   private Deque<Integer> fields = new ArrayDeque<>();
@@ -63,7 +64,18 @@ public class ValidatingRecordConsumer extends RecordConsumer {
    * @param schema   the schema to validate against
    */
   public ValidatingRecordConsumer(RecordConsumer delegate, MessageType schema) {
+    this(delegate, schema, false);
+  }
+
+  /**
+   * @param delegate the consumer to pass down the event to
+   * @param schema   the schema to validate against
+   * @param strictUnsignedIntegerValidation whether to enable strict unsigned integer validation
+   */
+  public ValidatingRecordConsumer(
+      RecordConsumer delegate, MessageType schema, boolean strictUnsignedIntegerValidation) {
     this.delegate = delegate;
+    this.strictUnsignedIntegerValidation = strictUnsignedIntegerValidation;
     this.types.push(schema);
   }
 
@@ -207,7 +219,9 @@ public class ValidatingRecordConsumer extends RecordConsumer {
   @Override
   public void addInteger(int value) {
     validate(INT32);
-    validateUnsignedInteger(value);
+    if (strictUnsignedIntegerValidation) {
+      validateUnsignedInteger(value);
+    }
     delegate.addInteger(value);
   }
 
@@ -217,7 +231,9 @@ public class ValidatingRecordConsumer extends RecordConsumer {
   @Override
   public void addLong(long value) {
     validate(INT64);
-    validateUnsignedLong(value);
+    if (strictUnsignedIntegerValidation) {
+      validateUnsignedLong(value);
+    }
     delegate.addLong(value);
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -361,6 +361,7 @@ public class ParquetWriter<T> implements Closeable {
         new CodecFactory(conf, encodingProps.getPageSizeThreshold()),
         rowGroupSize,
         validating,
+        false,
         conf,
         maxPaddingSize,
         encodingProps,
@@ -375,6 +376,7 @@ public class ParquetWriter<T> implements Closeable {
       CompressionCodecFactory codecFactory,
       long rowGroupSize,
       boolean validating,
+      boolean strictUnsignedIntegerValidation,
       ParquetConfiguration conf,
       int maxPaddingSize,
       ParquetProperties encodingProps,
@@ -417,7 +419,15 @@ public class ParquetWriter<T> implements Closeable {
     }
 
     this.writer = new InternalParquetRecordWriter<T>(
-        fileWriter, writeSupport, schema, extraMetadata, rowGroupSize, compressor, validating, encodingProps);
+        fileWriter,
+        writeSupport,
+        schema,
+        extraMetadata,
+        rowGroupSize,
+        compressor,
+        validating,
+        strictUnsignedIntegerValidation,
+        encodingProps);
   }
 
   public void write(T object) throws IOException {
@@ -474,6 +484,7 @@ public class ParquetWriter<T> implements Closeable {
     private long rowGroupSize = DEFAULT_BLOCK_SIZE;
     private int maxPaddingSize = MAX_PADDING_SIZE_DEFAULT;
     private boolean enableValidation = DEFAULT_IS_VALIDATING_ENABLED;
+    private boolean strictUnsignedIntegerValidation = false;
     private ParquetProperties.Builder encodingPropsBuilder = ParquetProperties.builder();
 
     protected Builder(Path path) {
@@ -712,6 +723,27 @@ public class ParquetWriter<T> implements Closeable {
      */
     public SELF withValidation(boolean enableValidation) {
       this.enableValidation = enableValidation;
+      return self();
+    }
+
+    /**
+     * Enable strict unsigned integer validation for the constructed writer.
+     *
+     * @return this builder for method chaining.
+     */
+    public SELF enableStrictUnsignedIntegerValidation() {
+      this.strictUnsignedIntegerValidation = true;
+      return self();
+    }
+
+    /**
+     * Enable or disable strict unsigned integer validation for the constructed writer.
+     *
+     * @param strictUnsignedIntegerValidation whether strict unsigned integer validation should be enabled
+     * @return this builder for method chaining.
+     */
+    public SELF withStrictUnsignedIntegerValidation(boolean strictUnsignedIntegerValidation) {
+      this.strictUnsignedIntegerValidation = strictUnsignedIntegerValidation;
       return self();
     }
 
@@ -978,6 +1010,7 @@ public class ParquetWriter<T> implements Closeable {
           codecFactory,
           rowGroupSize,
           enableValidation,
+          strictUnsignedIntegerValidation,
           conf,
           maxPaddingSize,
           encodingProps,

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/TestStrictUnsignedIntegerValidation.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/TestStrictUnsignedIntegerValidation.java
@@ -19,11 +19,10 @@
 package org.apache.parquet.hadoop.example;
 
 import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.junit.Assert.assertThrows;
-import org.apache.parquet.io.api.Binary;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +31,7 @@ import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.io.InvalidRecordException;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
 import org.junit.Rule;
@@ -277,10 +277,8 @@ public class TestStrictUnsignedIntegerValidation {
 
   @Test
   public void testBasicValidation() throws IOException {
-    MessageType schema = Types.buildMessage()
-        .required(INT32)
-        .named("int32_field")
-        .named("test_schema");
+    MessageType schema =
+        Types.buildMessage().required(INT32).named("int32_field").named("test_schema");
 
     File tempFile = new File(tempFolder.getRoot(), "basic_validation.parquet");
     Path outputPath = new Path(tempFile.getAbsolutePath());
@@ -295,10 +293,8 @@ public class TestStrictUnsignedIntegerValidation {
       Group validGroup = groupFactory.newGroup().append("int32_field", 42);
       writer.write(validGroup);
 
-      MessageType stringSchema = Types.buildMessage()
-          .required(BINARY)
-          .named("int32_field")
-          .named("test_schema");
+      MessageType stringSchema =
+          Types.buildMessage().required(BINARY).named("int32_field").named("test_schema");
 
       SimpleGroupFactory stringGroupFactory = new SimpleGroupFactory(stringSchema);
       Group invalidGroup = stringGroupFactory.newGroup().append("int32_field", Binary.fromString("not_an_int"));

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/TestStrictUnsignedIntegerValidation.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/TestStrictUnsignedIntegerValidation.java
@@ -1,0 +1,311 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.hadoop.example;
+
+import static org.apache.parquet.schema.LogicalTypeAnnotation.intType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.junit.Assert.assertThrows;
+import org.apache.parquet.io.api.Binary;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.io.InvalidRecordException;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Types;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * Test for unsigned integer validation in ExampleParquetWriter.
+ */
+public class TestStrictUnsignedIntegerValidation {
+
+  @Rule
+  public TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @Test
+  public void testValidUnsignedIntegerValues() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(8, false))
+        .named("uint8_field")
+        .required(INT32)
+        .as(intType(16, false))
+        .named("uint16_field")
+        .required(INT32)
+        .as(intType(32, false))
+        .named("uint32_field")
+        .required(INT64)
+        .as(intType(64, false))
+        .named("uint64_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "valid_unsigned.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group validGroup = groupFactory
+          .newGroup()
+          .append("uint8_field", 255)
+          .append("uint16_field", 65535)
+          .append("uint32_field", Integer.MAX_VALUE)
+          .append("uint64_field", Long.MAX_VALUE);
+
+      writer.write(validGroup);
+
+      Group zeroGroup = groupFactory
+          .newGroup()
+          .append("uint8_field", 0)
+          .append("uint16_field", 0)
+          .append("uint32_field", 0)
+          .append("uint64_field", 0L);
+
+      writer.write(zeroGroup);
+    }
+  }
+
+  @Test
+  public void testMaximumUnsignedIntegerValues() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(8, false))
+        .named("uint8_field")
+        .required(INT32)
+        .as(intType(16, false))
+        .named("uint16_field")
+        .required(INT32)
+        .as(intType(32, false))
+        .named("uint32_field")
+        .required(INT64)
+        .as(intType(64, false))
+        .named("uint64_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "max_unsigned.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group maxGroup = groupFactory
+          .newGroup()
+          .append("uint8_field", 255)
+          .append("uint16_field", 65535)
+          .append("uint32_field", Integer.MAX_VALUE)
+          .append("uint64_field", Long.MAX_VALUE);
+
+      writer.write(maxGroup);
+    }
+  }
+
+  @Test
+  public void testInvalidUint8Values() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(8, false))
+        .named("uint8_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "invalid_uint8.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group invalidGroup = groupFactory.newGroup().append("uint8_field", -1);
+      assertThrows(InvalidRecordException.class, () -> {
+        writer.write(invalidGroup);
+      });
+    }
+  }
+
+  @Test
+  public void testInvalidUint16Values() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(16, false))
+        .named("uint16_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "invalid_uint16.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group invalidGroup = groupFactory.newGroup().append("uint16_field", -20);
+      assertThrows(InvalidRecordException.class, () -> {
+        writer.write(invalidGroup);
+      });
+    }
+  }
+
+  @Test
+  public void testInvalidUint32Values() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(32, false))
+        .named("uint32_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "invalid_uint32.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group invalidGroup = groupFactory.newGroup().append("uint32_field", -100);
+      assertThrows(InvalidRecordException.class, () -> {
+        writer.write(invalidGroup);
+      });
+    }
+  }
+
+  @Test
+  public void testInvalidUint64Values() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT64)
+        .as(intType(64, false))
+        .named("uint64_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "invalid_uint64.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group invalidGroup = groupFactory.newGroup().append("uint64_field", -1000L);
+      assertThrows(InvalidRecordException.class, () -> {
+        writer.write(invalidGroup);
+      });
+    }
+  }
+
+  @Test
+  public void testValidationDisabledByDefault() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(8, false))
+        .named("uint8_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "validation_disabled.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer =
+        ExampleParquetWriter.builder(outputPath).withType(schema).build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group invalidGroup = groupFactory.newGroup().append("uint8_field", -5);
+      writer.write(invalidGroup);
+    }
+  }
+
+  @Test
+  public void testValidationCanBeExplicitlyDisabled() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(8, false))
+        .named("uint8_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "validation_explicit_disabled.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(false)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group invalidGroup = groupFactory.newGroup().append("uint8_field", -10);
+      writer.write(invalidGroup);
+    }
+  }
+
+  @Test
+  public void testBasicValidation() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .named("int32_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "basic_validation.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      Group validGroup = groupFactory.newGroup().append("int32_field", 42);
+      writer.write(validGroup);
+
+      MessageType stringSchema = Types.buildMessage()
+          .required(BINARY)
+          .named("int32_field")
+          .named("test_schema");
+
+      SimpleGroupFactory stringGroupFactory = new SimpleGroupFactory(stringSchema);
+      Group invalidGroup = stringGroupFactory.newGroup().append("int32_field", Binary.fromString("not_an_int"));
+
+      assertThrows(InvalidRecordException.class, () -> {
+        writer.write(invalidGroup);
+      });
+    }
+  }
+}

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/TestStrictUnsignedIntegerValidation.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/TestStrictUnsignedIntegerValidation.java
@@ -69,6 +69,7 @@ public class TestStrictUnsignedIntegerValidation {
     try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
         .withType(schema)
         .withValidation(true)
+        .withStrictUnsignedIntegerValidation(true)
         .build()) {
 
       SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
@@ -145,6 +146,7 @@ public class TestStrictUnsignedIntegerValidation {
     try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
         .withType(schema)
         .withValidation(true)
+        .withStrictUnsignedIntegerValidation(true)
         .build()) {
 
       SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
@@ -170,6 +172,7 @@ public class TestStrictUnsignedIntegerValidation {
     try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
         .withType(schema)
         .withValidation(true)
+        .withStrictUnsignedIntegerValidation(true)
         .build()) {
 
       SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
@@ -195,6 +198,7 @@ public class TestStrictUnsignedIntegerValidation {
     try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
         .withType(schema)
         .withValidation(true)
+        .withStrictUnsignedIntegerValidation(true)
         .build()) {
 
       SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
@@ -220,6 +224,7 @@ public class TestStrictUnsignedIntegerValidation {
     try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
         .withType(schema)
         .withValidation(true)
+        .withStrictUnsignedIntegerValidation(true)
         .build()) {
 
       SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
@@ -302,6 +307,66 @@ public class TestStrictUnsignedIntegerValidation {
       assertThrows(InvalidRecordException.class, () -> {
         writer.write(invalidGroup);
       });
+    }
+  }
+
+  @Test
+  public void testStrictUnsignedIntegerValidationEnabled() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(8, false))
+        .named("uint8_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "strict_validation_enabled.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .withStrictUnsignedIntegerValidation(true)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      // This should work - valid value
+      Group validGroup = groupFactory.newGroup().append("uint8_field", 255);
+      writer.write(validGroup);
+
+      // This should throw an exception - invalid value
+      Group invalidGroup = groupFactory.newGroup().append("uint8_field", -1);
+      assertThrows(InvalidRecordException.class, () -> {
+        writer.write(invalidGroup);
+      });
+    }
+  }
+
+  @Test
+  public void testStrictUnsignedIntegerValidationDisabled() throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(INT32)
+        .as(intType(8, false))
+        .named("uint8_field")
+        .named("test_schema");
+
+    File tempFile = new File(tempFolder.getRoot(), "strict_validation_disabled.parquet");
+    Path outputPath = new Path(tempFile.getAbsolutePath());
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withValidation(true)
+        .withStrictUnsignedIntegerValidation(false)
+        .build()) {
+
+      SimpleGroupFactory groupFactory = new SimpleGroupFactory(schema);
+
+      // This should work - valid value
+      Group validGroup = groupFactory.newGroup().append("uint8_field", 255);
+      writer.write(validGroup);
+
+      // This should also work - invalid value but strict validation is disabled
+      Group invalidGroup = groupFactory.newGroup().append("uint8_field", -1);
+      writer.write(invalidGroup);
     }
   }
 }


### PR DESCRIPTION
Summary:
 - This PR addresses the issue of ExampleParquetWriter writing invalid values for unsigned integer types.
 - Updated the ExampleParquetWriter.Builder with optional withStrictUnsignedIntegerValidation which can be enabled by caller.
 - Fixes #3142

Testing:
 - Added UTs