### PR TITLE
GH-2961: Cycle detection in AvroSchemaConverter to prevent infinite recursion

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -51,7 +51,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -152,16 +151,14 @@ public class AvroSchemaConverter {
       throw new IllegalArgumentException("Avro schema must be a record.");
     }
     return new MessageType(
-        avroSchema.getFullName(),
-        convertFields(avroSchema.getFields(), "", new HashSet<Schema>()));
+        avroSchema.getFullName(), convertFields(avroSchema.getFields(), "", new HashSet<Schema>()));
   }
 
   private List<Type> convertFields(List<Schema.Field> fields, String schemaPath) {
     return convertFields(fields, schemaPath, new HashSet<Schema>());
   }
 
-  private List<Type> convertFields(
-      List<Schema.Field> fields, String schemaPath, Set<Schema> seenSchemas) {
+  private List<Type> convertFields(List<Schema.Field> fields, String schemaPath, Set<Schema> seenSchemas) {
     List<Type> types = new ArrayList<Type>();
     for (Schema.Field field : fields) {
       if (field.schema().getType().equals(Schema.Type.NULL)) {
@@ -176,8 +173,7 @@ public class AvroSchemaConverter {
     return convertField(fieldName, schema, Type.Repetition.REQUIRED, schemaPath);
   }
 
-  private Type convertField(
-      String fieldName, Schema schema, String schemaPath, Set<Schema> seenSchemas) {
+  private Type convertField(String fieldName, Schema schema, String schemaPath, Set<Schema> seenSchemas) {
     return convertField(fieldName, schema, Type.Repetition.REQUIRED, schemaPath, seenSchemas);
   }
 
@@ -188,11 +184,7 @@ public class AvroSchemaConverter {
 
   @SuppressWarnings("deprecation")
   private Type convertField(
-      String fieldName,
-      Schema schema,
-      Type.Repetition repetition,
-      String schemaPath,
-      Set<Schema> seenSchemas) {
+      String fieldName, Schema schema, Type.Repetition repetition, String schemaPath, Set<Schema> seenSchemas) {
     Schema.Type type = schema.getType();
     LogicalType logicalType = schema.getLogicalType();
 
@@ -287,11 +279,7 @@ public class AvroSchemaConverter {
   }
 
   private Type convertUnion(
-      String fieldName,
-      Schema schema,
-      Type.Repetition repetition,
-      String schemaPath,
-      Set<Schema> seenSchemas) {
+      String fieldName, Schema schema, Type.Repetition repetition, String schemaPath, Set<Schema> seenSchemas) {
     List<Schema> nonNullSchemas = new ArrayList<Schema>(schema.getTypes().size());
     // Found any schemas in the union? Required for the edge case, where the union contains only a single type.
     boolean foundNullSchema = false;
@@ -323,8 +311,7 @@ public class AvroSchemaConverter {
 
   private Type convertUnionToGroupType(
       String fieldName, Type.Repetition repetition, List<Schema> nonNullSchemas, String schemaPath) {
-    return convertUnionToGroupType(
-        fieldName, repetition, nonNullSchemas, schemaPath, new HashSet<Schema>());
+    return convertUnionToGroupType(fieldName, repetition, nonNullSchemas, schemaPath, new HashSet<Schema>());
   }
 
   private Type convertUnionToGroupType(

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroSchemaConverter.java
@@ -152,14 +152,16 @@ public class AvroSchemaConverter {
       throw new IllegalArgumentException("Avro schema must be a record.");
     }
     return new MessageType(
-        avroSchema.getFullName(), convertFields(avroSchema.getFields(), "", new IdentityHashMap<Schema, Void>()));
+        avroSchema.getFullName(),
+        convertFields(avroSchema.getFields(), "", new IdentityHashMap<Schema, Void>()));
   }
 
   private List<Type> convertFields(List<Schema.Field> fields, String schemaPath) {
     return convertFields(fields, schemaPath, new IdentityHashMap<Schema, Void>());
   }
 
-  private List<Type> convertFields(List<Schema.Field> fields, String schemaPath, IdentityHashMap<Schema, Void> seenSchemas) {
+  private List<Type> convertFields(
+      List<Schema.Field> fields, String schemaPath, IdentityHashMap<Schema, Void> seenSchemas) {
     List<Type> types = new ArrayList<Type>();
     for (Schema.Field field : fields) {
       if (field.schema().getType().equals(Schema.Type.NULL)) {
@@ -174,7 +176,8 @@ public class AvroSchemaConverter {
     return convertField(fieldName, schema, Type.Repetition.REQUIRED, schemaPath);
   }
 
-  private Type convertField(String fieldName, Schema schema, String schemaPath, IdentityHashMap<Schema, Void> seenSchemas) {
+  private Type convertField(
+      String fieldName, Schema schema, String schemaPath, IdentityHashMap<Schema, Void> seenSchemas) {
     return convertField(fieldName, schema, Type.Repetition.REQUIRED, schemaPath, seenSchemas);
   }
 
@@ -185,7 +188,11 @@ public class AvroSchemaConverter {
 
   @SuppressWarnings("deprecation")
   private Type convertField(
-      String fieldName, Schema schema, Type.Repetition repetition, String schemaPath, IdentityHashMap<Schema, Void> seenSchemas) {
+      String fieldName,
+      Schema schema,
+      Type.Repetition repetition,
+      String schemaPath,
+      IdentityHashMap<Schema, Void> seenSchemas) {
     Schema.Type type = schema.getType();
     LogicalType logicalType = schema.getLogicalType();
 
@@ -280,7 +287,11 @@ public class AvroSchemaConverter {
   }
 
   private Type convertUnion(
-      String fieldName, Schema schema, Type.Repetition repetition, String schemaPath, IdentityHashMap<Schema, Void> seenSchemas) {
+      String fieldName,
+      Schema schema,
+      Type.Repetition repetition,
+      String schemaPath,
+      IdentityHashMap<Schema, Void> seenSchemas) {
     List<Schema> nonNullSchemas = new ArrayList<Schema>(schema.getTypes().size());
     // Found any schemas in the union? Required for the edge case, where the union contains only a single type.
     boolean foundNullSchema = false;
@@ -312,7 +323,8 @@ public class AvroSchemaConverter {
 
   private Type convertUnionToGroupType(
       String fieldName, Type.Repetition repetition, List<Schema> nonNullSchemas, String schemaPath) {
-    return convertUnionToGroupType(fieldName, repetition, nonNullSchemas, schemaPath, new IdentityHashMap<Schema, Void>());
+    return convertUnionToGroupType(
+        fieldName, repetition, nonNullSchemas, schemaPath, new IdentityHashMap<Schema, Void>());
   }
 
   private Type convertUnionToGroupType(

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -980,7 +980,7 @@ public class TestAvroSchemaConverter {
     Schema recursiveSchema = new Schema.Parser().parse(recursiveSchemaJson);
 
     assertThrows(
-        "Recursive Avro schema should throw UnsupportedOperationException",
+        "Recursive Avro schema should throw UnsupportedOperationException for cycles",
         UnsupportedOperationException.class,
         () -> new AvroSchemaConverter().convert(recursiveSchema));
   }
@@ -1011,7 +1011,7 @@ public class TestAvroSchemaConverter {
     Schema issueSchema = new Schema.Parser().parse(issueSchemaJson);
 
     assertThrows(
-        "Schema should throw UnsupportedOperationException",
+        "Schema hould throw UnsupportedOperationException for cycles",
         UnsupportedOperationException.class,
         () -> new AvroSchemaConverter().convert(issueSchema));
   }
@@ -1025,41 +1025,11 @@ public class TestAvroSchemaConverter {
 
     Schema recursiveSchema = new Schema.Parser().parse(recursiveSchemaJson);
 
-    try {
-      new AvroSchemaConverter().convert(recursiveSchema);
-      Assert.fail("Expected UnsupportedOperationException");
-    } catch (UnsupportedOperationException e) {
-      String message = e.getMessage();
-      Assert.assertTrue(
-          "Error message should mention recursion",
-          message.contains("Recursive Avro schemas are not supported"));
-      Assert.assertTrue("Error message should mention schema name", message.contains("TestRecord"));
-      Assert.assertTrue(
-          "Error message should mention max recursion depth", message.contains("maximum recursion depth"));
-    }
-  }
-
-  @Test
-  public void testConfigurableMaxRecursion() {
-    String recursiveSchemaJson = "{"
-        + "\"type\": \"record\", \"name\": \"Node\", \"fields\": ["
-        + "  {\"name\": \"child\", \"type\": [\"null\", \"Node\"], \"default\": null}"
-        + "]}";
-
-    Schema recursiveSchema = new Schema.Parser().parse(recursiveSchemaJson);
-    Configuration conf = new Configuration();
-
-    AvroSchemaConverter.setMaxRecursion(conf, 1);
+    // With our cycle detection fix, this should throw UnsupportedOperationException
     assertThrows(
-        "Should fail with max recursion 1",
+        "Recursive schema should throw UnsupportedOperationException with clear error message",
         UnsupportedOperationException.class,
-        () -> new AvroSchemaConverter(conf).convert(recursiveSchema));
-
-    AvroSchemaConverter.setMaxRecursion(conf, 5);
-    assertThrows(
-        "Should fail with max recursion 5",
-        UnsupportedOperationException.class,
-        () -> new AvroSchemaConverter(conf).convert(recursiveSchema));
+        () -> new AvroSchemaConverter().convert(recursiveSchema));
   }
 
   @Test


### PR DESCRIPTION
Summary: 
 - Currently recursive objects in avro can cause infinite recursion and stackoverflow error.
 - Added a cycle detection to prevent it and gracefully through error at a certain max depth, can be controlled through: `parquet.avro.max-recursion`
 - Fixes: #2961

Testing:
 - Added UTs