### PR TITLE
MINOR: Bump parquet-format to 2.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
     <hadoop.version>3.3.0</hadoop.version>
-    <parquet.format.version>2.11.0</parquet.format.version>
+    <parquet.format.version>2.12.0</parquet.format.version>
     <previous.version>1.15.1</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>${thrift.executable}</format.thrift.executable>


### PR DESCRIPTION
### Rationale for this change

Bump parquet-format to 2.12.0 to release parquet-java 1.16.0

### What changes are included in this PR?

Bump parquet-format to 2.12.0

### Are these changes tested?

Yes

### Are there any user-facing changes?

No