### PR TITLE
GH-3290: Restore Snapshot versions for vector/benchmark modules

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -39,7 +39,6 @@ import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.schema.MessageType;
 
-// unrelated change
 /**
  * Write records to a Parquet file.
  */

--- a/parquet-plugins/parquet-encoding-vector/pom.xml
+++ b/parquet-plugins/parquet-encoding-vector/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
-    <version>1.16.0</version>
+    <version>1.16.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/parquet-plugins/parquet-plugins-benchmarks/pom.xml
+++ b/parquet-plugins/parquet-plugins-benchmarks/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
-    <version>1.16.0</version>
+    <version>1.16.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
 - 1.16 release process did not revert back the snapshot versions correctly.
 - This caused the main to have inconsistent dependencies/ possible build failures.
 - Since the versions are listed as additional profiles and not in the module list by default, we should probably configure a maven release plugin which can include them through custom rules. Will add support as a followup.
 - Fixes #3290 