### PR TITLE
Add comparator for `UnknownLogicalType` (#3292)

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
@@ -119,6 +119,12 @@ public final class PrimitiveType extends Type {
                   LogicalTypeAnnotation.TimestampLogicalTypeAnnotation timestampLogicalType) {
                 return of(PrimitiveComparator.SIGNED_INT64_COMPARATOR);
               }
+
+              @Override
+              public Optional<PrimitiveComparator> visit(
+                  LogicalTypeAnnotation.UnknownLogicalTypeAnnotation unknownLogicalTypeAnnotation) {
+                return of(PrimitiveComparator.SIGNED_INT64_COMPARATOR);
+              }
             })
             .orElseThrow(() -> new ShouldNeverHappenException(
                 "No comparator logic implemented for INT64 logical type: " + logicalType));
@@ -182,6 +188,12 @@ public final class PrimitiveType extends Type {
                   return of(PrimitiveComparator.SIGNED_INT32_COMPARATOR);
                 }
                 return empty();
+              }
+
+              @Override
+              public Optional<PrimitiveComparator> visit(
+                  LogicalTypeAnnotation.UnknownLogicalTypeAnnotation unknownLogicalTypeAnnotation) {
+                return of(PrimitiveComparator.SIGNED_INT32_COMPARATOR);
               }
             })
             .orElseThrow(() -> new ShouldNeverHappenException(
@@ -281,6 +293,12 @@ public final class PrimitiveType extends Type {
               @Override
               public Optional<PrimitiveComparator> visit(
                   LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+                return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
+              }
+
+              @Override
+              public Optional<PrimitiveComparator> visit(
+                  LogicalTypeAnnotation.UnknownLogicalTypeAnnotation unknownLogicalTypeAnnotation) {
                 return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
               }
             })
@@ -416,6 +434,12 @@ public final class PrimitiveType extends Type {
               public Optional<PrimitiveComparator> visit(
                   LogicalTypeAnnotation.Float16LogicalTypeAnnotation float16LogicalType) {
                 return of(PrimitiveComparator.BINARY_AS_FLOAT16_COMPARATOR);
+              }
+
+              @Override
+              public Optional<PrimitiveComparator> visit(
+                  LogicalTypeAnnotation.UnknownLogicalTypeAnnotation unknownLogicalTypeAnnotation) {
+                return of(PrimitiveComparator.UNSIGNED_LEXICOGRAPHICAL_BINARY_COMPARATOR);
               }
             })
             .orElseThrow(() -> new ShouldNeverHappenException(

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestPrimitiveComparator.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestPrimitiveComparator.java
@@ -101,6 +101,29 @@ public class TestPrimitiveComparator {
   }
 
   @Test
+  public void testUnknownLogicalTypeComparator() {
+    PrimitiveType.PrimitiveTypeName[] types = new PrimitiveType.PrimitiveTypeName[] {
+      PrimitiveType.PrimitiveTypeName.BOOLEAN,
+      PrimitiveType.PrimitiveTypeName.BINARY,
+      PrimitiveType.PrimitiveTypeName.INT32,
+      PrimitiveType.PrimitiveTypeName.INT64,
+      PrimitiveType.PrimitiveTypeName.FLOAT,
+      PrimitiveType.PrimitiveTypeName.DOUBLE,
+      PrimitiveType.PrimitiveTypeName.INT96,
+      PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY
+    };
+
+    for (PrimitiveType.PrimitiveTypeName type : types) {
+      assertEquals(
+          new PrimitiveType(Type.Repetition.REQUIRED, type, "vo")
+              .withLogicalTypeAnnotation(LogicalTypeAnnotation.unknownType())
+              .comparator()
+              .compare(null, null),
+          0);
+    }
+  }
+
+  @Test
   public void testSignedInt64Comparator() {
     testInt64Comparator(
         SIGNED_INT64_COMPARATOR,


### PR DESCRIPTION
This was missing, which caused exceptions. This PR adds them including a test.

It takes the comparator of the underlying physical type, but it should always compare two null values:

https://github.com/apache/parquet-format/blob/471d33a3c9d46e05b8a189437a9364f959f93f09/LogicalTypes.md?plain=1#L887-L892

<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
