### PR TITLE
GH-3294: Include optional profiles for release process

### DIFF
--- a/dev/finalize-release
+++ b/dev/finalize-release
@@ -34,7 +34,7 @@ rc_tag="$release_tag-rc$2"
 new_development_version="$3-SNAPSHOT"
 
 git tag -am "Release Apache Parquet $release_version" "$release_tag" "$rc_tag"
-./mvnw --batch-mode release:update-versions -DdevelopmentVersion="$new_development_version"
+./mvnw --batch-mode -Pvector-plugins release:update-versions -DdevelopmentVersion="$new_development_version"
 ./mvnw -pl . versions:set-property -Dproperty=previous.version -DnewVersion="$release_version"
 git commit -am 'Prepare for next development iteration'
 

--- a/dev/prepare-release.sh
+++ b/dev/prepare-release.sh
@@ -39,6 +39,6 @@ new_development_version="$release_version-SNAPSHOT"
 tag="apache-parquet-$release_version-rc$2"
 
 ./mvnw release:clean
-./mvnw release:prepare -DskipTests -Darguments=-DskipTests -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
+./mvnw release:prepare -Pvector-plugins -DskipTests -Darguments=-DskipTests -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
 
 echo "Finish staging binary artifacts by running: ./mvnw release:perform"


### PR DESCRIPTION
 - Currently the optional profile (vector-plugins) in parquet includes 2 additional modules which are not included in the reactor list by default.
 - This can cause them to be missed during the release/revert process.
 - Including the same in the release process.
 - Fixes: #3294, related to #3288
 