### PR TITLE
GH-3300: add ParquetWriter and ParquetReader builders constructor without params

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetWriter.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.bytes.ByteBufferAllocator;
@@ -476,6 +477,9 @@ public class ParquetWriter<T> implements Closeable {
     private boolean enableValidation = DEFAULT_IS_VALIDATING_ENABLED;
     private ParquetProperties.Builder encodingPropsBuilder = ParquetProperties.builder();
 
+    protected Builder() {}
+
+    @Deprecated
     protected Builder(Path path) {
       this.path = path;
     }
@@ -524,6 +528,20 @@ public class ParquetWriter<T> implements Closeable {
      */
     public SELF withConf(ParquetConfiguration conf) {
       this.conf = conf;
+      return self();
+    }
+
+    /**
+     * Set the {@link OutputFile} to be written by the constructed writer.
+     *
+     * @param file a {@code OutputFile}
+     * @return this builder for method chaining.
+     */
+    public SELF withFile(OutputFile file) {
+      this.file = Objects.requireNonNull(file, "file cannot be null");
+      if (this.path != null) {
+        throw new IllegalStateException("Cannot set both path and file");
+      }
       return self();
     }
 
@@ -960,6 +978,9 @@ public class ParquetWriter<T> implements Closeable {
      * @throws IOException if there is an error while creating the writer
      */
     public ParquetWriter<T> build() throws IOException {
+      if (file == null && path == null) {
+        throw new IllegalStateException("File or Path must be set");
+      }
       if (conf == null) {
         conf = new HadoopParquetConfiguration();
       }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/ExampleParquetWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/example/ExampleParquetWriter.java
@@ -38,6 +38,17 @@ import org.apache.parquet.schema.MessageType;
 public class ExampleParquetWriter extends ParquetWriter<Group> {
 
   /**
+   * Creates a Builder without preconfigured Output File for configuring
+   * ParquetWriter with the example object model.
+   * THIS IS AN EXAMPLE ONLY AND NOT INTENDED FOR USE.
+   *
+   * @return a {@link Builder} to create a {@link ParquetWriter}
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
    * Creates a Builder for configuring ParquetWriter with the example object
    * model. THIS IS AN EXAMPLE ONLY AND NOT INTENDED FOR USE.
    *
@@ -104,6 +115,10 @@ public class ExampleParquetWriter extends ParquetWriter<Group> {
 
     private Builder(OutputFile file) {
       super(file);
+    }
+
+    private Builder() {
+      super();
     }
 
     public Builder withType(MessageType type) {


### PR DESCRIPTION
### Rationale for this change

Support the creation of multiple `ParquetWriter` and `ParquetReader` instances with different files, which part from a single builder.

More explanations in the issue GH-3300

### What changes are included in this PR?

- Create no-argument builder() static methods for the `ParquetWriter` and `ParquetReader` builders
- Make `file` non final to support late configuration
- Add `withFile` methods to configure the Output/InputFile to use after calling build. The code validates that there is no `path` already configured
- Add validations in `build` methods to guarantee the consistency of configured file.

### Are these changes tested?

`TestParquetReader` and `TestParquetWriter` classes are updated to include tests that verify all cases:
- Null configuration
- No configuration of file calling to build method
- Duplicate configuration via `path` and `file` options
- A file can be read or written

### Are there any user-facing changes?

No

Closes #3300
