### PR TITLE
GH-3298: Support unified file based configurations for CLI

### DIFF
--- a/parquet-cli/README.md
+++ b/parquet-cli/README.md
@@ -137,6 +137,7 @@ Usage: parquet [options] [command] [command options]
 ### Configuration Options
 
 - `--conf` or `--property`: Set any configuration property in format `key=value`. Can be specified multiple times.
+- `--config-file`: Path to a properties configuration file containing key=value pairs.
 
 Examples:
 ```bash
@@ -146,5 +147,8 @@ parquet convert input.avro -o output.parquet --conf parquet.avro.write-old-list-
 
 # Multiple options
 parquet convert-csv input.csv -o output.parquet --schema schema.avsc --conf parquet.avro.write-parquet-uuid=true --conf parquet.avro.write-old-list-structure=false
+
+# Using config file
+parquet convert input.avro -o output.parquet --config-file config.properties
 
 ```

--- a/parquet-cli/README.md
+++ b/parquet-cli/README.md
@@ -137,7 +137,7 @@ Usage: parquet [options] [command] [command options]
 ### Configuration Options
 
 - `--conf` or `--property`: Set any configuration property in format `key=value`. Can be specified multiple times.
-- `--config-file`: Path to a properties configuration file containing key=value pairs.
+- `--config-file`: Path to a configuration file (`.properties` or `.xml` format).
 
 Examples:
 ```bash

--- a/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/Main.java
@@ -27,8 +27,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.util.Properties;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configurable;
@@ -188,7 +188,8 @@ public class Main extends Configured implements Tool {
           props.forEach((key, value) -> merged.set(key.toString(), value.toString()));
           console.debug("Loaded configuration from file: {}", configFilePath);
         } catch (Exception e) {
-          throw new IllegalArgumentException("Failed to load config file '" + configFilePath + "': " + e.getMessage(), e);
+          throw new IllegalArgumentException(
+              "Failed to load config file '" + configFilePath + "': " + e.getMessage(), e);
         }
       }
 

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
@@ -18,6 +18,10 @@
  */
 package org.apache.parquet.cli;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ToolRunner;
 import org.junit.Assert;
@@ -30,5 +34,22 @@ public class MainTest {
   public void mainTest() throws Exception {
     ToolRunner.run(new Configuration(), new Main(LoggerFactory.getLogger(MainTest.class)), new String[] {});
     Assert.assertTrue("we simply verify there are no errors here", true);
+  }
+
+  @Test
+  public void testConfigFileLoading() throws Exception {
+    File configFile = File.createTempFile("test-config", ".properties");
+    configFile.deleteOnExit();
+
+    try (FileWriter writer = new FileWriter(configFile)) {
+      writer.write("test.key=test.value\n");
+    }
+
+    try {
+      new Main(LoggerFactory.getLogger(MainTest.class)).run(new String[]{"--config-file", configFile.getAbsolutePath(), "help"});
+      Assert.assertTrue("Config file loading should not throw exception", true);
+    } catch (IllegalArgumentException e) {
+      Assert.fail("Config file loading failed: " + e.getMessage());
+    }
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
@@ -51,4 +51,20 @@ public class MainTest {
       Assert.fail("Config file loading failed: " + e.getMessage());
     }
   }
+
+  @Test
+  public void testLocalPropertiesFile() throws Exception {
+    String configFile = getClass().getResource("/test-config.properties").getPath();
+    ToolRunner.run(new Configuration(), new Main(LoggerFactory.getLogger(MainTest.class)), new String[] {
+      "--config-file", configFile, "version"
+    });
+  }
+
+  @Test
+  public void testLocalXmlFile() throws Exception {
+    String configFile = getClass().getResource("/test-config.xml").getPath();
+    ToolRunner.run(new Configuration(), new Main(LoggerFactory.getLogger(MainTest.class)), new String[] {
+      "--config-file", configFile, "version"
+    });
+  }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
@@ -20,8 +20,6 @@ package org.apache.parquet.cli;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.io.IOException;
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ToolRunner;
 import org.junit.Assert;
@@ -46,7 +44,8 @@ public class MainTest {
     }
 
     try {
-      new Main(LoggerFactory.getLogger(MainTest.class)).run(new String[]{"--config-file", configFile.getAbsolutePath(), "help"});
+      new Main(LoggerFactory.getLogger(MainTest.class))
+          .run(new String[] {"--config-file", configFile.getAbsolutePath(), "help"});
       Assert.assertTrue("Config file loading should not throw exception", true);
     } catch (IllegalArgumentException e) {
       Assert.fail("Config file loading failed: " + e.getMessage());

--- a/parquet-cli/src/test/resources/test-config.properties
+++ b/parquet-cli/src/test/resources/test-config.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+test.key=test.value
+parquet.avro.write-old-list-structure=false
+parquet.compression=SNAPPY
+parquet.block.size=134217728

--- a/parquet-cli/src/test/resources/test-config.xml
+++ b/parquet-cli/src/test/resources/test-config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<configuration>
+  <property>
+    <name>test.key</name>
+    <value>test.value</value>
+  </property>
+
+  <property>
+    <name>parquet.avro.write-old-list-structure</name>
+    <value>false</value>
+  </property>
+
+  <property>
+    <name>parquet.compression</name>
+    <value>SNAPPY</value>
+  </property>
+
+</configuration>


### PR DESCRIPTION
 - Minor patch to allow setting configurations through a single properties file available locally for the CLI
 - User can simply pass a path to config instead of hardcoding the whole config bag.
 - Followup to #3283, closes #3298
 - Supports hadoop style xml and properties files