### PR TITLE
MINOR: Post release of 1.16.0

### DIFF
--- a/dev/finalize-release
+++ b/dev/finalize-release
@@ -34,7 +34,7 @@ rc_tag="$release_tag-rc$2"
 new_development_version="$3-SNAPSHOT"
 
 git tag -am "Release Apache Parquet $release_version" "$release_tag" "$rc_tag"
-./mvnw --batch-mode -Pvector-plugins release:update-versions -DdevelopmentVersion="$new_development_version"
+./mvnw --batch-mode release:update-versions -DdevelopmentVersion="$new_development_version"
 ./mvnw -pl . versions:set-property -Dproperty=previous.version -DnewVersion="$release_version"
 git commit -am 'Prepare for next development iteration'
 

--- a/dev/prepare-release.sh
+++ b/dev/prepare-release.sh
@@ -39,6 +39,6 @@ new_development_version="$release_version-SNAPSHOT"
 tag="apache-parquet-$release_version-rc$2"
 
 ./mvnw release:clean
-./mvnw release:prepare -Pvector-plugins -DskipTests -Darguments=-DskipTests -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
+./mvnw release:prepare -DskipTests -Darguments=-DskipTests -Dtag="$tag" "-DreleaseVersion=$release_version" -DdevelopmentVersion="$new_development_version"
 
 echo "Finish staging binary artifacts by running: ./mvnw release:perform"

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
     <hadoop.version>3.3.0</hadoop.version>
     <parquet.format.version>2.12.0</parquet.format.version>
-    <previous.version>1.15.1</previous.version>
+    <previous.version>1.16.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>${thrift.executable}</format.thrift.executable>
     <pig.version>0.16.0</pig.version>


### PR DESCRIPTION
### Rationale for this change

This is the post release process of 1.16.0.

### What changes are included in this PR?

- Set previous version to 1.16.0 for japicmp
- Remove optional profile from release script

### Are these changes tested?

No

### Are there any user-facing changes?

No
