### PR TITLE
GH-3149: Enable ParquetAvroReader to handle decimal types for int32/64

### DIFF
--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroConverters.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroConverters.java
@@ -345,7 +345,6 @@ public class AvroConverters {
 
   static final class FieldDecimalIntConverter extends AvroPrimitiveConverter {
     private final int scale;
-    private int[] dict = null;
 
     public FieldDecimalIntConverter(ParentValueContainer parent, PrimitiveType type) {
       super(parent);
@@ -358,29 +357,10 @@ public class AvroConverters {
     public void addInt(int value) {
       parent.add(new BigDecimal(BigInteger.valueOf(value), scale));
     }
-
-    @Override
-    public boolean hasDictionarySupport() {
-      return true;
-    }
-
-    @Override
-    public void setDictionary(Dictionary dictionary) {
-      dict = new int[dictionary.getMaxId() + 1];
-      for (int i = 0; i <= dictionary.getMaxId(); i++) {
-        dict[i] = dictionary.decodeToInt(i);
-      }
-    }
-
-    @Override
-    public void addValueFromDictionary(int dictionaryId) {
-      addInt(dict[dictionaryId]);
-    }
   }
 
   static final class FieldDecimalLongConverter extends AvroPrimitiveConverter {
     private final int scale;
-    private long[] dict = null;
 
     public FieldDecimalLongConverter(ParentValueContainer parent, PrimitiveType type) {
       super(parent);
@@ -392,24 +372,6 @@ public class AvroConverters {
     @Override
     public void addLong(long value) {
       parent.add(new BigDecimal(BigInteger.valueOf(value), scale));
-    }
-
-    @Override
-    public boolean hasDictionarySupport() {
-      return true;
-    }
-
-    @Override
-    public void setDictionary(Dictionary dictionary) {
-      dict = new long[dictionary.getMaxId() + 1];
-      for (int i = 0; i <= dictionary.getMaxId(); i++) {
-        dict[i] = dictionary.decodeToLong(i);
-      }
-    }
-
-    @Override
-    public void addValueFromDictionary(int dictionaryId) {
-      addLong(dict[dictionaryId]);
     }
   }
 }

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -337,6 +337,14 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
     return newConverter(schema, type, model, null, setter, validator);
   }
 
+  private static boolean isDecimalType(Type type) {
+    if (!type.isPrimitive()) {
+      return false;
+    }
+    LogicalTypeAnnotation annotation = type.getLogicalTypeAnnotation();
+    return annotation instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
+  }
+
   private static Converter newConverter(
       Schema schema,
       Type type,
@@ -359,6 +367,9 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       case BOOLEAN:
         return new AvroConverters.FieldBooleanConverter(parent);
       case INT:
+        if (isDecimalType(type)) {
+          return new AvroConverters.FieldDecimalIntConverter(parent, type.asPrimitiveType());
+        }
         Class<?> intDatumClass = getDatumClass(conversion, knownClass, schema, model);
         if (intDatumClass == null) {
           return new AvroConverters.FieldIntegerConverter(parent);
@@ -374,6 +385,9 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
         }
         return new AvroConverters.FieldIntegerConverter(parent);
       case LONG:
+        if (isDecimalType(type)) {
+          return new AvroConverters.FieldDecimalLongConverter(parent, type.asPrimitiveType());
+        }
         return new AvroConverters.FieldLongConverter(parent);
       case FLOAT:
         return new AvroConverters.FieldFloatConverter(parent);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
@@ -417,7 +417,8 @@ public class TestReadWrite {
 
     MessageType parquetSchema = new MessageType(
         "test_decimal_int64_values",
-        new PrimitiveType(REQUIRED, INT64, "decimal_salary").withLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(1, 10)));
+        new PrimitiveType(REQUIRED, INT64, "decimal_salary")
+            .withLogicalTypeAnnotation(LogicalTypeAnnotation.decimalType(1, 10)));
 
     try (ParquetWriter<Group> writer =
         ExampleParquetWriter.builder(path).withType(parquetSchema).build()) {
@@ -451,8 +452,7 @@ public class TestReadWrite {
     Object firstSalary = records.get(0).get("decimal_salary");
     Object secondSalary = records.get(1).get("decimal_salary");
 
-    Assert.assertTrue(
-        "Should be BigDecimal, but is " + firstSalary.getClass(), firstSalary instanceof BigDecimal);
+    Assert.assertTrue("Should be BigDecimal, but is " + firstSalary.getClass(), firstSalary instanceof BigDecimal);
     Assert.assertEquals("Should be 23.4, but is " + firstSalary, new BigDecimal("23.4"), firstSalary);
     Assert.assertEquals("Should be 120.3, but is " + secondSalary, new BigDecimal("120.3"), secondSalary);
   }


### PR DESCRIPTION
 - Add support for Decimal on the int 32/64 avro reader. 
 - Currently there exists a bug on the reader where decimal annotation is not respected when reading int32/64 values.
 - This causes decimal component to be missing for unscaled integer.
 - DecimalLogicalTypeAnnotation is now correctly detected and routed to the FieldDecimalConverters that handle the addition/dictionary decoding logic
 - Fixes #3149.