### PR TITLE
GH-3224: Make ParquetProperties.valuesWriterFactory thread safe

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -396,7 +396,7 @@ public class ParquetProperties {
     private int pageValueCountThreshold = DEFAULT_PAGE_VALUE_COUNT_THRESHOLD;
     private boolean estimateNextSizeCheck = DEFAULT_ESTIMATE_ROW_COUNT_FOR_PAGE_SIZE_CHECK;
     private ByteBufferAllocator allocator = new HeapByteBufferAllocator();
-    private ValuesWriterFactory valuesWriterFactory = DEFAULT_VALUES_WRITER_FACTORY;
+    private ValuesWriterFactory valuesWriterFactory = new DefaultValuesWriterFactory();
     private int columnIndexTruncateLength = DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH;
     private int statisticsTruncateLength = DEFAULT_STATISTICS_TRUNCATE_LENGTH;
     private boolean statisticsEnabled = DEFAULT_STATISTICS_ENABLED;

--- a/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/ParquetProperties.java
@@ -69,6 +69,11 @@ public class ParquetProperties {
 
   public static final boolean DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED = true;
 
+  /**
+   * @deprecated This shared instance can cause thread safety issues when used by multiple builders concurrently.
+   * Use {@code new DefaultValuesWriterFactory()} instead to create individual instances.
+   */
+  @Deprecated
   public static final ValuesWriterFactory DEFAULT_VALUES_WRITER_FACTORY = new DefaultValuesWriterFactory();
 
   private static final int MIN_SLAB_SIZE = 64;

--- a/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesThreadSafetyTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesThreadSafetyTest.java
@@ -18,12 +18,11 @@
  */
 package org.apache.parquet.column;
 
-import org.apache.parquet.column.values.factory.ValuesWriterFactory;
-import org.junit.Test;
+import static org.junit.Assert.assertNotSame;
 
 import java.lang.reflect.Field;
-
-import static org.junit.Assert.assertNotSame;
+import org.apache.parquet.column.values.factory.ValuesWriterFactory;
+import org.junit.Test;
 
 public class ParquetPropertiesThreadSafetyTest {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesThreadSafetyTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesThreadSafetyTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column;
+
+import org.apache.parquet.column.values.factory.ValuesWriterFactory;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.assertNotSame;
+
+public class ParquetPropertiesThreadSafetyTest {
+
+  @Test
+  public void testBuilderValuesWriterFactoryNotShared() throws Exception {
+    ParquetProperties.Builder builder1 = ParquetProperties.builder();
+    ParquetProperties.Builder builder2 = ParquetProperties.builder();
+    ParquetProperties.Builder builder3 = ParquetProperties.builder();
+
+    Field factoryField = ParquetProperties.Builder.class.getDeclaredField("valuesWriterFactory");
+    factoryField.setAccessible(true);
+
+    ValuesWriterFactory factory1 = (ValuesWriterFactory) factoryField.get(builder1);
+    ValuesWriterFactory factory2 = (ValuesWriterFactory) factoryField.get(builder2);
+    ValuesWriterFactory factory3 = (ValuesWriterFactory) factoryField.get(builder3);
+
+    assertNotSame("Builder instances should not share ValuesWriterFactory instances", factory1, factory2);
+    assertNotSame("Builder instances should not share ValuesWriterFactory instances", factory2, factory3);
+    assertNotSame("Builder instances should not share ValuesWriterFactory instances", factory1, factory3);
+  }
+}


### PR DESCRIPTION
### Rationale for this change
 - Move away from shared singleton DEFAULT_VALUES_WRITER_FACTORY to new instance per builder to prevent concurrent threads from corrupting each other's delegateFactory state.
 - Currently there is a bug where multiple builders can corrupt each others delegateFactory that can cause files to get written with wrong format.
 - Since valuesWriterFactory.initialize() uses the singleton state which can be altered by another writer thread. 
 - Fixes: #3224
 - Added UT to ensure multiple builders dont share the same ValuesWriterFactory state.

### Are these changes tested?
- Yes

### Are there any user-facing changes?
- Partially

Closes: #3224