### PR TITLE
GH-3321 Exclude package-info.class from shaded fastutil dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,12 @@
                       <exclude>**</exclude>
                     </excludes>
                   </filter>
+                  <filter>
+                    <artifact>it.unimi.dsi:fastutil</artifact>
+                    <excludes>
+                      <exclude>it/unimi/dsi/fastutil/**/package-info.class</exclude>
+                    </excludes>
+                  </filter>
                 </filters>
                 <relocations>
                   <relocation>


### PR DESCRIPTION
### Rationale for this change

I've noticed that some JARs include `package-info.class` files from the shaded `it.unimi.dsi:fastutil` dependency.

These files are located in packages that are otherwise empty and I believe these `package-info.class` files are unnecessary, even in artifacts that make use of other fastutil classes.

### What changes are included in this PR?

Filtering these files out in the maven-shade-plugin configuration to reduce the final JAR size.

### Are these changes tested?

No, apart of existing build process.

### Are there any user-facing changes?

No

Closes #3321
