### PR TITLE
MINOR: Remove unused parquet-thrift dependencies

### DIFF
--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <scope>test</scope>
+      <scope>provided</scope>
     </dependency>
     <!-- Guava is a dependency of hadoop-common, but scoped to compile. We need to
          explicity declare it as a test dependency. -->


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
There are some unnecessary dependencies in parquet-thrift.  Comments for a couple of them suggest that they're still needed for pig integration, but my local builds worked fine without them.

### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?
NO

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
