### PR TITLE
MINOR: parquet-avro tests should not debug to stderr

### DIFF
--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -372,7 +372,6 @@ public class TestAvroSchemaConverter {
     Schema schema = Schema.createRecord("HasArray", null, null, false);
     schema.setFields(
         Lists.newArrayList(new Schema.Field("myarray", Schema.createArray(optional(innerRecord)), null, null)));
-    System.out.println("Avro schema: " + schema.toString(true));
 
     testRoundTripConversion(
         NEW_BEHAVIOR,
@@ -398,7 +397,6 @@ public class TestAvroSchemaConverter {
     Schema schema = Schema.createRecord("HasArray", null, null, false);
     schema.setFields(
         Lists.newArrayList(new Schema.Field("myarray", Schema.createArray(optional(innerRecord)), null, null)));
-    System.out.println("Avro schema: " + schema.toString(true));
 
     // Cannot use round-trip assertion because InnerRecord optional is removed
     testAvroToParquetConversion(
@@ -418,7 +416,6 @@ public class TestAvroSchemaConverter {
     Schema schema = Schema.createRecord("AvroCompatListInList", null, null, false);
     schema.setFields(
         Lists.newArrayList(new Schema.Field("listOfLists", listOfLists, null, JsonProperties.NULL_VALUE)));
-    System.out.println("Avro schema: " + schema.toString(true));
 
     testRoundTripConversion(
         schema,
@@ -462,7 +459,6 @@ public class TestAvroSchemaConverter {
     Schema schema = Schema.createRecord("ThriftCompatListInList", null, null, false);
     schema.setFields(
         Lists.newArrayList(new Schema.Field("listOfLists", listOfLists, null, JsonProperties.NULL_VALUE)));
-    System.out.println("Avro schema: " + schema.toString(true));
 
     // Cannot use round-trip assertion because repeated group names differ
     testParquetToAvroConversion(
@@ -494,7 +490,6 @@ public class TestAvroSchemaConverter {
     Schema schema = Schema.createRecord("UnknownTwoLevelListInList", null, null, false);
     schema.setFields(
         Lists.newArrayList(new Schema.Field("listOfLists", listOfLists, null, JsonProperties.NULL_VALUE)));
-    System.out.println("Avro schema: " + schema.toString(true));
 
     // Cannot use round-trip assertion because repeated group names differ
     testParquetToAvroConversion(


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Logging debug information to stderr creates noise, especially when trying to run tests with maven's quite mode (`-q`).  stderr is sometime appealing because stdout of tests can be suppressed by default.  I was initially going to change these statements to print to stdout but I think they can be removed entirely because any assertion failures would show the schemas. 

### What changes are included in this PR?


### Are these changes tested?
N/A, but tests will still pass

### Are there any user-facing changes?
NO

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
