### PR TITLE
GH-3331: Track Column index page skip statistics during file read

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -1423,7 +1423,8 @@ public class ParquetFileReader implements Closeable {
       if (columnDescriptor != null) {
         OffsetIndex offsetIndex = ciStore.getOffsetIndex(mc.getPath());
 
-        OffsetIndex filteredOffsetIndex = filterOffsetIndex(offsetIndex, rowRanges, block.getRowCount());
+        OffsetIndex filteredOffsetIndex =
+            filterOffsetIndex(offsetIndex, rowRanges, block.getRowCount(), options);
         for (OffsetRange range : calculateOffsetRanges(filteredOffsetIndex, mc, offsetIndex.getOffset(0))) {
           BenchmarkCounter.incrementTotalBytes(range.getLength());
           long startingPos = range.getOffset();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReaderMetrics.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReaderMetrics.java
@@ -27,7 +27,9 @@ public enum ParquetFileReaderMetrics {
   ReadThroughput("read throughput when reading Parquet file from storage (MB/sec)"),
   DecompressTime("time spent in block decompression"),
   DecompressSize("decompressed data size (MB)"),
-  DecompressThroughput("block decompression throughput (MB/sec)");
+  DecompressThroughput("block decompression throughput (MB/sec)"),
+  PagesIncluded("pages included due to column index filtering"),
+  PagesSkipped("pages skipped due to column index filtering");
 
   private final String desc;
 


### PR DESCRIPTION
### Rationale for this change
 - Added support for tracking the pages included and pages skipped due to column indexes.
 - This can provide the reader with information like skip ratio(%), representing how useful the index was for a give file read.
 - Simply increments the pages skipped vs pages included when filtering, and wired up to the existing callback.

### Are these changes tested?
 - Yes, CI

### Are there any user-facing changes?
 - Yes

Closes: #3331 
