### PR TITLE
GH-2836: Support reading pure parquet files with cat

### DIFF
--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
@@ -24,8 +24,15 @@ import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.proto.ProtoParquetWriter;
 import org.apache.parquet.proto.test.TestProtobuf;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -94,6 +101,57 @@ public class CatCommandTest extends ParquetFileTest {
 
     int result = cmd.run();
     Assert.assertEquals(0, result);
+  }
+
+  @Test
+  public void testCatCommandWithHyphenatedFieldNames() throws Exception {
+    File hyphenFile = new File(getTempFolder(), "hyphenated_fields.parquet");
+    writeParquetWithHyphenatedFields(hyphenFile);
+
+    CatCommand cmd = new CatCommand(createLogger(), 1);
+    cmd.sourceFiles = Arrays.asList(hyphenFile.getAbsolutePath());
+    cmd.setConf(new Configuration());
+
+    int result = cmd.run();
+    Assert.assertEquals(0, result);
+  }
+
+  private static void writeParquetWithHyphenatedFields(File file) throws IOException {
+    MessageType schema = Types.buildMessage()
+        .required(PrimitiveTypeName.INT32)
+        .named("order_id")
+        .required(PrimitiveTypeName.BINARY)
+        .named("customer-name")
+        .required(PrimitiveTypeName.BINARY)
+        .named("product-category")
+        .required(PrimitiveTypeName.DOUBLE)
+        .named("sale-amount")
+        .required(PrimitiveTypeName.BINARY)
+        .named("region")
+        .named("SalesRecord");
+
+    SimpleGroupFactory factory = new SimpleGroupFactory(schema);
+
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(new Path(file.getAbsolutePath()))
+        .withType(schema)
+        .build()) {
+
+      Group record1 = factory.newGroup()
+          .append("order_id", 1001)
+          .append("customer-name", "John Smith")
+          .append("product-category", "Electronics")
+          .append("sale-amount", 299.99)
+          .append("region", "North");
+      writer.write(record1);
+
+      Group record2 = factory.newGroup()
+          .append("order_id", 1002)
+          .append("customer-name", "Jane Doe")
+          .append("product-category", "Home-Garden")
+          .append("sale-amount", 149.50)
+          .append("region", "South");
+      writer.write(record2);
+    }
   }
 
   private static void writeProtoParquet(File file) throws Exception {


### PR DESCRIPTION
### Rationale for this change
 - Parquet cat has a bug where it fails for files with hyphens since cat uses avro reader by default which has stricter rules.
 - Ensure we can still read pure parquet files, with parquet group reader as fallback.
 - Existing reader remains unchanged, we just read with parquet group reader if the read fails.
 - Closes: #2836

Before:
```
Time elapsed: 1.170 s <<< ERROR!
org.apache.avro.SchemaParseException: Illegal character in: customer-name
        at org.apache.avro.Schema.validateName(Schema.java:1625)
        at org.apache.avro.Schema.access$400(Schema.java:94)
        at org.apache.avro.Schema$Field.<init>(Schema.java:558)
        at org.apache.avro.SchemaBuilder$FieldBuilder.completeField(SchemaBuilder.java:2258)
        at org.apache.avro.SchemaBuilder$FieldBuilder.completeField(SchemaBuilder.java:2254)
        at org.apache.avro.SchemaBuilder$FieldBuilder.access$5100(SchemaBuilder.java:2150)
        at org.apache.avro.SchemaBuilder$GenericDefault.noDefault(SchemaBuilder.java:2557)
        at org.apache.parquet.avro.AvroSchemaConverter.convertFields(AvroSchemaConverter.java:376)
```

After:
```
order_id: 1001
customer-name: John Smith
product-category: Electronics
sale-amount: 299.99
region: North
```

### Are these changes tested?
- Yes

### Are there any user-facing changes?
 - Yes
