### PR TITLE
GH-3315: Variant binary read does not take length into account

### DIFF
--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
@@ -612,7 +612,9 @@ class VariantUtil {
     int start = value.position() + 1 + U32_SIZE;
     int length = readUnsigned(value, value.position() + 1, U32_SIZE);
     checkIndex(start + length - 1, value.limit());
-    return slice(value, start);
+    ByteBuffer result = slice(value, start);
+    result.limit(start + length);
+    return result;
   }
 
   static String getString(ByteBuffer value) {


### PR DESCRIPTION
### Rationale for this change

Extracting Binary value from Variant, creating the ByteBuffer doesn't consider the length of the Binary element, creating a ByteBuffer with the size of the remaining Variant byte[]

### What changes are included in this PR?

Creating the Binary, configure the limit of ByteBuffer using the calculated length 

### Are these changes tested?

Yes, in a test that creates Variant with multiple Binary elements that have more content after them.

### Are there any user-facing changes?

No

Closes #3315
