### PR TITLE
GH-3317: Fix bytes written by VariantBuilder.appendFloat

### DIFF
--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
@@ -358,7 +358,7 @@ public class VariantBuilder {
     onAppend();
     checkCapacity(1 /* header size */ + 4);
     writeBuffer[writePos] = VariantUtil.HEADER_FLOAT;
-    VariantUtil.writeLong(writeBuffer, writePos + 1, Float.floatToIntBits(f), 8);
+    VariantUtil.writeLong(writeBuffer, writePos + 1, Float.floatToIntBits(f), 4);
     writePos += 5;
   }
 


### PR DESCRIPTION
### Rationale for this change
 - Fixed the bug by correcting the bytes written value to 4 in VariantBuilder.appendFloat()
 - Added test to ensure we only write 5 bytes into the buffer (1 header + 4 float)
 - Should prevent any over-indexing the buffer

### Are these changes tested?
 - Yes

### Are there any user-facing changes?
 - Yes

Closes: #3317