### PR TITLE
GH-3316: Fix representation type for VariantBuilder decimal

### DIFF
--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
@@ -227,14 +227,13 @@ public class VariantBuilder {
   public void appendDecimal(BigDecimal d) {
     onAppend();
     BigInteger unscaled = d.unscaledValue();
-    if (d.scale() <= VariantUtil.MAX_DECIMAL4_PRECISION && d.precision() <= VariantUtil.MAX_DECIMAL4_PRECISION) {
+    if (d.precision() <= VariantUtil.MAX_DECIMAL4_PRECISION) {
       checkCapacity(2 /* header and scale size */ + 4);
       writeBuffer[writePos] = VariantUtil.HEADER_DECIMAL4;
       writeBuffer[writePos + 1] = (byte) d.scale();
       VariantUtil.writeLong(writeBuffer, writePos + 2, unscaled.intValueExact(), 4);
       writePos += 6;
-    } else if (d.scale() <= VariantUtil.MAX_DECIMAL8_PRECISION
-        && d.precision() <= VariantUtil.MAX_DECIMAL8_PRECISION) {
+    } else if (d.precision() <= VariantUtil.MAX_DECIMAL8_PRECISION) {
       checkCapacity(2 /* header and scale size */ + 8);
       writeBuffer[writePos] = VariantUtil.HEADER_DECIMAL8;
       writeBuffer[writePos + 1] = (byte) d.scale();

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalarBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalarBuilder.java
@@ -245,6 +245,42 @@ public class TestVariantScalarBuilder {
   }
 
   @Test
+  public void testDecimalBuilderUsesOnlyPrecision() {
+
+    BigDecimal smallPrecisionLargeScale = new BigDecimal("1").scaleByPowerOfTen(-20);
+    VariantBuilder vb1 = new VariantBuilder();
+    vb1.appendDecimal(smallPrecisionLargeScale);
+    VariantTestUtil.testVariant(vb1.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
+      Assert.assertEquals(smallPrecisionLargeScale, v.getDecimal());
+    });
+
+    BigDecimal mediumPrecisionLargeScale = new BigDecimal("1234567890").scaleByPowerOfTen(-25);
+    VariantBuilder vb2 = new VariantBuilder();
+    vb2.appendDecimal(mediumPrecisionLargeScale);
+    VariantTestUtil.testVariant(vb2.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
+      Assert.assertEquals(mediumPrecisionLargeScale, v.getDecimal());
+    });
+
+    BigDecimal maxDecimal4Precision = new BigDecimal("123456789").scaleByPowerOfTen(-18);
+    VariantBuilder vb3 = new VariantBuilder();
+    vb3.appendDecimal(maxDecimal4Precision);
+    VariantTestUtil.testVariant(vb3.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
+      Assert.assertEquals(maxDecimal4Precision, v.getDecimal());
+    });
+
+    BigDecimal maxDecimal8Precision = new BigDecimal("123456789012345678").scaleByPowerOfTen(-19);
+    VariantBuilder vb4 = new VariantBuilder();
+    vb4.appendDecimal(maxDecimal8Precision);
+    VariantTestUtil.testVariant(vb4.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
+      Assert.assertEquals(maxDecimal8Precision, v.getDecimal());
+    });
+  }
+
+  @Test
   public void testDateBuilder() {
     VariantBuilder vb = new VariantBuilder();
     int days = Math.toIntExact(LocalDate.of(2024, 12, 16).toEpochDay());


### PR DESCRIPTION
### Rationale for this change
 - Since VariantBuilder decimal looks at scale for deciding the representation, it can cause low precision numbers to be stored in wide format.
 - Removed the scale looking just at decimal similar to `SchemaConverter.visit(Decimal)` in Parquet
 - Added tests to prevent future regression, Closes: #3316

### Are these changes tested?
 - Yes

### Are there any user-facing changes?
 - Yes