### PR TITLE
GH-2607: Improve "null decryptor" exception in column chunk metadata

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/metadata/ColumnChunkMetaData.java
@@ -824,7 +824,10 @@ class EncryptedColumnChunkMetaData extends ColumnChunkMetaData {
     if (decrypted) return;
 
     if (null == fileDecryptor) {
-      throw new ParquetCryptoRuntimeException(path + ". Null File Decryptor");
+      throw new ParquetCryptoRuntimeException(
+          "Column '" + path + "' is encrypted but no decryption properties were provided. "
+              + "Please provide FileDecryptionProperties when reading the file using ParquetReader.builder() "
+              + "or ParquetFileReader.open() methods.");
     }
 
     // Decrypt the ColumnMetaData


### PR DESCRIPTION
### Rationale for this change
 - Closes: #2607
 - Users get cryptic "null decryptor" exception when decryption properties are not available/decryptor could not be created.
 - Improve exception and add more actionable error message for reader.

### Are these changes tested?
 - Yes / CI

### Are there any user-facing changes?
 - Yes