### PR TITLE
GH-3342: Throw typed exception for Parquet footer error

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -596,7 +596,8 @@ public class ParquetFileReader implements Closeable {
 
     int FOOTER_LENGTH_SIZE = 4;
     if (fileLen < MAGIC.length + FOOTER_LENGTH_SIZE + MAGIC.length) { // MAGIC + data + footer + footerIndex + MAGIC
-      throw new ParquetDecodingException(filePath + " is not a Parquet file (length is too low: " + fileLen + ")");
+      throw new ParquetDecodingException(
+          filePath + " is not a Parquet file (length is too low: " + fileLen + ")");
     }
 
     // Read footer length and magic string - with a single seek
@@ -618,15 +619,15 @@ public class ParquetFileReader implements Closeable {
     } else if (Arrays.equals(EFMAGIC, magic)) {
       encryptedFooterMode = true;
     } else {
-      throw new ParquetDecodingException(
-        filePath + " is not a Parquet file. Expected magic number at tail, but found " + Arrays.toString(magic));
+      throw new ParquetDecodingException(filePath
+          + " is not a Parquet file. Expected magic number at tail, but found " + Arrays.toString(magic));
     }
 
     long fileMetadataIndex = fileMetadataLengthIndex - fileMetadataLength;
     LOG.debug("read footer length: {}, footer index: {}", fileMetadataLength, fileMetadataIndex);
     if (fileMetadataIndex < magic.length || fileMetadataIndex >= fileMetadataLengthIndex) {
       throw new ParquetDecodingException(
-        "corrupted file: the footer index is not within the file: " + fileMetadataIndex);
+          "corrupted file: the footer index is not within the file: " + fileMetadataIndex);
     }
     f.seek(fileMetadataIndex);
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Currently, `ParquetFileReader` throws `RuntimeException`s when footer parsing fails.

This can be improved by throwing a `ParquetDecodingException` instead, so footer corruption surfaces as a typed exception instead of a plain `RuntimeException`. This helps avoid matching on error message to catch errors occurred during footer parsing.

### What changes are included in this PR?

Throw a `ParquetDecodingException` when Parquet footer parsing fails instead of a `RuntimeException`. The error messages remain the same.

### Are these changes tested?

Existing tests. `ParquetDecodingException` extends `RuntimeException` so existing catch code should continue to work.


### Are there any user-facing changes?
No.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #3342