### PR TITLE
GH-3345: parquet-cli cat/head/scan/to-avro/convert command support int96 type

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
@@ -285,6 +285,7 @@ public abstract class BaseCommand implements Command, Configurable {
 
   @Override
   public void setConf(Configuration conf) {
+    conf.setBoolean(AvroReadSupport.READ_INT96_AS_FIXED, true);
     this.conf = conf;
     HadoopFileSystemURLStreamHandler.setDefaultConf(conf);
   }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/FileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/FileTest.java
@@ -40,6 +40,7 @@ public abstract class FileTest {
   static final String BINARY_FIELD = "binary_field";
   static final String FIXED_LEN_BYTE_ARRAY_FIELD = "flba_field";
   static final String DATE_FIELD = "date_field";
+  static final String INT96_FIELD = "int96_field";
 
   static final String[] COLORS = {"RED", "BLUE", "YELLOW", "GREEN", "WHITE"};
 

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
@@ -75,6 +75,8 @@ public abstract class ParquetFileTest extends FileTest {
         .required(PrimitiveTypeName.INT32)
         .as(LogicalTypeAnnotation.dateType())
         .named(DATE_FIELD)
+        .required(PrimitiveTypeName.INT96)
+        .named(INT96_FIELD)
         .named("schema");
   }
 
@@ -109,7 +111,8 @@ public abstract class ParquetFileTest extends FileTest {
             .append(DOUBLE_FIELD, 2.0d + i)
             .append(BINARY_FIELD, Binary.fromString(COLORS[i % COLORS.length]))
             .append(FIXED_LEN_BYTE_ARRAY_FIELD, Binary.fromConstantByteArray(bytes))
-            .append(DATE_FIELD, i));
+            .append(DATE_FIELD, i)
+            .append(INT96_FIELD, Binary.fromConstantByteArray(bytes)));
       }
     }
   }


### PR DESCRIPTION
parquet-cli cat/head/scan/to-avro/convert command support int96

### Rationale for this change
parquet-cli supports reading data containing int96 types.

### What changes are included in this PR?

### Are these changes tested?
yes.

### Are there any user-facing changes?
user can directly read int96 types, int96 types are parsed as byte array.

Closes #3345
