### PR TITLE
GH-3175: support protobuf library version 4

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -445,10 +445,9 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
 
     private void writeAllFields(MessageOrBuilder pb) {
       Descriptor messageDescriptor = pb.getDescriptorForType();
-      String syntax =
-          messageDescriptor.getFile().toProto().getSyntax();
+      String syntax = messageDescriptor.getFile().toProto().getSyntax();
       if ("editions".equals(syntax)) {
-          throw new UnsupportedOperationException("protocol buffers 'editions' not supported");
+        throw new UnsupportedOperationException("protocol buffers 'editions' not supported");
       }
       boolean isProto2 = !"proto3".equals(syntax);
 


### PR DESCRIPTION


### Rationale for this change

The getSyntax method on messageDescriptor.getFile() got removed in protobuf version 4.
It crashes when a user updates to protobuf 4 and uses the parquet library.

### What changes are included in this PR?

This change gets the syntax information directly from the proto, this works in protobuf v3 and v4.


### Are these changes tested?

yes, running the existing tests (with protobuf 3). 

### Are there any user-facing changes?

Closes #3175 

Related to #3182 

