### PR TITLE
Bump easymock 5.6.0 to support Java 25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
-      <version>5.5.0</version>
+      <version>5.6.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Upgrade easymock to 5.6.0, which transitively upgrades bytebuddy to 1.17.5 to support Java 25

https://github.com/easymock/easymock/releases/tag/easymock-5.6.0
https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.5

To fix the failure

```
[ERROR] org.apache.parquet.thrift.projection.TestStrictFieldProjectionFilter.testWarnWhenMultiplePatternsMatch -- Time elapsed: 0.364 s <<< ERROR!
java.lang.IllegalArgumentException: Could not create type
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:170)
	at net.bytebuddy.TypeCache$WithInlineExpunction.findOrInsert(TypeCache.java:399)
	at org.easymock.internal.ClassProxyFactory.doCreateProxy(ClassProxyFactory.java:171)
	at org.easymock.internal.ClassProxyFactory.createProxy(ClassProxyFactory.java:154)
	at org.easymock.internal.MocksControl.createMock(MocksControl.java:110)
	at org.easymock.internal.MockBuilder.createMock(MockBuilder.java:222)
	at org.easymock.internal.MockBuilder.createMock(MockBuilder.java:227)
	at org.easymock.internal.MockBuilder.createMock(MockBuilder.java:197)
Caused by: java.lang.IllegalArgumentException: org.easymock.mocks.StrictFieldProjectionFilter$$$EasyMock$2 must be defined in the same package as org.easymock.internal.ClassProxyFactory
	at net.bytebuddy.dynamic.loading.ClassInjector$UsingLookup.injectRaw(ClassInjector.java:1682)
	at net.bytebuddy.dynamic.loading.ClassInjector$AbstractBase.injectRaw(ClassInjector.java:166)
	at net.bytebuddy.dynamic.loading.ClassInjector$AbstractBase.inject(ClassInjector.java:154)
	at net.bytebuddy.dynamic.loading.ClassLoadingStrategy$UsingLookup.load(ClassLoadingStrategy.java:519)
	at net.bytebuddy.dynamic.TypeResolutionStrategy$Passive.initialize(TypeResolutionStrategy.java:101)
	at net.bytebuddy.dynamic.DynamicType$Default$Unloaded.load(DynamicType.java:6424)
	at org.easymock.internal.ClassProxyFactory.lambda$doCreateProxy$0(ClassProxyFactory.java:181)
	at net.bytebuddy.TypeCache.findOrInsert(TypeCache.java:168)
```

### What changes are included in this PR?

Bump easymock 5.6.0

### Are these changes tested?

Pass existing UT in GHA to ensure the changes break nothing, and I tested with a patched Hadoop version internally that supports Java 25, all UT passes.

### Are there any user-facing changes?

No.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
