### PR TITLE
Minor: Upgrade spotless plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <jackson-databind.version>2.19.2</jackson-databind.version>
     <japicmp.version>0.23.1</japicmp.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
-    <spotless.version>2.30.0</spotless.version>
+    <spotless.version>2.46.1</spotless.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
     <hadoop.version>3.3.0</hadoop.version>


### PR DESCRIPTION
With java 8 dropped we can upgrade spotless to 2.46.x and close some minor, transitive CVEs

Upgrading to 3.x would require dropping java 11
