### PR TITLE
Minor: `ci-before_install.sh` should show wget errors and retry

### DIFF
--- a/dev/ci-before_install.sh
+++ b/dev/ci-before_install.sh
@@ -31,7 +31,16 @@ sudo apt-get install -qq --no-install-recommends build-essential pv autoconf aut
    libevent-dev automake libtool flex bison pkg-config g++ libssl-dev xmlstarlet
 date
 pwd
-wget -nv -O- https://archive.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz | tar zxf -
+for attempt in 1 2 3; do
+  if wget -nv -O- https://archive.apache.org/dist/thrift/$THRIFT_VERSION/thrift-$THRIFT_VERSION.tar.gz | tar zxf -; then
+    break
+  fi
+  if [[ "$attempt" -eq 3 ]]; then
+    echo "Failed to download thrift after ${attempt} attempts." >&2
+    exit 1
+  fi
+  sleep $((attempt * 5))
+done
 cd thrift-${THRIFT_VERSION}
 chmod +x ./configure
 ./configure --disable-libs


### PR DESCRIPTION
The `wget` fetch of the thrift distribution is failing sometimes (due to rate limiting?) but the exact failure is completely suppressed with the `-q` flag.  Adding `-nv` will show the errors but keep the successes quiet.  Setting pipefail will allow the script to fail fast at this point since the failure is in a pipelined command.

If we see that rate limiting is in fact the problem, we can add retries here.