### PR TITLE
[minor] remove comment from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,14 +400,6 @@
           <header>src/license.txt</header>
           <strictCheck>true</strictCheck>
         </configuration>
-        <!--executions>
-          <execution>
-            <phase>test</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions-->
       </plugin>
 
       <plugin>


### PR DESCRIPTION
git blame says this `<executions>` stanza has been commented out since 2012.  Seems ok to remove.