### PR TITLE
MINOR: Fix error message in SimpleGroup.add() for Binary

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
+++ b/parquet-column/src/main/java/org/apache/parquet/example/data/simple/SimpleGroup.java
@@ -230,7 +230,7 @@ public class SimpleGroup extends Group {
         break;
       default:
         throw new UnsupportedOperationException(
-            getType().asPrimitiveType().getName() + " not supported for Binary");
+            getType().getType(fieldIndex).asPrimitiveType().getName() + " not supported for Binary");
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

`SimpleGroup.add(int fieldIndex, Binary value)` throws an exception if the schema doesn't fit which is expected, but with a wrong error message (`xxxx is not primitive`).

### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
