### PR TITLE
MINOR: `japicmp` checks are failing after Java 11 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -571,6 +571,8 @@
             </excludeModules>
             <excludes>
               <exclude>${shade.prefix}</exclude>
+              <!-- JDK 11 adds interface methods/bridges on PrimitiveIterator.OfInt; ignore japicmp source incompatibility -->
+              <exclude>org.apache.parquet.internal.column.columnindex.IndexIterator</exclude>
               <!-- Removal of a protected method in a class that's not supposed to be subclassed by third-party code -->
               <exclude>org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReader#gatherElementDataFromStreams(byte[])</exclude>
               <!-- Due to the removal of deprecated methods -->


### PR DESCRIPTION
After the Java 11 release, japicmp became uphappy with `IndexIterator` even though that file hasn't changed in years. CI checks and push checks are now failing.  This change excludes the file from japicmp.  An alternative would be to explicitly implement the default behavior for new methods like `next()` but that seems like a worse outcome.

That said, I don't fully understand japicmp so maybe excluding the file is worse.

Error message from failing checks:

```
Error:  Failed to execute goal com.github.siom79.japicmp:japicmp-maven-plugin:0.23.1:cmp (default) on project parquet-column: There is at least one incompatibility:
  org.apache.parquet.internal.column.columnindex.IndexIterator:METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE -> [Help 1]
```

I used codex to understand and fix this problem.  I asked it for an explanation suitable for a PR description and it gave me this:

>   The japicmp check started failing after the Java 11 baseline because PrimitiveIterator.OfInt exposes additional interface methods/bridges in the Java 11 API surface. IndexIterator still
  works at runtime (defaults cover those methods), but japicmp flags it as a source‑incompatible change since the class implements that interface and doesn’t declare those methods itself.
  This is a tooling false positive driven by the JDK upgrade, not an actual behavior regression.

> This change excludes org.apache.parquet.internal.column.columnindex.IndexIterator from japicmp to keep the compatibility check focused on real API changes. The exclusion aligns with prior
  japicmp exceptions for JDK‑related interface‑method noise and unblocks the build without changing runtime behavior.