### PR TITLE
Implement per column compression

### DIFF
--- a/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesCompressionTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesCompressionTest.java
@@ -38,7 +38,7 @@ public class ParquetPropertiesCompressionTest {
   }
 
   @Test
-public void testSetDefaultCompressionCodec() {
+  public void testSetDefaultCompressionCodec() {
     ParquetProperties props = ParquetProperties.builder()
         .withCompressionCodec(CompressionCodecName.SNAPPY)
         .build();

--- a/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesCompressionTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesCompressionTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.column;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.junit.Test;
+
+public class ParquetPropertiesCompressionTest {
+
+  private static ColumnDescriptor col(String name) {
+    return new ColumnDescriptor(new String[] {name}, PrimitiveTypeName.BINARY, 0, 0);
+  }
+
+  @Test
+  public void testDefaultCompressionCodecIsUncompressed() {
+    ParquetProperties props = ParquetProperties.builder().build();
+    assertEquals(CompressionCodecName.UNCOMPRESSED, props.getCompressionCodec(col("any_column")));
+    assertEquals(CompressionCodecName.UNCOMPRESSED, props.getDefaultCompressionCodec());
+  }
+
+  @Test
+public void testSetDefaultCompressionCodec() {
+    ParquetProperties props = ParquetProperties.builder()
+        .withCompressionCodec(CompressionCodecName.SNAPPY)
+        .build();
+    assertEquals(CompressionCodecName.SNAPPY, props.getCompressionCodec(col("any_column")));
+    assertEquals(CompressionCodecName.SNAPPY, props.getDefaultCompressionCodec());
+  }
+
+  @Test
+  public void testPerColumnCompressionCodec() {
+    ParquetProperties props = ParquetProperties.builder()
+        .withCompressionCodec(CompressionCodecName.SNAPPY)
+        .withCompressionCodec("col_a", CompressionCodecName.GZIP)
+        .withCompressionCodec("col_b", CompressionCodecName.UNCOMPRESSED)
+        .build();
+
+    // Per-column overrides
+    assertEquals(CompressionCodecName.GZIP, props.getCompressionCodec(col("col_a")));
+    assertEquals(CompressionCodecName.UNCOMPRESSED, props.getCompressionCodec(col("col_b")));
+    // Default for non-overridden columns
+    assertEquals(CompressionCodecName.SNAPPY, props.getCompressionCodec(col("col_c")));
+    assertEquals(CompressionCodecName.SNAPPY, props.getDefaultCompressionCodec());
+  }
+
+  @Test
+  public void testCopyPreservesCompressionCodec() {
+    ParquetProperties original = ParquetProperties.builder()
+        .withCompressionCodec(CompressionCodecName.GZIP)
+        .withCompressionCodec("col_a", CompressionCodecName.SNAPPY)
+        .build();
+
+    ParquetProperties copy = ParquetProperties.copy(original).build();
+
+    assertEquals(CompressionCodecName.GZIP, copy.getCompressionCodec(col("other")));
+    assertEquals(CompressionCodecName.SNAPPY, copy.getCompressionCodec(col("col_a")));
+  }
+
+  @Test
+  public void testCopyCanOverrideDefault() {
+    ParquetProperties original = ParquetProperties.builder()
+        .withCompressionCodec(CompressionCodecName.GZIP)
+        .withCompressionCodec("col_a", CompressionCodecName.SNAPPY)
+        .build();
+
+    ParquetProperties modified = ParquetProperties.copy(original)
+        .withCompressionCodec(CompressionCodecName.ZSTD)
+        .build();
+
+    // Default overridden
+    assertEquals(CompressionCodecName.ZSTD, modified.getCompressionCodec(col("other")));
+    // Per-column override preserved
+    assertEquals(CompressionCodecName.SNAPPY, modified.getCompressionCodec(col("col_a")));
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullDefaultCompressionCodecThrows() {
+    ParquetProperties.builder().withCompressionCodec((CompressionCodecName) null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testNullPerColumnCompressionCodecThrows() {
+    ParquetProperties.builder().withCompressionCodec("col_a", null);
+  }
+}

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -44,6 +44,7 @@ import org.apache.parquet.column.statistics.geospatial.GeospatialStatistics;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
 import org.apache.parquet.column.values.bloomfilter.BloomFilterWriteStore;
 import org.apache.parquet.column.values.bloomfilter.BloomFilterWriter;
+import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.crypto.AesCipher;
 import org.apache.parquet.crypto.InternalColumnEncryptionSetup;
@@ -649,6 +650,83 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       BlockCipher.Encryptor headerBlockEncryptor = null;
       BlockCipher.Encryptor pageBlockEncryptor = null;
       ColumnPath columnPath = ColumnPath.get(path.getPath());
+
+      InternalColumnEncryptionSetup columnSetup = fileEncryptor.getColumnSetup(columnPath, true, columnOrdinal);
+      if (columnSetup.isEncrypted()) {
+        headerBlockEncryptor = columnSetup.getMetaDataEncryptor();
+        pageBlockEncryptor = columnSetup.getDataEncryptor();
+      }
+
+      writers.put(
+          path,
+          new ColumnChunkPageWriter(
+              path,
+              compressor,
+              allocator,
+              columnIndexTruncateLength,
+              pageWriteChecksumEnabled,
+              headerBlockEncryptor,
+              pageBlockEncryptor,
+              fileAAD,
+              rowGroupOrdinal,
+              columnOrdinal));
+    }
+  }
+
+  /**
+   * Construct a page write store with per-column compression support.
+   * Each column's compression codec is resolved from {@code props} via
+   * {@link ParquetProperties#getCompressionCodec(ColumnDescriptor)}.
+   *
+   * @param codecFactory           factory to create compressors for each codec
+   * @param props                  properties containing per-column compression configuration
+   * @param schema                 the message schema
+   * @param allocator              byte buffer allocator
+   * @param columnIndexTruncateLength truncate length for column indexes
+   * @param pageWriteChecksumEnabled  whether to write page checksums
+   * @param fileEncryptor          file encryptor (null if not encrypted)
+   * @param rowGroupOrdinal        row group ordinal
+   */
+  public ColumnChunkPageWriteStore(
+      CompressionCodecFactory codecFactory,
+      ParquetProperties props,
+      MessageType schema,
+      ByteBufferAllocator allocator,
+      int columnIndexTruncateLength,
+      boolean pageWriteChecksumEnabled,
+      InternalFileEncryptor fileEncryptor,
+      int rowGroupOrdinal) {
+    this.schema = schema;
+    if (null == fileEncryptor) {
+      for (ColumnDescriptor path : schema.getColumns()) {
+        BytesInputCompressor compressor = codecFactory.getCompressor(props.getCompressionCodec(path));
+        writers.put(
+            path,
+            new ColumnChunkPageWriter(
+                path,
+                compressor,
+                allocator,
+                columnIndexTruncateLength,
+                pageWriteChecksumEnabled,
+                null,
+                null,
+                null,
+                -1,
+                -1));
+      }
+      return;
+    }
+
+    // Encrypted file
+    int columnOrdinal = -1;
+    byte[] fileAAD = fileEncryptor.getFileAAD();
+    for (ColumnDescriptor path : schema.getColumns()) {
+      columnOrdinal++;
+      BlockCipher.Encryptor headerBlockEncryptor = null;
+      BlockCipher.Encryptor pageBlockEncryptor = null;
+      ColumnPath columnPath = ColumnPath.get(path.getPath());
+
+      BytesInputCompressor compressor = codecFactory.getCompressor(props.getCompressionCodec(path));
 
       InternalColumnEncryptionSetup columnSetup = fileEncryptor.getColumnSetup(columnPath, true, columnOrdinal);
       if (columnSetup.isEncrypted()) {

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -608,8 +608,14 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       boolean pageWriteChecksumEnabled,
       InternalFileEncryptor fileEncryptor,
       int rowGroupOrdinal) {
-    this(path -> compressor, schema, allocator, columnIndexTruncateLength,
-        pageWriteChecksumEnabled, fileEncryptor, rowGroupOrdinal);
+    this(
+        path -> compressor,
+        schema,
+        allocator,
+        columnIndexTruncateLength,
+        pageWriteChecksumEnabled,
+        fileEncryptor,
+        rowGroupOrdinal);
   }
 
   public ColumnChunkPageWriteStore(
@@ -621,9 +627,14 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       boolean pageWriteChecksumEnabled,
       InternalFileEncryptor fileEncryptor,
       int rowGroupOrdinal) {
-    this(path -> codecFactory.getCompressor(props.getCompressionCodec(path)),
-        schema, allocator, columnIndexTruncateLength,
-        pageWriteChecksumEnabled, fileEncryptor, rowGroupOrdinal);
+    this(
+        path -> codecFactory.getCompressor(props.getCompressionCodec(path)),
+        schema,
+        allocator,
+        columnIndexTruncateLength,
+        pageWriteChecksumEnabled,
+        fileEncryptor,
+        rowGroupOrdinal);
   }
 
   private ColumnChunkPageWriteStore(

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -618,25 +618,6 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
         rowGroupOrdinal);
   }
 
-  public ColumnChunkPageWriteStore(
-      CompressionCodecFactory codecFactory,
-      ParquetProperties props,
-      MessageType schema,
-      ByteBufferAllocator allocator,
-      int columnIndexTruncateLength,
-      boolean pageWriteChecksumEnabled,
-      InternalFileEncryptor fileEncryptor,
-      int rowGroupOrdinal) {
-    this(
-        path -> codecFactory.getCompressor(props.getCompressionCodec(path)),
-        schema,
-        allocator,
-        columnIndexTruncateLength,
-        pageWriteChecksumEnabled,
-        fileEncryptor,
-        rowGroupOrdinal);
-  }
-
   private ColumnChunkPageWriteStore(
       Function<ColumnDescriptor, BytesInputCompressor> compressorProvider,
       MessageType schema,
@@ -693,6 +674,88 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
               fileAAD,
               rowGroupOrdinal,
               columnOrdinal));
+    }
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for {@link ColumnChunkPageWriteStore}. Prefer this over the constructors when new
+   * parameters are needed so that callers do not have to be updated every time a parameter is
+   * added.
+   */
+  public static class Builder {
+    private Function<ColumnDescriptor, BytesInputCompressor> compressorProvider;
+    private MessageType schema;
+    private ByteBufferAllocator allocator;
+    private int columnIndexTruncateLength = ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH;
+    private boolean pageWriteChecksumEnabled = ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED;
+    private InternalFileEncryptor fileEncryptor = null;
+    private int rowGroupOrdinal = 0;
+
+    private Builder() {}
+
+    /**
+     * Use a single compressor for every column.
+     */
+    public Builder withCompressor(BytesInputCompressor compressor) {
+      this.compressorProvider = path -> compressor;
+      return this;
+    }
+
+    /**
+     * Resolve the compressor per column from the given codec factory and properties, allowing
+     * per-column compression codecs.
+     */
+    public Builder withCodecFactory(CompressionCodecFactory codecFactory, ParquetProperties props) {
+      this.compressorProvider = path -> codecFactory.getCompressor(props.getCompressionCodec(path));
+      return this;
+    }
+
+    public Builder withSchema(MessageType schema) {
+      this.schema = schema;
+      return this;
+    }
+
+    public Builder withAllocator(ByteBufferAllocator allocator) {
+      this.allocator = allocator;
+      return this;
+    }
+
+    public Builder withColumnIndexTruncateLength(int columnIndexTruncateLength) {
+      this.columnIndexTruncateLength = columnIndexTruncateLength;
+      return this;
+    }
+
+    public Builder withPageWriteChecksumEnabled(boolean pageWriteChecksumEnabled) {
+      this.pageWriteChecksumEnabled = pageWriteChecksumEnabled;
+      return this;
+    }
+
+    public Builder withFileEncryptor(InternalFileEncryptor fileEncryptor) {
+      this.fileEncryptor = fileEncryptor;
+      return this;
+    }
+
+    public Builder withRowGroupOrdinal(int rowGroupOrdinal) {
+      this.rowGroupOrdinal = rowGroupOrdinal;
+      return this;
+    }
+
+    public ColumnChunkPageWriteStore build() {
+      if (compressorProvider == null) {
+        throw new IllegalStateException("A compressor or codec factory must be set");
+      }
+      return new ColumnChunkPageWriteStore(
+          compressorProvider,
+          schema,
+          allocator,
+          columnIndexTruncateLength,
+          pageWriteChecksumEnabled,
+          fileEncryptor,
+          rowGroupOrdinal);
     }
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -147,27 +147,19 @@ class InternalParquetRecordWriter<T> {
   }
 
   private void initStore() {
-    ColumnChunkPageWriteStore columnChunkPageWriteStore;
+    ColumnChunkPageWriteStore.Builder storeBuilder = ColumnChunkPageWriteStore.builder()
+        .withSchema(schema)
+        .withAllocator(props.getAllocator())
+        .withColumnIndexTruncateLength(props.getColumnIndexTruncateLength())
+        .withPageWriteChecksumEnabled(props.getPageWriteChecksumEnabled())
+        .withFileEncryptor(fileEncryptor)
+        .withRowGroupOrdinal(rowGroupOrdinal);
     if (codecFactory != null) {
-      columnChunkPageWriteStore = new ColumnChunkPageWriteStore(
-          codecFactory,
-          props,
-          schema,
-          props.getAllocator(),
-          props.getColumnIndexTruncateLength(),
-          props.getPageWriteChecksumEnabled(),
-          fileEncryptor,
-          rowGroupOrdinal);
+      storeBuilder.withCodecFactory(codecFactory, props);
     } else {
-      columnChunkPageWriteStore = new ColumnChunkPageWriteStore(
-          compressor,
-          schema,
-          props.getAllocator(),
-          props.getColumnIndexTruncateLength(),
-          props.getPageWriteChecksumEnabled(),
-          fileEncryptor,
-          rowGroupOrdinal);
+      storeBuilder.withCompressor(compressor);
     }
+    ColumnChunkPageWriteStore columnChunkPageWriteStore = storeBuilder.build();
     pageStore = columnChunkPageWriteStore;
     bloomFilterWriteStore = columnChunkPageWriteStore;
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -526,7 +526,8 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         .withRowGroupRowCountLimit(getBlockRowCountLimit(conf))
         .withPageRowCountLimit(getPageRowCountLimit(conf))
         .withPageWriteChecksumEnabled(getPageWriteChecksumEnabled(conf))
-        .withStatisticsEnabled(getStatisticsEnabled(conf));
+        .withStatisticsEnabled(getStatisticsEnabled(conf))
+        .withCompressionCodec(codec);
     new ColumnConfigParser()
         .withColumnConfig(
             ENABLE_DICTIONARY, key -> conf.getBoolean(key, false), propsBuilder::withDictionaryEncoding)
@@ -598,7 +599,6 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
         fileWriteContext.getSchema(),
         fileWriteContext.getExtraMetaData(),
         blockSize,
-        codec,
         validating,
         props,
         memoryManager,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetOutputFormat.java
@@ -546,6 +546,10 @@ public class ParquetOutputFormat<T> extends FileOutputFormat<Void, T> {
             STATISTICS_ENABLED,
             key -> conf.getBoolean(key, ParquetProperties.DEFAULT_STATISTICS_ENABLED),
             propsBuilder::withStatisticsEnabled)
+        .withColumnConfig(
+            COMPRESSION,
+            key -> CompressionCodecName.fromConf(conf.get(key)),
+            propsBuilder::withCompressionCodec)
         .parseConfig(conf);
 
     ParquetProperties props = propsBuilder.build();

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordWriter.java
@@ -201,15 +201,11 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
       MemoryManager memoryManager,
       Configuration conf) {
     this.codecFactory = new CodecFactory(conf, props.getPageSizeThreshold());
+    // Ensure the default compression codec from ParquetOutputFormat is set in props
+    ParquetProperties propsWithCodec =
+        ParquetProperties.copy(props).withCompressionCodec(codec).build();
     internalWriter = new InternalParquetRecordWriter<T>(
-        w,
-        writeSupport,
-        schema,
-        extraMetaData,
-        blockSize,
-        codecFactory.getCompressor(codec),
-        validating,
-        props);
+        w, writeSupport, schema, extraMetaData, blockSize, codecFactory, validating, propsWithCodec);
     this.memoryManager = Objects.requireNonNull(memoryManager, "memoryManager cannot be null");
     memoryManager.addWriter(internalWriter, blockSize);
   }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetRecordWriter.java
@@ -188,7 +188,10 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
    * @param codec         the compression codec used to compress the pages
    * @param validating    if schema validation should be turned on
    * @param props         parquet encoding properties
+   * @deprecated Use {@link #ParquetRecordWriter(ParquetFileWriter, WriteSupport, MessageType, Map, long, boolean, ParquetProperties, MemoryManager, Configuration)}
+   *             and set the compression codec in {@link ParquetProperties} instead
    */
+  @Deprecated
   ParquetRecordWriter(
       ParquetFileWriter w,
       WriteSupport<T> writeSupport,
@@ -200,12 +203,42 @@ public class ParquetRecordWriter<T> extends RecordWriter<Void, T> {
       ParquetProperties props,
       MemoryManager memoryManager,
       Configuration conf) {
+    this(
+        w,
+        writeSupport,
+        schema,
+        extraMetaData,
+        blockSize,
+        validating,
+        ParquetProperties.copy(props).withCompressionCodec(codec).build(),
+        memoryManager,
+        conf);
+  }
+
+  /**
+   * @param w             the file to write to
+   * @param writeSupport  the class to convert incoming records
+   * @param schema        the schema of the records
+   * @param extraMetaData extra meta data to write in the footer of the file
+   * @param blockSize     the size of a block in the file (this will be approximate)
+   * @param validating    if schema validation should be turned on
+   * @param props         parquet encoding properties (including compression codec configuration)
+   * @param memoryManager memory manager for the write
+   * @param conf          hadoop configuration
+   */
+  public ParquetRecordWriter(
+      ParquetFileWriter w,
+      WriteSupport<T> writeSupport,
+      MessageType schema,
+      Map<String, String> extraMetaData,
+      long blockSize,
+      boolean validating,
+      ParquetProperties props,
+      MemoryManager memoryManager,
+      Configuration conf) {
     this.codecFactory = new CodecFactory(conf, props.getPageSizeThreshold());
-    // Ensure the default compression codec from ParquetOutputFormat is set in props
-    ParquetProperties propsWithCodec =
-        ParquetProperties.copy(props).withCompressionCodec(codec).build();
     internalWriter = new InternalParquetRecordWriter<T>(
-        w, writeSupport, schema, extraMetaData, blockSize, codecFactory, validating, propsWithCodec);
+        w, writeSupport, schema, extraMetaData, blockSize, codecFactory, validating, props);
     this.memoryManager = Objects.requireNonNull(memoryManager, "memoryManager cannot be null");
     memoryManager.addWriter(internalWriter, blockSize);
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -62,7 +62,6 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.page.PageWriter;
 import org.apache.parquet.column.statistics.BinaryStatistics;
 import org.apache.parquet.column.statistics.Statistics;
-import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.hadoop.ParquetFileWriter.Mode;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -342,9 +341,13 @@ public class TestColumnChunkPageWriteStore {
 
     OutputFileForTesting outputFile = new OutputFileForTesting(file, conf);
     ParquetFileWriter writer = new ParquetFileWriter(
-        outputFile, schema, ParquetFileWriter.Mode.CREATE,
-        ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.MAX_PADDING_SIZE_DEFAULT,
-        null, ParquetProperties.builder().withAllocator(allocator).build());
+        outputFile,
+        schema,
+        ParquetFileWriter.Mode.CREATE,
+        ParquetWriter.DEFAULT_BLOCK_SIZE,
+        ParquetWriter.MAX_PADDING_SIZE_DEFAULT,
+        null,
+        ParquetProperties.builder().withAllocator(allocator).build());
     writer.start();
     writer.startBlock(1);
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -22,6 +22,7 @@ import static org.apache.parquet.column.Encoding.PLAIN;
 import static org.apache.parquet.column.Encoding.RLE;
 import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FILTER;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
+import static org.apache.parquet.hadoop.metadata.CompressionCodecName.SNAPPY;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
 import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
@@ -61,6 +62,7 @@ import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.column.page.PageWriter;
 import org.apache.parquet.column.statistics.BinaryStatistics;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.hadoop.ParquetFileWriter.Mode;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -313,6 +315,66 @@ public class TestColumnChunkPageWriteStore {
               any(),
               any(),
               any());
+    }
+  }
+
+  @Test
+  public void testPerColumnCompression() throws Exception {
+    Path file = new Path("target/test/TestColumnChunkPageWriteStore/testPerColumnCompression.parquet");
+    Path root = file.getParent();
+    FileSystem fs = file.getFileSystem(conf);
+    if (fs.exists(root)) {
+      fs.delete(root, true);
+    }
+    fs.mkdirs(root);
+
+    MessageType schema = MessageTypeParser.parseMessageType(
+        "message test { required binary col_a; required binary col_b; required binary col_c; }");
+
+    ParquetProperties props = ParquetProperties.builder()
+        .withCompressionCodec(CompressionCodecName.GZIP)
+        .withCompressionCodec("col_a", CompressionCodecName.SNAPPY)
+        .withCompressionCodec("col_c", CompressionCodecName.UNCOMPRESSED)
+        .build();
+
+    CodecFactory codecFactory = new CodecFactory(conf, pageSize);
+    allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
+
+    OutputFileForTesting outputFile = new OutputFileForTesting(file, conf);
+    ParquetFileWriter writer = new ParquetFileWriter(
+        outputFile, schema, ParquetFileWriter.Mode.CREATE,
+        ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.MAX_PADDING_SIZE_DEFAULT,
+        null, ParquetProperties.builder().withAllocator(allocator).build());
+    writer.start();
+    writer.startBlock(1);
+
+    try (ColumnChunkPageWriteStore store = new ColumnChunkPageWriteStore(
+        codecFactory, props, schema, allocator, Integer.MAX_VALUE, false, null, 0)) {
+      BytesInput fakeData = BytesInput.fromInt(42);
+      BinaryStatistics fakeStats = new BinaryStatistics();
+      for (ColumnDescriptor col : schema.getColumns()) {
+        PageWriter pageWriter = store.getPageWriter(col);
+        pageWriter.writePage(fakeData, 1, 1, fakeStats, RLE, RLE, PLAIN);
+      }
+      store.flushToFileWriter(writer);
+    }
+    writer.endBlock();
+    writer.end(new HashMap<>());
+
+    // Read back and verify per-column codecs in metadata
+    ParquetMetadata footer = ParquetFileReader.readFooter(conf, file, NO_FILTER);
+    for (ColumnChunkMetaData column : footer.getBlocks().get(0).getColumns()) {
+      switch (column.getPath().toDotString()) {
+        case "col_a":
+          assertEquals(SNAPPY, column.getCodec());
+          break;
+        case "col_b":
+          assertEquals(GZIP, column.getCodec());
+          break;
+        case "col_c":
+          assertEquals(UNCOMPRESSED, column.getCodec());
+          break;
+      }
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -351,8 +351,13 @@ public class TestColumnChunkPageWriteStore {
     writer.start();
     writer.startBlock(1);
 
-    try (ColumnChunkPageWriteStore store = new ColumnChunkPageWriteStore(
-        codecFactory, props, schema, allocator, Integer.MAX_VALUE, false, null, 0)) {
+    try (ColumnChunkPageWriteStore store = ColumnChunkPageWriteStore.builder()
+        .withCodecFactory(codecFactory, props)
+        .withSchema(schema)
+        .withAllocator(allocator)
+        .withColumnIndexTruncateLength(Integer.MAX_VALUE)
+        .withPageWriteChecksumEnabled(false)
+        .build()) {
       BytesInput fakeData = BytesInput.fromInt(42);
       BinaryStatistics fakeStats = new BinaryStatistics();
       for (ColumnDescriptor col : schema.getColumns()) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -988,8 +988,8 @@ public class TestParquetWriter {
     conf.set("parquet.compression#col_a", "SNAPPY");
     conf.set("parquet.compression#col_b", "UNCOMPRESSED");
 
-    ParquetProperties.Builder propsBuilder = ParquetProperties.builder()
-        .withCompressionCodec(ParquetOutputFormat.getCompression(conf));
+    ParquetProperties.Builder propsBuilder =
+        ParquetProperties.builder().withCompressionCodec(ParquetOutputFormat.getCompression(conf));
     new ColumnConfigParser()
         .withColumnConfig(
             ParquetOutputFormat.COMPRESSION,
@@ -1000,9 +1000,15 @@ public class TestParquetWriter {
     ParquetProperties props = propsBuilder.build();
 
     MessageType schema = Types.buildMessage()
-        .required(BINARY).as(stringType()).named("col_a")
-        .required(BINARY).as(stringType()).named("col_b")
-        .required(BINARY).as(stringType()).named("col_c")
+        .required(BINARY)
+        .as(stringType())
+        .named("col_a")
+        .required(BINARY)
+        .as(stringType())
+        .named("col_b")
+        .required(BINARY)
+        .as(stringType())
+        .named("col_c")
         .named("test_schema");
 
     for (org.apache.parquet.column.ColumnDescriptor col : schema.getColumns()) {


### PR DESCRIPTION
### Rationale for this change

Issue Raised here: https://github.com/apache/parquet-format/issues/553

The Parquet spec already supports per-column compression, each column chunk stores its own CompressionCodecName in the footer metadata. However, the parquet-java writer API currently forces a single compression codec for all columns in a file. This PR address that gap by exposing per-column compression configuration through the existing ColumnProperty<T> infrastructure.

### What changes are included in this PR?

- ParquetProperties: Added ColumnProperty<CompressionCodecName> following the same pattern used for dictionary encoding, bloom filters.
 - ColumnChunkPageWriteStore: Added a new constructor that accepts CompressionCodecFactory + ParquetProperties 
 - InternalParquetRecordWriter: Added a new constructor accepting CompressionCodecFactory instead of a single BytesInputCompressor. 
 - ParquetWriter: Added withCompressionCodec(String,CompressionCodecName) builder method. Updated the core constructor to pass the CompressionCodecFactory through to the writer stack.
 - ParquetOutputFormat: Added ColumnConfigParser entry so per-column compression can be configured via Hadoop config keys (parquet.compression#<column>=CODEC).
 - ParquetRecordWriter: Updated to pass CompressionCodecFactory to InternalParquetRecordWriter.

### Are these changes tested?
* Added test within this pr

### Are there any user-facing changes?

Two new public APIs are introduced:
```
  ParquetWriter.builder(path)
      .withCompressionCodec(CompressionCodecName.SNAPPY)
         // default for all columns
      .withCompressionCodec("embeddings",
  CompressionCodecName.UNCOMPRESSED)  // per-column override
      .build();

  Hadoop configuration (new key pattern):
  parquet.compression#<column_path>=<CODEC_NAME>
```

cc @julienledem @emkornfield 