### PR TITLE
GH-3399: Hint IDE the source code generated by thrift

### DIFF
--- a/parquet-format-structures/pom.xml
+++ b/parquet-format-structures/pom.xml
@@ -133,6 +133,25 @@
           <quiet>true</quiet>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>add-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/thrift</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -206,6 +206,25 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.6.0</version>
+        <executions>
+          <execution>
+            <id>add-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-test-sources/thrift</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
### Rationale for this change

Hint IDE the source code generated by thrift so it will not report `The import org.apache.parquet.xxxxxx cannot be resolved`

### What changes are included in this PR?

Modified two pom.xml files and added `build-helper-maven-plugin` plugin.

### Are these changes tested?

Yes.


### Are there any user-facing changes?

No.

Closes #3399
