### PR TITLE
GH-3406: fix Float16 statistics handling for NaN and zero values

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BinaryColumnIndexBuilder.java
+++ b/parquet-column/src/main/java/org/apache/parquet/internal/column/columnindex/BinaryColumnIndexBuilder.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.parquet.filter2.predicate.Statistics;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.Float16;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveComparator;
 import org.apache.parquet.schema.PrimitiveType;
 
@@ -82,6 +84,8 @@ class BinaryColumnIndexBuilder extends ColumnIndexBuilder {
   private final List<Binary> maxValues = new ArrayList<>();
   private final BinaryTruncator truncator;
   private final int truncateLength;
+  private final boolean isFloat16;
+  private boolean invalid;
 
   private static Binary convert(ByteBuffer buffer) {
     return Binary.fromReusedByteBuffer(buffer);
@@ -94,6 +98,7 @@ class BinaryColumnIndexBuilder extends ColumnIndexBuilder {
   BinaryColumnIndexBuilder(PrimitiveType type, int truncateLength) {
     truncator = BinaryTruncator.getTruncator(type);
     this.truncateLength = truncateLength;
+    this.isFloat16 = type.getLogicalTypeAnnotation() instanceof LogicalTypeAnnotation.Float16LogicalTypeAnnotation;
   }
 
   @Override
@@ -104,12 +109,43 @@ class BinaryColumnIndexBuilder extends ColumnIndexBuilder {
 
   @Override
   void addMinMax(Object min, Object max) {
-    minValues.add(min == null ? null : truncator.truncateMin((Binary) min, truncateLength));
-    maxValues.add(max == null ? null : truncator.truncateMax((Binary) max, truncateLength));
+    Binary bMin = (Binary) min;
+    Binary bMax = (Binary) max;
+
+    if (isFloat16 && bMin != null && bMax != null) {
+      if (bMin.length() != LogicalTypeAnnotation.Float16LogicalTypeAnnotation.BYTES
+          || bMax.length() != LogicalTypeAnnotation.Float16LogicalTypeAnnotation.BYTES) {
+        // Should not happen for Float16
+        invalid = true;
+      } else {
+        short sMin = bMin.get2BytesLittleEndian();
+        short sMax = bMax.get2BytesLittleEndian();
+
+        if (Float16.isNaN(sMin) || Float16.isNaN(sMax)) {
+          invalid = true;
+        }
+
+        // Sorting order is undefined for -0.0 so let min = -0.0 and max = +0.0 to
+        // ensure that no 0.0 values are skipped
+        // +0.0 is 0x0000, -0.0 is 0x8000 (little endian: 00 00, 00 80)
+        if (sMin == (short) 0x0000) {
+          bMin = Float16.NEGATIVE_ZERO_LITTLE_ENDIAN;
+        }
+        if (sMax == (short) 0x8000) {
+          bMax = Float16.POSITIVE_ZERO_LITTLE_ENDIAN;
+        }
+      }
+    }
+
+    minValues.add(bMin == null ? null : truncator.truncateMin(bMin, truncateLength));
+    maxValues.add(bMax == null ? null : truncator.truncateMax(bMax, truncateLength));
   }
 
   @Override
   ColumnIndexBase<Binary> createColumnIndex(PrimitiveType type) {
+    if (invalid) {
+      return null;
+    }
     BinaryColumnIndex columnIndex = new BinaryColumnIndex(type);
     columnIndex.minValues = minValues.toArray(new Binary[0]);
     columnIndex.maxValues = maxValues.toArray(new Binary[0]);

--- a/parquet-column/src/main/java/org/apache/parquet/schema/Float16.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/Float16.java
@@ -46,6 +46,13 @@ import org.apache.parquet.io.api.Binary;
  * Ref: https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/libcore/util/FP16.java
  */
 public class Float16 {
+  // Positive zero of type half-precision float.
+  public static final Binary POSITIVE_ZERO_LITTLE_ENDIAN =
+      Binary.fromConstantByteArray(new byte[] {0x00, 0x00}, 0, 2);
+  // Negative zero of type half-precision float.
+  public static final Binary NEGATIVE_ZERO_LITTLE_ENDIAN =
+      Binary.fromConstantByteArray(new byte[] {0x00, (byte) 0x80}, 0, 2);
+
   // Positive infinity of type half-precision float.
   private static final short POSITIVE_INFINITY = (short) 0x7c00;
   // A Not-a-Number representation of a half-precision float.

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestFloat16Statistics.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestFloat16Statistics.java
@@ -135,8 +135,8 @@ public class TestFloat16Statistics {
   // Float16Builder: Drop min/max values in case of NaN as the sorting order of values is undefined
   private Binary[] valuesWithNaNStatsMinMax = {
     Binary.fromConstantByteArray(new byte[] {(byte) 0x00, (byte) 0x00}), // +0
-    Binary.fromConstantByteArray(new byte[] {(byte) 0x00, (byte) 0x80})
-  }; // -0
+    Binary.fromConstantByteArray(new byte[] {(byte) 0x00, (byte) 0x00})
+  }; // +0
 
   @Test
   public void testFloat16StatisticsMultipleCases() throws IOException {


### PR DESCRIPTION
### Rationale for this change

1. When creating column index and NaN is the min or max value, column index will not be generated.
2. When creating statistic and the min value is +0, the min value will be changed to -0. When the max value is -0, it will be changed to +0.

### What changes are included in this PR?

- In `Statistics<>.Float16Builder` and `BinaryColumnIndexBuilder`, this PR will adjust value when the min or max value is +0 or -0.
- In `BinaryColumnIndexBuilder`, this PR will mark the column index is invalid when the min or max value is NaN.
- In `Statistics<>.Float16Builder`, statistic will be changed to (+0.0, +0.0) which is the same behavior as `Double`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes. This PR corrects the behavior about `Float16`.

Closes #3406 
