### PR TITLE
Bump dependabot limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,4 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    open-pull-requests-limit: 50


### PR DESCRIPTION
We have currently 5 open dependabot PRs that are blocked mostly by Java 17 or each other. This enables to have more PRs open to bump other dependencies.

<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
