### PR TITLE
GH-3307: Replace deprecated BIT_PACKED with RLE in DevNullValuesWriter

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bitpacking/DevNullValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bitpacking/DevNullValuesWriter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.column.values.bitpacking;
 
-import static org.apache.parquet.column.Encoding.BIT_PACKED;
+import static org.apache.parquet.column.Encoding.RLE;
 
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
@@ -72,7 +72,7 @@ public class DevNullValuesWriter extends ValuesWriter {
 
   @Override
   public Encoding getEncoding() {
-    return BIT_PACKED;
+    return RLE;
   }
 
   @Override


### PR DESCRIPTION
### Rationale for this change
Fixes #3307

When repetition/definition levels are empty (i.e., `maxLevel == 0` for required, non-repeated fields), `DevNullValuesWriter` is used as a no-op writer that produces zero bytes. However, its `getEncoding()` method returns the deprecated `BIT_PACKED` encoding, which gets written into the `DataPageHeader` metadata (`repetition_level_encoding` / `definition_level_encoding`) and the column chunk encoding list.

Since parquet-java already uses `RLE` as the encoding for levels, the metadata should reflect `RLE` rather than the deprecated `BIT_PACKED`. 

### What changes are included in this PR?
Changed `DevNullValuesWriter.getEncoding()` to return `Encoding.RLE` instead of `Encoding.BIT_PACKED`.


### Are these changes tested?
 Yes. All existing tests in `parquet-column` and `parquet-hadoop` pass without modification.

### Are there any user-facing changes?
Newly written Parquet files will report `RLE` instead of `BIT_PACKED` in page header metadata for empty repetition/definition levels. This has no impact on file compatibility — readers do not decode level data when the byte length is zero, regardless of the encoding value in the header.