### PR TITLE
GH-3410: Bump jackson dependencies from 2.19.2 to 2.21.2

### DIFF
--- a/parquet-cli/pom.xml
+++ b/parquet-cli/pom.xml
@@ -178,7 +178,7 @@
     <dependency>
       <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-annotations.version}</version>
     </dependency>
     <dependency>
       <groupId>${jackson.datatype.groupId}</groupId>

--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-annotations.version}</version>
     </dependency>
     <dependency>
       <groupId>${jackson.groupId}</groupId>

--- a/parquet-jackson/pom.xml
+++ b/parquet-jackson/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-annotations.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/parquet-thrift/pom.xml
+++ b/parquet-thrift/pom.xml
@@ -121,7 +121,7 @@
     <dependency>
       <groupId>${jackson.groupId}</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
+      <version>${jackson-annotations.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,8 +75,9 @@
     <jackson.datatype.groupId>com.fasterxml.jackson.datatype</jackson.datatype.groupId>
     <jackson.package>com.fasterxml.jackson</jackson.package>
     <!-- To upgrade jackson, check the jdk versions inside the jar and include any new versions in the shading in parquet-jackson. -->
-    <jackson.version>2.19.2</jackson.version>
-    <jackson-databind.version>2.19.2</jackson-databind.version>
+    <jackson.version>2.21.2</jackson.version>
+    <jackson-databind.version>2.21.2</jackson-databind.version>
+    <jackson-annotations.version>2.21</jackson-annotations.version>
     <japicmp.version>0.23.1</japicmp.version>
     <javax.annotation.version>1.3.2</javax.annotation.version>
     <spotless.version>2.46.1</spotless.version>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Closes #3410, fixing https://github.com/advisories/GHSA-72hv-8253-57qq
This should supersede #3456 and #3439

### What changes are included in this PR?

- Upgrade jackson-core from `2.19.2` to `2.21.2`
- Upgrade jackson-databind from `2.19.2` to `2.21.2`
- Add jackson-annotations 2.21 as a separate dependency

### Are these changes tested?
Existing tests.

### Are there any user-facing changes?
No.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
