### PR TITLE
GH-3461: Avoid unnecessary debug logging overhead in record write hot path

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/InternalParquetRecordWriter.java
@@ -171,7 +171,9 @@ class InternalParquetRecordWriter<T> {
 
   private void checkBlockSizeReached() throws IOException {
     if (recordCount >= rowGroupRecordCountThreshold) {
-      LOG.debug("record count reaches threshold: flushing {} records to disk.", recordCount);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("record count reaches threshold: flushing {} records to disk.", recordCount);
+      }
       flushRowGroupToStore();
       initStore();
       recordCountForNextMemCheck = min(
@@ -185,7 +187,9 @@ class InternalParquetRecordWriter<T> {
       // flush the row group if it is within ~2 records of the limit
       // it is much better to be slightly under size than to be over at all
       if (memSize > (nextRowGroupSize - 2 * recordSize)) {
-        LOG.debug("mem size {} > {}: flushing {} records to disk.", memSize, nextRowGroupSize, recordCount);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("mem size {} > {}: flushing {} records to disk.", memSize, nextRowGroupSize, recordCount);
+        }
         flushRowGroupToStore();
         initStore();
         recordCountForNextMemCheck = min(
@@ -201,7 +205,9 @@ class InternalParquetRecordWriter<T> {
             recordCount
                 + props.getMaxRowCountForPageSizeCheck() // will not look more than max records ahead
             );
-        LOG.debug("Checked mem at {} will check again at: {}", recordCount, recordCountForNextMemCheck);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Checked mem at {} will check again at: {}", recordCount, recordCountForNextMemCheck);
+        }
       }
     }
   }


### PR DESCRIPTION
### Rationale for this change

`InternalParquetRecordWriter.checkBlockSizeReached` runs in a hot path, and we observed unnecessary overhead from debug log argument handling when debug logging is disabled. At high throughput (millions of records), this avoidable work can accumulate and impact write efficiency.

### What changes are included in this PR?

This PR adds `LOG.isDebugEnabled()` guards around debug log statements in `InternalParquetRecordWriter.checkBlockSizeReached`.

### Are these changes tested?

No new tests were added because the change is non-functional and limited to logging guards. Existing writer tests continue to cover the affected code paths functionally, and behavior is expected to remain unchanged.

### Are there any user-facing changes?

There are no user-facing behavior changes. The expected impact is reduced internal overhead in high-volume write scenarios when debug logging is not enabled.

Closes #3461
