### PR TITLE
GH-3464: Improve `DeltaByteArrayWriter.writeBytes` to avoid unnecessary allocation and scalar prefix comparison

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
@@ -89,7 +89,7 @@ public class DeltaByteArrayWriter extends ValuesWriter {
 
   @Override
   public void writeBytes(Binary v) {
-    byte[] vb = v.getBytesUnsafe();
+    byte[] vb = v.isBackingBytesReused() ? v.getBytes() : v.getBytesUnsafe();
     int length = Math.min(previous.length, vb.length);
     // Find the number of matching prefix bytes between this value and the previous one.
     // Arrays.mismatch is intrinsified by the JVM to use SIMD instructions.
@@ -99,9 +99,6 @@ public class DeltaByteArrayWriter extends ValuesWriter {
     }
     prefixLengthWriter.writeInteger(i);
     suffixWriter.writeBytes(v.slice(i, vb.length - i));
-    // Retain an owned copy for prefix comparison with the next value.
-    // getBytesUnsafe() may return the backing array directly, so we must copy
-    // if the Binary's backing bytes may be reused by the caller.
-    previous = v.isBackingBytesReused() ? v.getBytes() : vb;
+    previous = vb;
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.column.values.deltastrings;
 
+import java.util.Arrays;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.column.Encoding;
@@ -88,14 +89,19 @@ public class DeltaByteArrayWriter extends ValuesWriter {
 
   @Override
   public void writeBytes(Binary v) {
-    int i = 0;
-    byte[] vb = v.getBytes();
-    int length = previous.length < vb.length ? previous.length : vb.length;
-    // find the number of matching prefix bytes between this value and the previous one
-    for (i = 0; (i < length) && (previous[i] == vb[i]); i++)
-      ;
+    byte[] vb = v.getBytesUnsafe();
+    int length = Math.min(previous.length, vb.length);
+    // Find the number of matching prefix bytes between this value and the previous one.
+    // Arrays.mismatch is intrinsified by the JVM to use SIMD instructions.
+    int i = Arrays.mismatch(previous, 0, length, vb, 0, length);
+    if (i < 0) {
+      i = length; // all bytes in the common range matched
+    }
     prefixLengthWriter.writeInteger(i);
     suffixWriter.writeBytes(v.slice(i, vb.length - i));
-    previous = vb;
+    // Retain an owned copy for prefix comparison with the next value.
+    // getBytesUnsafe() may return the backing array directly, so we must copy
+    // if the Binary's backing bytes may be reused by the caller.
+    previous = v.isBackingBytesReused() ? v.getBytes() : vb;
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/deltastrings/TestDeltaByteArray.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/deltastrings/TestDeltaByteArray.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.column.values.deltastrings;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.Utils;
@@ -127,5 +128,25 @@ public class TestDeltaByteArray {
     writer.reset();
 
     assertReadWrite(writer, new DeltaByteArrayReader(), values);
+  }
+
+  @Test
+  public void testReusedBackingArrayRegression() throws Exception {
+    DeltaByteArrayWriter writer = new DeltaByteArrayWriter(64 * 1024, 64 * 1024, new DirectByteBufferAllocator());
+    DeltaByteArrayReader reader = new DeltaByteArrayReader();
+
+    byte[] buffer = "parquet-000".getBytes(StandardCharsets.UTF_8);
+    writer.writeBytes(Binary.fromReusedByteArray(buffer));
+
+    System.arraycopy("parquet-111".getBytes(StandardCharsets.UTF_8), 0, buffer, 0, buffer.length);
+    writer.writeBytes(Binary.fromReusedByteArray(buffer));
+
+    System.arraycopy("parquet-222".getBytes(StandardCharsets.UTF_8), 0, buffer, 0, buffer.length);
+    writer.writeBytes(Binary.fromReusedByteArray(buffer));
+
+    Binary[] decoded = Utils.readData(reader, writer.getBytes().toInputStream(), 3);
+    Assert.assertEquals(Binary.fromString("parquet-000"), decoded[0]);
+    Assert.assertEquals(Binary.fromString("parquet-111"), decoded[1]);
+    Assert.assertEquals(Binary.fromString("parquet-222"), decoded[2]);
   }
 }


### PR DESCRIPTION
### Rationale for this change

`DeltaByteArrayWriter.writeBytes()` is on the hot path for `DELTA_BYTE_ARRAY` encoding and had avoidable overhead:

1. **Per-value allocation from `getBytes()`.**  
   `getBytes()` always creates a new array. For prefix comparison this copy is unnecessary.

2. **Scalar prefix scan.**  
   The byte-by-byte loop is replaced with `Arrays.mismatch(...)`, which maps to optimized JVM intrinsics.

In profiling (custom JFR benchmark on a large merge workload), this method was a top allocation hotspot before the change.

### What changes are included in this PR?

In `DeltaByteArrayWriter.writeBytes()`:

- `v.getBytes()` -> `v.getBytesUnsafe()` for read-only prefix comparison.
- Manual prefix loop -> `Arrays.mismatch(previous, 0, length, vb, 0, length)`.
- `previous = vb` -> `previous = v.isBackingBytesReused() ? v.getBytes() : vb`  
  (defensive copy only when the backing bytes may be reused by the caller).

This preserves semantics while removing unnecessary allocations in the common case.

### Benchmark signal (custom, directional)

On a custom JFR-profiled merge workload (180M rows, 4 binary columns), this change significantly reduced allocations and lowered CPU attributed to this path.  
(Results are workload/JDK dependent and provided as directional evidence.)

### Are these changes tested?

Yes.

- Existing coverage: `TestDeltaByteArray` round-trip tests (including skip/skipN/reset paths).
- Added regression test: `testReusedBackingArrayRegression` in `TestDeltaByteArray` to verify correctness when the same mutable backing array is reused across writes.

### Are there any user-facing changes?

No API or format changes. This is a transparent performance optimization; encoded data remains compatible/interchangeable.

Closes #3464