### PR TITLE
GH-3468: Fix lint error which block compilation

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -763,7 +763,7 @@ public class ParquetMetadataConverter {
       switch (stat.getPage_type()) {
         case DATA_PAGE_V2:
           builder.withV2Pages();
-          // falls through
+        // falls through
         case DATA_PAGE:
           builder.addDataEncoding(getEncoding(stat.getEncoding()), stat.getCount());
           break;

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/DirectCodecFactory.java
@@ -103,8 +103,8 @@ class DirectCodecFactory extends CodecFactory implements AutoCloseable {
         return new SnappyCompressor();
       case ZSTD:
         return new ZstdCompressor();
-        // todo: create class similar to the SnappyCompressor for zlib and exclude it as
-        // snappy is above since it also generates allocateDirect calls.
+      // todo: create class similar to the SnappyCompressor for zlib and exclude it as
+      // snappy is above since it also generates allocateDirect calls.
       default:
         return super.createCompressor(codecName);
     }

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
@@ -226,7 +226,7 @@ public class BufferedProtocolReadToWrite implements ProtocolPipe {
         writeShortAction(buffer, s);
         break;
       case TType.ENUM: // same as i32 => actually never seen in the protocol layer as enums are written as a i32
-        // field
+      // field
       case TType.I32:
         final int i = in.readI32();
         checkEnum(expectedType, i);

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ProtocolReadToWrite.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ProtocolReadToWrite.java
@@ -74,7 +74,7 @@ public class ProtocolReadToWrite implements ProtocolPipe {
         out.writeI16(in.readI16());
         break;
       case TType.ENUM: // same as i32 => actually never seen in the protocol layer as enums are written as a i32
-        // field
+      // field
       case TType.I32:
         out.writeI32(in.readI32());
         break;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### 1. Rationale for this change

The project has comment formatting issues that violate lint rules, which **block compilation**. This PR fixes those lint errors to allow the project to compile successfully.

---

### 2. What changes are included in this PR?

This PR contains **purely code style / comment formatting** adjustments across **4 Java files**:

| File | Change |
|---|---|
| `ParquetMetadataConverter.java` | Fixed formatting/indentation of the `// falls through` comment in a switch statement |
| `DirectCodecFactory.java` | Realigned a multi-line `// todo:` comment to comply with lint rules |
| `BufferedProtocolReadToWrite.java` | Fixed indentation of a multi-line comment related to `TType.ENUM` |
| `ProtocolReadToWrite.java` | Same as above — fixed multi-line comment indentation |

All changes are strictly comment formatting corrections. **No functional code was modified.**

---

### 3. Are these changes tested?

Yes. The author confirmed the changes were verified through **Compile** and **UT (Unit Tests)**. Since only comment formatting was changed with no logic modifications, passing compilation and unit tests provides sufficient validation.

---

### 4. Are there any user-facing changes?

**No.** This PR only corrects comment code style. It does not affect any APIs, functional behavior, or anything perceivable by end users.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
