### PR TITLE
Fix 'occured' typo in exception javadocs

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/CompilationException.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/CompilationException.java
@@ -21,7 +21,7 @@ package org.apache.parquet.io;
 import org.apache.parquet.ParquetRuntimeException;
 
 /**
- * thrown when a problem occured while compiling the column reader
+ * thrown when a problem occurred while compiling the column reader
  */
 public class CompilationException extends ParquetRuntimeException {
   private static final long serialVersionUID = 1L;

--- a/parquet-column/src/main/java/org/apache/parquet/io/ParquetDecodingException.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/ParquetDecodingException.java
@@ -21,7 +21,7 @@ package org.apache.parquet.io;
 import org.apache.parquet.ParquetRuntimeException;
 
 /**
- * thrown when an encoding problem occured
+ * thrown when an encoding problem occurred
  */
 public class ParquetDecodingException extends ParquetRuntimeException {
   private static final long serialVersionUID = 1L;

--- a/parquet-column/src/main/java/org/apache/parquet/io/ParquetEncodingException.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/ParquetEncodingException.java
@@ -21,7 +21,7 @@ package org.apache.parquet.io;
 import org.apache.parquet.ParquetRuntimeException;
 
 /**
- * thrown when a decoding problem occured
+ * thrown when a decoding problem occurred
  */
 public class ParquetEncodingException extends ParquetRuntimeException {
   private static final long serialVersionUID = 1L;


### PR DESCRIPTION
Javadoc-only typo fix: `occured` -> `occurred` in three exception classes:

- `ParquetEncodingException.java`
- `ParquetDecodingException.java`
- `CompilationException.java`