### PR TITLE
GH-3482: parquet-hadoop tests to work behind a web proxy

### DIFF
--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
@@ -38,8 +38,14 @@ public class InterOpTester {
   private static final Logger LOG = LoggerFactory.getLogger(InterOpTester.class);
   // since PARQUET_TESTING_REPO might be beyond a web proxy ...
   private static OkHttpClient createOkHttpClientOptProxy() {
-    String proxyHost = System.getProperty("https.proxyHost");
-    String proxyPort = System.getProperty("https.proxyPort");
+    /* We use a different JVM property set,
+     * because CI may define JVM properties
+     * "https.proxyHost" and "https.proxyPort"
+     * and that proxy won't support some compressions
+     * (e.g. gzip/snappy on github.com CI).
+     /
+    String proxyHost = System.getProperty("parquet.https.proxyHost");
+    String proxyPort = System.getProperty("parquet.https.proxyPort");
     OkHttpClient client = null;
     if (proxyHost != null || proxyPort != null) {
       try {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
@@ -37,7 +37,7 @@ public class InterOpTester {
   private static final String PARQUET_TESTING_PATH = "target/parquet-testing/";
   private static final Logger LOG = LoggerFactory.getLogger(InterOpTester.class);
   // since PARQUET_TESTING_REPO might be beyond a web proxy ...
-  private static OkHttpClient createOkHttpClientOptProxy() {
+  public static OkHttpClient createOkHttpClientOptProxy() {
     /* We use a different JVM property set,
      * because CI may define JVM properties
      * "https.proxyHost" and "https.proxyPort"

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
@@ -47,7 +47,7 @@ public class InterOpTester {
     String proxyHost = System.getProperty("parquet.https.proxyHost");
     String proxyPort = System.getProperty("parquet.https.proxyPort");
     OkHttpClient client = null;
-    if (proxyHost != null || proxyPort != null) {
+    if (proxyHost != null && proxyPort != null) {
       try {
         int port = Integer.valueOf(proxyPort);
         Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, port));

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
@@ -43,7 +43,7 @@ public class InterOpTester {
      * "https.proxyHost" and "https.proxyPort"
      * and that proxy won't support some compressions
      * (e.g. gzip/snappy on github.com CI).
-     /
+     */
     String proxyHost = System.getProperty("parquet.https.proxyHost");
     String proxyPort = System.getProperty("parquet.https.proxyPort");
     OkHttpClient client = null;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
@@ -20,6 +20,8 @@
 package org.apache.parquet.hadoop;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -34,7 +36,24 @@ public class InterOpTester {
   private static final String PARQUET_TESTING_REPO = "https://github.com/apache/parquet-testing/raw/";
   private static final String PARQUET_TESTING_PATH = "target/parquet-testing/";
   private static final Logger LOG = LoggerFactory.getLogger(InterOpTester.class);
-  private OkHttpClient httpClient = new OkHttpClient();
+  // since PARQUET_TESTING_REPO might be beyond a web proxy ...
+  private static OkHttpClient createOkHttpClientOptProxy() {
+    String proxyHost = System.getProperty("https.proxyHost");
+    String proxyPort = System.getProperty("https.proxyPort");
+    OkHttpClient client = null;
+    if (proxyHost != null || proxyPort != null) {
+      try {
+        int port = Integer.valueOf(proxyPort);
+        Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, port));
+        client = new OkHttpClient.Builder().proxy(proxy).build();
+      } catch (NumberFormatException e) {
+      }
+    }
+    if (client == null) client = new OkHttpClient();
+    return client;
+  }
+
+  private OkHttpClient httpClient = createOkHttpClientOptProxy();
 
   public Path GetInterOpFile(String fileName, String changeset) throws IOException {
     return GetInterOpFile(fileName, changeset, "data");

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/InterOpTester.java
@@ -53,6 +53,13 @@ public class InterOpTester {
         Proxy proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, port));
         client = new OkHttpClient.Builder().proxy(proxy).build();
       } catch (NumberFormatException e) {
+        LOG.warn(
+            "Ignoring proxy configuration because proxy port could not be parsed: "
+                + "parquet.https.proxyHost='{}', parquet.https.proxyPort='{}'. "
+                + "Falling back to a direct connection.",
+            proxyHost,
+            proxyPort,
+            e);
       }
     }
     if (client == null) client = new OkHttpClient();

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInteropBloomFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInteropBloomFilter.java
@@ -57,7 +57,7 @@ public class TestInteropBloomFilter {
   private static String DATA_INDEX_BLOOM_WITH_LENGTH_FILE = "data_index_bloom_encoding_with_length.parquet";
 
   private static final Logger LOG = LoggerFactory.getLogger(TestInteropBloomFilter.class);
-  private OkHttpClient httpClient = new OkHttpClient();
+  private OkHttpClient httpClient = InterOpTester.createOkHttpClientOptProxy();
 
   @Test
   public void testReadDataIndexBloomParquetFiles() throws IOException {


### PR DESCRIPTION
### Rationale for this change

Allow `parquet-hadoop` tests to work behind a web proxy. Otherwise their failures stop some other jar files from being build.

### What changes are included in this PR?

Analysis of system properties `parquet.https.proxyHost` and `parquet.https.proxyPort`, and if set, use a `Proxy` for `OkHttpClient` creation.
We use a new different JVM property set and not a widely used one, because CI may define JVM properties `https.proxyHost` and `https.proxyPort` and that proxy won't support some compressions (e.g. gzip/snappy on github.com CI).

### Are these changes tested?

The `./mvn clean build` now passes when I'm behind a web proxy.

### Are there any user-facing changes?

No.

<!-- Closes #3482 -->
