### PR TITLE
GH-3484: Eliminate per-page heap allocation for CRC32 checksums when using direct `ByteBufferAllocator`

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -94,6 +94,7 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
     private Statistics totalStatistics;
     private final SizeStatistics totalSizeStatistics;
     private final GeospatialStatistics totalGeospatialStatistics;
+    private final ByteBufferAllocator allocator;
     private final ByteBufferReleaser releaser;
 
     private final CRC32 crc;
@@ -121,6 +122,7 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
         int columnOrdinal) {
       this.path = path;
       this.compressor = compressor;
+      this.allocator = allocator;
       this.releaser = new ByteBufferReleaser(allocator);
       this.buf = new ConcatenatingByteBufferCollector(allocator);
       this.columnIndexBuilder = ColumnIndexBuilder.getBuilder(path.getPrimitiveType(), columnIndexTruncateLength);
@@ -217,7 +219,9 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       }
       if (pageWriteChecksumEnabled) {
         crc.reset();
-        crc.update(compressedBytes.toByteBuffer(releaser));
+        try (ByteBufferReleaser pageReleaser = new ByteBufferReleaser(allocator)) {
+          crc.update(compressedBytes.toByteBuffer(pageReleaser));
+        }
         parquetMetadataConverter.writeDataPageV1Header(
             (int) uncompressedSize,
             (int) compressedSize,
@@ -321,14 +325,16 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       }
       if (pageWriteChecksumEnabled) {
         crc.reset();
-        if (repetitionLevels.size() > 0) {
-          crc.update(repetitionLevels.toByteBuffer(releaser));
-        }
-        if (definitionLevels.size() > 0) {
-          crc.update(definitionLevels.toByteBuffer(releaser));
-        }
-        if (compressedData.size() > 0) {
-          crc.update(compressedData.toByteBuffer(releaser));
+        try (ByteBufferReleaser pageReleaser = new ByteBufferReleaser(allocator)) {
+          if (repetitionLevels.size() > 0) {
+            crc.update(repetitionLevels.toByteBuffer(pageReleaser));
+          }
+          if (definitionLevels.size() > 0) {
+            crc.update(definitionLevels.toByteBuffer(pageReleaser));
+          }
+          if (compressedData.size() > 0) {
+            crc.update(compressedData.toByteBuffer(pageReleaser));
+          }
         }
         parquetMetadataConverter.writeDataPageV2Header(
             uncompressedSize,

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -217,7 +217,7 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       }
       if (pageWriteChecksumEnabled) {
         crc.reset();
-        crc.update(compressedBytes.toByteArray());
+        crc.update(compressedBytes.toByteBuffer(releaser));
         parquetMetadataConverter.writeDataPageV1Header(
             (int) uncompressedSize,
             (int) compressedSize,
@@ -322,13 +322,13 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       if (pageWriteChecksumEnabled) {
         crc.reset();
         if (repetitionLevels.size() > 0) {
-          crc.update(repetitionLevels.toByteArray());
+          crc.update(repetitionLevels.toByteBuffer(releaser));
         }
         if (definitionLevels.size() > 0) {
-          crc.update(definitionLevels.toByteArray());
+          crc.update(definitionLevels.toByteBuffer(releaser));
         }
         if (compressedData.size() > 0) {
-          crc.update(compressedData.toByteArray());
+          crc.update(compressedData.toByteBuffer(releaser));
         }
         parquetMetadataConverter.writeDataPageV2Header(
             uncompressedSize,


### PR DESCRIPTION
### Rationale for this change

`ColumnChunkPageWriter.writePage()` and `writePageV2()` call `BytesInput.toByteArray()` to feed compressed page data into `CRC32.update(byte[])`. When the writer uses a direct `ByteBufferAllocator`, this forces a full heap copy of every compressed page solely for checksumming. Since page write checksums are enabled by default (`DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED = true`), this allocation occurs on every page write and negates part of the benefit of using a direct allocator.

### What changes are included in this PR?

Replace `crc.update(x.toByteArray())` with `crc.update(x.toByteBuffer(pageReleaser))`, using a per-page `ByteBufferReleaser` scoped via try-with-resources so the CRC buffer is returned to the allocator immediately after `crc.update()`.

- `writePage()` (V1): 1 call for `compressedBytes`, wrapped in a per-page releaser.
- `writePageV2()`: 3 calls for `repetitionLevels`, `definitionLevels`, and `compressedData`, sharing one per-page releaser.

`CRC32.update(ByteBuffer)` has been available since Java 9 and operates directly on the buffer's memory without copying. The `ColumnChunkPageWriter` already has a long-lived `releaser` field, but reusing it for CRC buffers would defer release until the column chunk closes — for column chunks with many pages (e.g. `TestLargeColumnChunk`'s ~2 GB chunk) this accumulates buffers and exhausts the heap. Scoping each CRC update to its own releaser keeps the lifetime equal to the duration of `crc.update()`. When the allocator is heap-based, behaviour remains functionally equivalent to the previous code.

### Are these changes tested?

Covered by existing tests:

- `TestColumnChunkPageWriteStore` — both heap and direct allocator paths (`test` and `testWithDirectBuffers`); exercises `writePageV2` with checksums enabled by default.
- `TestDataPageChecksums` — V1 and V2 pages with checksums on/off.
- `TestLargeColumnChunk` — single column chunk larger than `Integer.MAX_VALUE`, which detected an earlier revision of this PR that retained CRC buffers for the chunk lifetime.

### Are there any user-facing changes?

No. This is an internal optimization. CRC32 checksums are computed identically; only the intermediate memory representation changes.

Closes #3484
