### PR TITLE
GH-3478: Fix LZ4_RAW heap decompression

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/CodecFactory.java
@@ -39,6 +39,7 @@ import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.compression.CompressionCodecFactory;
 import org.apache.parquet.conf.HadoopParquetConfiguration;
 import org.apache.parquet.conf.ParquetConfiguration;
+import org.apache.parquet.hadoop.codec.Lz4RawCodec;
 import org.apache.parquet.hadoop.codec.ZstandardCodec;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.util.ConfigurationUtil;
@@ -170,11 +171,12 @@ public class CodecFactory implements CompressionCodecFactory {
       }
       InputStream is = codec.createInputStream(bytes.toInputStream(), decompressor);
 
-      // We need to explicitly close the ZstdDecompressorStream here to release the resources it holds to
-      // avoid off-heap memory fragmentation issue, see https://github.com/apache/parquet-format/issues/398.
-      // This change will load the decompressor stream into heap a little earlier, since the problem it solves
-      // only happens in the ZSTD codec, so this modification is only made for ZSTD streams.
-      if (codec instanceof ZstandardCodec) {
+      // Eagerly materialize the decompressed stream for codecs that require all input in a single buffer.
+      // ZSTD: releases off-heap resources early to avoid fragmentation (see parquet-format#398).
+      // LZ4_RAW: requires one-shot decompression; the lazy StreamBytesInput.writeInto() path reads via
+      // Channels.newChannel() in ~8KB chunks, causing the decompressor to be called with an undersized
+      // output buffer (see #3478).
+      if (codec instanceof ZstandardCodec || codec instanceof Lz4RawCodec) {
         decompressed = BytesInput.copy(BytesInput.from(is, decompressedSize));
         is.close();
       } else {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
@@ -33,13 +33,21 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.parquet.bytes.ByteBufferReleaser;
 import org.apache.parquet.bytes.BytesInput;
+import org.apache.parquet.bytes.DirectByteBufferAllocator;
+import org.apache.parquet.bytes.TrackingByteBufferAllocator;
+import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
+import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
+import org.apache.parquet.hadoop.CodecFactory;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 public class TestCompressionCodec {
+
+  private final int pageSize = 64 * 1024;
 
   @Test
   public void testLz4RawBlock() throws IOException {
@@ -174,6 +182,35 @@ public class TestCompressionCodec {
       default:
         // Not implemented yet
         return null;
+    }
+  }
+
+  /**
+   * Regression test for #3478: LZ4_RAW heap decompression fails when the decompressed page
+   * exceeds the ~8KB chunk size used by stream materialization in BytesInput.copy().
+   */
+  @Test
+  public void testLz4RawHeapDecompressorCanCopyLargePage() throws IOException {
+    final int size = 16 * 1024;
+    final byte[] raw = new byte[size];
+    new Random(42).nextBytes(raw);
+
+    try (TrackingByteBufferAllocator allocator =
+            TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
+        ByteBufferReleaser releaser = new ByteBufferReleaser(allocator)) {
+      CodecFactory heapCodecFactory = new CodecFactory(new Configuration(), pageSize);
+      BytesInputCompressor compressor = heapCodecFactory.getCompressor(CompressionCodecName.LZ4_RAW);
+      BytesInputDecompressor decompressor = heapCodecFactory.getDecompressor(CompressionCodecName.LZ4_RAW);
+
+      BytesInput compressed = compressor.compress(BytesInput.from(raw));
+      BytesInput decompressed = decompressor.decompress(compressed, size);
+
+      BytesInput copied = decompressed.copy(releaser);
+      Assert.assertArrayEquals(raw, copied.toByteArray());
+
+      compressor.release();
+      decompressor.release();
+      heapCodecFactory.release();
     }
   }
 


### PR DESCRIPTION
### What changes were proposed?

Eagerly materialize the decompressed stream for `LZ4_RAW` in `CodecFactory`, matching the existing pattern used for ZSTD. Added a regression test.

Closes #3478

### Why are the changes needed?

When reading `LZ4_RAW`-compressed data through the heap codec path, decompression fails if the decompressed page exceeds ~8KB. The lazy `StreamBytesInput.writeInto()` path reads via `Channels.newChannel()` in ~8KB chunks, but LZ4_RAW requires all compressed input in a single buffer for one-shot decompression. This causes `MalformedInputException: all input must be consumed` in production reads, particularly during dictionary filter evaluation (`DictionaryPageReader.reusableCopy()`).

The fix extends the existing ZSTD eager-materialization pattern (added for parquet-format#398) to also cover `LZ4_RAW`:

```java
if (codec instanceof ZstandardCodec || codec instanceof Lz4RawCodec) {
  decompressed = BytesInput.copy(BytesInput.from(is, decompressedSize));
  is.close();
}
```

### How was this tested?

Added `testLz4RawHeapDecompressorCanCopyLargePage` to `TestCompressionCodec`:
- Compresses a 16KB random page via `CodecFactory` heap path
- Decompresses and calls `BytesInput.copy()` to exercise the chunked materialization path
- **Fails without the fix**, passes with it

All existing tests continue to pass (6/6 in `TestCompressionCodec`, 11/11 across all codec tests).