### PR TITLE
GH-3493: Optimize PlainValuesReader with direct ByteBuffer reads

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesReader.java
@@ -19,25 +19,36 @@
 package org.apache.parquet.column.values.plain;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.LittleEndianDataInputStream;
 import org.apache.parquet.column.values.ValuesReader;
-import org.apache.parquet.io.ParquetDecodingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Plain encoding for float, double, int, long
+ * Plain encoding for float, double, int, long.
+ *
+ * <p>Reads directly from a {@link ByteBuffer} with {@link ByteOrder#LITTLE_ENDIAN} byte order,
+ * bypassing the {@link LittleEndianDataInputStream} wrapper to avoid per-value virtual dispatch
+ * overhead. The underlying page data is obtained as a single contiguous {@link ByteBuffer} via
+ * {@link ByteBufferInputStream#slice(int)}.
  */
 public abstract class PlainValuesReader extends ValuesReader {
   private static final Logger LOG = LoggerFactory.getLogger(PlainValuesReader.class);
 
-  protected LittleEndianDataInputStream in;
+  ByteBuffer buffer;
 
   @Override
   public void initFromPage(int valueCount, ByteBufferInputStream stream) throws IOException {
     LOG.debug("init from page at offset {} for length {}", stream.position(), stream.available());
-    this.in = new LittleEndianDataInputStream(stream.remainingStream());
+    int available = stream.available();
+    if (available > 0) {
+      this.buffer = stream.slice(available).order(ByteOrder.LITTLE_ENDIAN);
+    } else {
+      this.buffer = ByteBuffer.allocate(0).order(ByteOrder.LITTLE_ENDIAN);
+    }
   }
 
   @Override
@@ -45,31 +56,16 @@ public abstract class PlainValuesReader extends ValuesReader {
     skip(1);
   }
 
-  void skipBytesFully(int n) throws IOException {
-    int skipped = 0;
-    while (skipped < n) {
-      skipped += in.skipBytes(n - skipped);
-    }
-  }
-
   public static class DoublePlainValuesReader extends PlainValuesReader {
 
     @Override
     public void skip(int n) {
-      try {
-        skipBytesFully(n * 8);
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not skip " + n + " double values", e);
-      }
+      buffer.position(buffer.position() + n * 8);
     }
 
     @Override
     public double readDouble() {
-      try {
-        return in.readDouble();
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not read double", e);
-      }
+      return buffer.getDouble();
     }
   }
 
@@ -77,20 +73,12 @@ public abstract class PlainValuesReader extends ValuesReader {
 
     @Override
     public void skip(int n) {
-      try {
-        skipBytesFully(n * 4);
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not skip " + n + " floats", e);
-      }
+      buffer.position(buffer.position() + n * 4);
     }
 
     @Override
     public float readFloat() {
-      try {
-        return in.readFloat();
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not read float", e);
-      }
+      return buffer.getFloat();
     }
   }
 
@@ -98,20 +86,12 @@ public abstract class PlainValuesReader extends ValuesReader {
 
     @Override
     public void skip(int n) {
-      try {
-        in.skipBytes(n * 4);
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not skip " + n + " ints", e);
-      }
+      buffer.position(buffer.position() + n * 4);
     }
 
     @Override
     public int readInteger() {
-      try {
-        return in.readInt();
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not read int", e);
-      }
+      return buffer.getInt();
     }
   }
 
@@ -119,20 +99,12 @@ public abstract class PlainValuesReader extends ValuesReader {
 
     @Override
     public void skip(int n) {
-      try {
-        in.skipBytes(n * 8);
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not skip " + n + " longs", e);
-      }
+      buffer.position(buffer.position() + n * 8);
     }
 
     @Override
     public long readLong() {
-      try {
-        return in.readLong();
-      } catch (IOException e) {
-        throw new ParquetDecodingException("could not read long", e);
-      }
+      return buffer.getLong();
     }
   }
 }

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataInputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataInputStream.java
@@ -21,10 +21,24 @@ package org.apache.parquet.bytes;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 /**
- * Based on DataInputStream but little endian and without the String/char methods
+ * Based on DataInputStream but little endian and without the String/char methods.
+ *
+ * @deprecated This class has no remaining production usages and is
+ *     significantly slower than reading directly from a {@link ByteBuffer} configured with
+ *     {@link ByteOrder#LITTLE_ENDIAN}. Each {@link #readInt()} performs four virtual
+ *     {@code in.read()} calls and reassembles the value with bit shifts, while
+ *     {@link ByteBuffer#getInt()} on a little-endian buffer is a HotSpot intrinsic that
+ *     compiles to a single unaligned load on x86/ARM. For new code, prefer
+ *     {@link ByteBufferInputStream#slice(int)} followed by
+ *     {@code buffer.order(ByteOrder.LITTLE_ENDIAN)} and {@link ByteBuffer#getInt()} /
+ *     {@link ByteBuffer#getLong()} / {@link ByteBuffer#getFloat()} /
+ *     {@link ByteBuffer#getDouble()}. This class will be removed in a future release.
  */
+@Deprecated
 public final class LittleEndianDataInputStream extends InputStream {
 
   private final InputStream in;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -38,9 +38,8 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.inOrder;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteOrder;
 import java.util.HashMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -49,7 +48,6 @@ import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
-import org.apache.parquet.bytes.LittleEndianDataInputStream;
 import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
@@ -249,12 +247,7 @@ public class TestColumnChunkPageWriteStore {
   }
 
   private int intValue(BytesInput in) throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    in.writeAllTo(baos);
-    LittleEndianDataInputStream os = new LittleEndianDataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-    int i = os.readInt();
-    os.close();
-    return i;
+    return in.toByteBuffer().order(ByteOrder.LITTLE_ENDIAN).getInt();
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -594,6 +594,8 @@
               <exclude>org.apache.parquet.internal.column.columnindex.IndexIterator</exclude>
               <!-- Removal of a protected method in a class that's not supposed to be subclassed by third-party code -->
               <exclude>org.apache.parquet.column.values.bytestreamsplit.ByteStreamSplitValuesReader#gatherElementDataFromStreams(byte[])</exclude>
+              <!-- Removal of a protected internal field that should not have been part of the public API -->
+              <exclude>org.apache.parquet.column.values.plain.PlainValuesReader#in</exclude>
               <!-- Due to the removal of deprecated methods -->
               <exclude>org.apache.parquet.arrow.schema.SchemaMapping$TypeMappingVisitor#visit(org.apache.parquet.arrow.schema.SchemaMapping$MapTypeMapping)</exclude>
               <!-- Intentional removal of deprecated Pig support from parquet-thrift -->


### PR DESCRIPTION
### Rationale for this change

Closes #3493.

`PlainValuesReader` (used for PLAIN-encoded INT32, INT64, FLOAT, and DOUBLE columns, and for decoding the dictionary page of every dictionary-encoded numeric column) currently reads each value through a `LittleEndianDataInputStream` wrapper around a `ByteBufferInputStream`. Per value, `readInt()` performs 4 separate virtual `in.read()` calls and reassembles the result with bit shifts. The `LittleEndianDataInputStream.readInt()` method itself carries a TODO comment from years ago suggesting exactly this kind of replacement.

### What changes are included in this PR?

**Commit 1** — `Optimize PlainValuesReader with direct ByteBuffer reads`

In `PlainValuesReader.initFromPage()`, obtain the page data as a single contiguous `ByteBuffer` via `stream.slice(stream.available())` with `ByteOrder.LITTLE_ENDIAN`, and call the corresponding `ByteBuffer` accessor directly per value:

- `readInteger()` → `buffer.getInt()`
- `readLong()`    → `buffer.getLong()`
- `readFloat()`   → `buffer.getFloat()`
- `readDouble()`  → `buffer.getDouble()`
- `skip(n)`       → `buffer.position(buffer.position() + n * typeSize)`

`ByteBuffer.getInt()` with the appropriate byte order is a HotSpot intrinsic that compiles to a single unaligned load instruction on x86/ARM — no virtual dispatch, no per-byte assembly, no checked `IOException` on the per-value path. `ByteBufferInputStream.slice()` already handles both single-buffer (zero-copy view) and multi-buffer (single contiguous copy) cases transparently.

**Commit 2** — `Deprecate LittleEndianDataInputStream and migrate last test usage`

After commit 1, `LittleEndianDataInputStream` has no remaining production usages. This commit:
- Adds `@Deprecated` and detailed javadoc pointing to the faster `ByteBuffer` + `LITTLE_ENDIAN` alternative
- Migrates the only remaining usage in `TestColumnChunkPageWriteStore.intValue()` to `BytesInput.toByteBuffer().order(LITTLE_ENDIAN).getInt()`, eliminating a `BytesInput → ByteArrayOutputStream → ByteArrayInputStream → LittleEndianDataInputStream` round-trip

The class is left in place (only `@Deprecated`) for source/binary compatibility of any downstream code that may still reference it. It can be removed in a future major release.

### Benchmark results

`IntEncodingBenchmark.decodePlain` (100,000 INT32 values per invocation, JMH `-wi 3 -i 5 -f 1`):

| Pattern          | Before (ops/s) | After (ops/s)   | Speedup |
|------------------|---------------:|----------------:|--------:|
| SEQUENTIAL       |     92,918,297 |   1,143,149,235 | **12.3x** |
| RANDOM           |     92,126,888 |   1,147,547,093 | **12.5x** |
| LOW_CARDINALITY  |     93,005,451 |   1,142,666,760 | **12.3x** |
| HIGH_CARDINALITY |     93,312,596 |   1,144,681,876 | **12.3x** |

The speedup is consistent across data patterns because the bottleneck is entirely in the per-value dispatch overhead, not the data itself. All four numeric plain reader types (int, long, float, double) benefit equally.

### Are these changes tested?

Yes. All 573 `parquet-column` and 308 `parquet-common` tests pass. The migrated `TestColumnChunkPageWriteStore.testColumnOrderV1` test passes; the two pre-existing `getSubject` failures in `TestColumnChunkPageWriteStore` on JDK 18+ are unrelated and reproduce on `master` without these changes.

### Are there any user-facing changes?

`LittleEndianDataInputStream` is now `@Deprecated`. No behavioral or binary-compatibility changes for existing callers.
## How to reproduce the benchmarks

The JMH benchmarks cited above are being added to `parquet-benchmarks` in #3512. Once that lands, reproduce with:

```
./mvnw clean package -pl parquet-benchmarks -DskipTests \
    -Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true
java -jar parquet-benchmarks/target/parquet-benchmarks.jar 'IntEncodingBenchmark.decodePlain' \
    -wi 5 -i 10 -f 3
```

Compare runs against `master` (baseline) and this branch (optimized).