### PR TITLE
GH-3495: Optimize PlainValuesWriter with direct ByteBuffer slab writes (~2.5x encode speedup)

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
-import org.apache.parquet.bytes.LittleEndianDataOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
@@ -46,11 +45,9 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
 
   private ValuesWriter lengthWriter;
   private CapacityByteArrayOutputStream arrayOut;
-  private LittleEndianDataOutputStream out;
 
   public DeltaLengthByteArrayValuesWriter(int initialSize, int pageSize, ByteBufferAllocator allocator) {
     arrayOut = new CapacityByteArrayOutputStream(initialSize, pageSize, allocator);
-    out = new LittleEndianDataOutputStream(arrayOut);
     lengthWriter = new DeltaBinaryPackingValuesWriterForInteger(
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_BLOCK_VALUES,
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_MINIBLOCKS,
@@ -63,7 +60,7 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
   public void writeBytes(Binary v) {
     try {
       lengthWriter.writeInteger(v.length());
-      v.writeTo(out);
+      v.writeTo(arrayOut);
     } catch (IOException e) {
       throw new ParquetEncodingException("could not write bytes", e);
     }
@@ -76,11 +73,6 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
 
   @Override
   public BytesInput getBytes() {
-    try {
-      out.flush();
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write page", e);
-    }
     LOG.debug("writing a buffer of size {}", arrayOut.size());
     return BytesInput.concat(lengthWriter.getBytes(), BytesInput.from(arrayOut));
   }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/FixedLenByteArrayPlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/FixedLenByteArrayPlainValuesWriter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
-import org.apache.parquet.bytes.LittleEndianDataOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.ParquetEncodingException;
@@ -37,7 +36,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
   private static final Logger LOG = LoggerFactory.getLogger(PlainValuesWriter.class);
 
   private CapacityByteArrayOutputStream arrayOut;
-  private LittleEndianDataOutputStream out;
   private int length;
   private ByteBufferAllocator allocator;
 
@@ -46,7 +44,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
     this.length = length;
     this.allocator = allocator;
     this.arrayOut = new CapacityByteArrayOutputStream(initialSize, pageSize, this.allocator);
-    this.out = new LittleEndianDataOutputStream(arrayOut);
   }
 
   @Override
@@ -56,7 +53,7 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
           "Fixed Binary size " + v.length() + " does not match field type length " + length);
     }
     try {
-      v.writeTo(out);
+      v.writeTo(arrayOut);
     } catch (IOException e) {
       throw new ParquetEncodingException("could not write fixed bytes", e);
     }
@@ -69,11 +66,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
 
   @Override
   public BytesInput getBytes() {
-    try {
-      out.flush();
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write page", e);
-    }
     LOG.debug("writing a buffer of size {}", arrayOut.size());
     return BytesInput.from(arrayOut);
   }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/PlainValuesWriter.java
@@ -23,7 +23,6 @@ import java.nio.charset.Charset;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
-import org.apache.parquet.bytes.LittleEndianDataOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.ParquetEncodingException;
@@ -41,18 +40,16 @@ public class PlainValuesWriter extends ValuesWriter {
   public static final Charset CHARSET = Charset.forName("UTF-8");
 
   private CapacityByteArrayOutputStream arrayOut;
-  private LittleEndianDataOutputStream out;
 
   public PlainValuesWriter(int initialSize, int pageSize, ByteBufferAllocator allocator) {
     arrayOut = new CapacityByteArrayOutputStream(initialSize, pageSize, allocator);
-    out = new LittleEndianDataOutputStream(arrayOut);
   }
 
   @Override
   public final void writeBytes(Binary v) {
     try {
-      out.writeInt(v.length());
-      v.writeTo(out);
+      arrayOut.writeInt(v.length());
+      v.writeTo(arrayOut);
     } catch (IOException e) {
       throw new ParquetEncodingException("could not write bytes", e);
     }
@@ -60,47 +57,27 @@ public class PlainValuesWriter extends ValuesWriter {
 
   @Override
   public final void writeInteger(int v) {
-    try {
-      out.writeInt(v);
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write int", e);
-    }
+    arrayOut.writeInt(v);
   }
 
   @Override
   public final void writeLong(long v) {
-    try {
-      out.writeLong(v);
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write long", e);
-    }
+    arrayOut.writeLong(v);
   }
 
   @Override
   public final void writeFloat(float v) {
-    try {
-      out.writeFloat(v);
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write float", e);
-    }
+    arrayOut.writeInt(Float.floatToIntBits(v));
   }
 
   @Override
   public final void writeDouble(double v) {
-    try {
-      out.writeDouble(v);
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write double", e);
-    }
+    arrayOut.writeLong(Double.doubleToLongBits(v));
   }
 
   @Override
   public void writeByte(int value) {
-    try {
-      out.write(value);
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write byte", e);
-    }
+    arrayOut.write(value);
   }
 
   @Override
@@ -110,11 +87,6 @@ public class PlainValuesWriter extends ValuesWriter {
 
   @Override
   public BytesInput getBytes() {
-    try {
-      out.flush();
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write page", e);
-    }
     if (LOG.isDebugEnabled()) LOG.debug("writing a buffer of size {}", arrayOut.size());
     return BytesInput.from(arrayOut);
   }
@@ -127,7 +99,6 @@ public class PlainValuesWriter extends ValuesWriter {
   @Override
   public void close() {
     arrayOut.close();
-    out.close();
   }
 
   @Override

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/CapacityByteArrayOutputStream.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.parquet.OutputStreamCloseException;
@@ -194,6 +195,7 @@ public class CapacityByteArrayOutputStream extends OutputStream {
     LOG.debug("used {} slabs, adding new slab of size {}", slabs.size(), nextSlabSize);
 
     this.currentSlab = allocator.allocate(nextSlabSize);
+    this.currentSlab.order(ByteOrder.LITTLE_ENDIAN);
     this.slabs.add(currentSlab);
     this.bytesAllocated = Math.addExact(this.bytesAllocated, nextSlabSize);
   }
@@ -223,6 +225,34 @@ public class CapacityByteArrayOutputStream extends OutputStream {
       currentSlab.put(b, off, len);
     }
     bytesUsed = Math.addExact(bytesUsed, len);
+  }
+
+  /**
+   * Writes an int in little-endian byte order directly to the underlying slab,
+   * bypassing intermediate byte array decomposition. Slabs are set to
+   * {@link ByteOrder#LITTLE_ENDIAN} order so {@code putInt} produces the correct encoding.
+   *
+   * @param v the int value to write
+   */
+  public void writeInt(int v) {
+    if (currentSlab.remaining() < 4) {
+      addSlab(4);
+    }
+    currentSlab.putInt(v);
+    bytesUsed = Math.addExact(bytesUsed, 4);
+  }
+
+  /**
+   * Writes a long in little-endian byte order directly to the underlying slab.
+   *
+   * @param v the long value to write
+   */
+  public void writeLong(long v) {
+    if (currentSlab.remaining() < 8) {
+      addSlab(8);
+    }
+    currentSlab.putLong(v);
+    bytesUsed = Math.addExact(bytesUsed, 8);
   }
 
   private void writeToOutput(OutputStream out, ByteBuffer buf, int len) throws IOException {

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataOutputStream.java
@@ -24,8 +24,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Based on DataOutputStream but in little endian and without the String/char methods
+ * Based on DataOutputStream but in little endian and without the String/char methods.
+ *
+ * @deprecated As of release following the {@link CapacityByteArrayOutputStream#writeInt(int)}
+ *     and {@link CapacityByteArrayOutputStream#writeLong(long)} additions, this class is no
+ *     longer used by Parquet's own writers. Producers of PLAIN-encoded data should write
+ *     little-endian values directly into a {@link java.nio.ByteBuffer} configured with
+ *     {@link java.nio.ByteOrder#LITTLE_ENDIAN}, which compiles to a single intrinsic store on
+ *     little-endian architectures and avoids the per-call byte decomposition and virtual
+ *     dispatch performed here. This class is retained for binary compatibility and will be
+ *     removed in a future release.
  */
+@Deprecated
 public class LittleEndianDataOutputStream extends OutputStream {
 
   private static final Logger LOG = LoggerFactory.getLogger(LittleEndianDataOutputStream.class);

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataOutputStream.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/LittleEndianDataOutputStream.java
@@ -40,6 +40,7 @@ public class LittleEndianDataOutputStream extends OutputStream {
 
   private static final Logger LOG = LoggerFactory.getLogger(LittleEndianDataOutputStream.class);
   private final OutputStream out;
+  private byte writeBuffer[] = new byte[8];
 
   /**
    * Creates a new data output stream to write data to the specified
@@ -140,8 +141,9 @@ public class LittleEndianDataOutputStream extends OutputStream {
    * @see java.io.FilterOutputStream#out
    */
   public final void writeShort(int v) throws IOException {
-    out.write((v >>> 0) & 0xFF);
-    out.write((v >>> 8) & 0xFF);
+    writeBuffer[0] = (byte) (v >>> 0);
+    writeBuffer[1] = (byte) (v >>> 8);
+    out.write(writeBuffer, 0, 2);
   }
 
   /**
@@ -154,16 +156,12 @@ public class LittleEndianDataOutputStream extends OutputStream {
    * @see java.io.FilterOutputStream#out
    */
   public final void writeInt(int v) throws IOException {
-    // TODO: see note in LittleEndianDataInputStream: maybe faster
-    // to use Integer.reverseBytes() and then writeInt, or a ByteBuffer
-    // approach
-    out.write((v >>> 0) & 0xFF);
-    out.write((v >>> 8) & 0xFF);
-    out.write((v >>> 16) & 0xFF);
-    out.write((v >>> 24) & 0xFF);
+    writeBuffer[0] = (byte) (v >>> 0);
+    writeBuffer[1] = (byte) (v >>> 8);
+    writeBuffer[2] = (byte) (v >>> 16);
+    writeBuffer[3] = (byte) (v >>> 24);
+    out.write(writeBuffer, 0, 4);
   }
-
-  private byte writeBuffer[] = new byte[8];
 
   /**
    * Writes a <code>long</code> to the underlying output stream as eight


### PR DESCRIPTION
## Summary

Closes #3495. Also subsumes #3518 (closed; PR #3519 closed in favor of folding here).

Three-commit PR: optimize `PlainValuesWriter`, deprecate the now-unused `LittleEndianDataOutputStream` wrapper, and apply the long-standing bulk-write TODO inside that class for the benefit of any remaining external callers.

### Commit 1 — `PlainValuesWriter` direct ByteBuffer writes

Removes the `LittleEndianDataOutputStream` layer between `PlainValuesWriter` and `CapacityByteArrayOutputStream`. Adds `writeInt(int)`/`writeLong(long)` methods on CBOS that write directly to its internal `ByteBuffer` slabs (set to `LITTLE_ENDIAN`), making the value write a single HotSpot intrinsic instead of a 4-byte decomposition through a temp array and an `OutputStream` chain.

**`IntEncodingBenchmark.encodePlain`** (100k INT32 / invocation, JMH `-wi 5 -i 10 -f 2`):

| Pattern           | Before (ops/s) | After (ops/s) | Improvement |
|-------------------|---------------:|--------------:|:-----------:|
| SEQUENTIAL        |     20,944,860 |    53,231,121 | **+154%** (2.55x) |
| RANDOM            |     20,613,242 |    53,419,118 | **+160%** |
| LOW_CARDINALITY   |     20,749,103 |    53,510,247 | **+158%** |
| HIGH_CARDINALITY  |     20,521,786 |    52,825,012 | **+157%** |

The same code path is shared by `writeLong`, `writeFloat`, `writeDouble`, and the length prefix in `writeBytes(Binary)`, so PLAIN-encoded `INT64`/`FLOAT`/`DOUBLE`/`BINARY` columns benefit too. Decode benchmarks (`decodePlain` etc.) are unchanged, as expected.

### Commit 2 — Deprecate `LittleEndianDataOutputStream`, remove last wrapper usages

Pure API cleanup, **no measurable performance impact**. After commit 1, `FixedLenByteArrayPlainValuesWriter` and `DeltaLengthByteArrayValuesWriter` were the last two production usages of `LittleEndianDataOutputStream`. Both wrapped a `CapacityByteArrayOutputStream` only to call `Binary.writeTo(out)`, which goes through `OutputStream.write(byte[], int, int)` — the wrapper added nothing for that call. Removing the wrapper allows marking `LittleEndianDataOutputStream` as `@Deprecated` (kept for binary compatibility, scheduled for removal in a future major).

Benchmarks for the two touched paths (`BinaryEncodingBenchmark`, JMH `-wi 5 -i 10 -f 3`, 30 samples per row) are within ±5% with allocation rates per op unchanged within 2% — consistent with noise rather than a real effect either way. Rationale is code health (one fewer wrapper layer, deprecation of an internal-shaped public class), not performance. Full numbers are in the commit message.

### Commit 3 — Bulk write in `LittleEndianDataOutputStream.writeInt`/`writeShort`

Resolves the long-standing TODO in `writeInt` flagging per-byte writes as a potential improvement. Replaces 4 individual `out.write(int)` calls with a single `out.write(byte[], 0, 4)` using the existing `writeBuffer[]` field — matching the pattern already used by `writeLong`. Same change applied to `writeShort` (4 → 1 call collapses to 2 → 1).

Although commit 2 deprecates the class and no Parquet code path still uses it, this optimization is worth landing for any external Parquet-format producer still on the wrapper until they migrate to direct ByteBuffer writes. The change is ~10 lines and obviously correct (mirrors the existing `writeLong` pattern).

Benchmark (`IntEncodingBenchmark.encodePlain` routed through `LittleEndianDataOutputStream`):

| | Before (ops/s) | After (ops/s) | Improvement |
|---|---:|---:|:---:|
| writeInt path | ~20.9M | ~28.2M | **+35%** |

## Validation

- `parquet-column`: 573 tests pass
- `parquet-common`: 308 tests pass
- Built with `-Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true`

## Related

This is the second in a small series of focused performance PRs from work in https://github.com/iemejia/parquet-perf. The first was #3494.

## How to reproduce the benchmarks

The JMH benchmarks cited above are being added to `parquet-benchmarks` in #3512. Once that lands, reproduce with:

```
./mvnw clean package -pl parquet-benchmarks -DskipTests \
    -Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true
java -jar parquet-benchmarks/target/parquet-benchmarks.jar 'IntEncodingBenchmark.encodePlain' \
    -wi 5 -i 10 -f 3
```

Compare runs against `master` (baseline) and this branch (optimized).