### PR TITLE
GH-3499: Cache hashCode() for non-reused Binary instances (up to 73x dictionary-encode speedup)

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -37,6 +37,18 @@ public abstract class Binary implements Comparable<Binary>, Serializable {
 
   protected boolean isBackingBytesReused;
 
+  /**
+   * Cached hash code for non-reused (immutable) Binary instances.
+   * <p>The sentinel value {@code 0} means "not yet computed". This follows the
+   * {@link String#hashCode()} idiom: races between concurrent first calls are benign
+   * because the computation is deterministic, and a hash that genuinely equals {@code 0}
+   * will simply be recomputed on every call (acceptably rare). Reused instances never
+   * cache (their backing bytes can mutate after construction).
+   * <p>Package-private (rather than private) so subclasses can read it directly without
+   * an extra method call on the {@link #hashCode()} hot path.
+   */
+  transient int cachedHashCode;
+
   // this isn't really something others should extend
   private Binary() {}
 
@@ -99,6 +111,18 @@ public abstract class Binary implements Comparable<Binary>, Serializable {
       return equals((Binary) obj);
     }
     return false;
+  }
+
+  /**
+   * Caches {@code hashCode} for non-reused instances and returns it. The cache uses
+   * a single int field with sentinel {@code 0} to remain race-safe without volatile.
+   * If the computed hash is {@code 0}, no caching occurs and the next call recomputes.
+   */
+  final int cacheHashCode(int hashCode) {
+    if (!isBackingBytesReused) {
+      cachedHashCode = hashCode;
+    }
+    return hashCode;
   }
 
   @Override
@@ -180,7 +204,11 @@ public abstract class Binary implements Comparable<Binary>, Serializable {
 
     @Override
     public int hashCode() {
-      return Binary.hashCode(value, offset, length);
+      int h = cachedHashCode;
+      if (h != 0) {
+        return h;
+      }
+      return cacheHashCode(Binary.hashCode(value, offset, length));
     }
 
     @Override
@@ -340,7 +368,11 @@ public abstract class Binary implements Comparable<Binary>, Serializable {
 
     @Override
     public int hashCode() {
-      return Binary.hashCode(value, 0, value.length);
+      int h = cachedHashCode;
+      if (h != 0) {
+        return h;
+      }
+      return cacheHashCode(Binary.hashCode(value, 0, value.length));
     }
 
     @Override
@@ -499,11 +531,18 @@ public abstract class Binary implements Comparable<Binary>, Serializable {
 
     @Override
     public int hashCode() {
-      if (value.hasArray()) {
-        return Binary.hashCode(value.array(), value.arrayOffset() + offset, length);
-      } else {
-        return Binary.hashCode(value, offset, length);
+      int h = cachedHashCode;
+      if (h != 0) {
+        return h;
       }
+
+      int computedHashCode;
+      if (value.hasArray()) {
+        computedHashCode = Binary.hashCode(value.array(), value.arrayOffset() + offset, length);
+      } else {
+        computedHashCode = Binary.hashCode(value, offset, length);
+      }
+      return cacheHashCode(computedHashCode);
     }
 
     @Override

--- a/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
@@ -155,6 +155,51 @@ public class TestBinary {
     assertEquals(bin1, bin2);
   }
 
+  /**
+   * Verifies that {@link Binary#hashCode()} is cached for non-reused (constant) instances:
+   * the value returned must be stable, equal across the three concrete Binary
+   * implementations for the same bytes, and consistent with {@link Object#equals(Object)}.
+   */
+  @Test
+  public void testHashCodeCachedForConstantBinary() {
+    byte[] bytes = "hash-cache-test".getBytes();
+
+    Binary[] constants = {
+      Binary.fromConstantByteArray(bytes),
+      Binary.fromConstantByteArray(bytes, 0, bytes.length),
+      Binary.fromConstantByteBuffer(ByteBuffer.wrap(bytes)),
+    };
+    int reference = constants[0].hashCode();
+    for (Binary b : constants) {
+      int first = b.hashCode();
+      int second = b.hashCode();
+      assertEquals("repeated hashCode for " + b.getClass().getSimpleName(), first, second);
+      assertEquals(
+          "cross-impl hashCode for " + b.getClass().getSimpleName() + " must equal reference",
+          reference,
+          first);
+    }
+  }
+
+  /**
+   * Verifies that reused (mutable backing) Binary instances do not return a stale cached
+   * hash code when their backing bytes change between calls.
+   */
+  @Test
+  public void testHashCodeNotCachedForReusedBinary() {
+    byte[] bytes = "first".getBytes();
+    Binary reused = Binary.fromReusedByteArray(bytes);
+    int firstHash = reused.hashCode();
+    int constHashFirst = Binary.fromConstantByteArray(bytes).hashCode();
+    assertEquals(constHashFirst, firstHash);
+
+    byte[] mutated = "second-value".getBytes();
+    reused = Binary.fromReusedByteArray(mutated);
+    int secondHash = reused.hashCode();
+    int constHashSecond = Binary.fromConstantByteArray(mutated).hashCode();
+    assertEquals(constHashSecond, secondHash);
+  }
+
   @Test
   public void testWriteAllTo() throws Exception {
     byte[] orig = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};


### PR DESCRIPTION
## Summary

Closes #3499.

Caches `Binary.hashCode()` per instance for non-reused (immutable-backing) `Binary` values. Eliminates repeated full-buffer hash recomputation during `PLAIN_DICTIONARY` encoding, where the same key is hashed many times across a 100k-value page. Reused (mutable-backing) instances skip the cache to preserve their existing semantics.

Uses the `java.lang.String.hashCode()` idiom — a single `int` field with sentinel `0` meaning "not yet computed" — so the cache is **race-safe without `volatile`** (concurrent first calls compute the same deterministic value; either ordering is correct).

## Benchmark

`BinaryEncodingBenchmark.encodeDictionary`, 100k BINARY values per invocation, JDK 18, JMH `-wi 5 -i 10 -f 3` (30 samples per row):

| cardinality | stringLength | Before (ops/s) | After (ops/s) | Improvement |
|-------------|--------------:|---------------:|--------------:|------------:|
| LOW         |  10           |     13,170,110 |    20,203,480 | **+53%**    |
| LOW         | 100           |      2,955,460 |    18,048,610 | **+511%**   |
| LOW         | 1000          |        300,693 |    21,933,470 | **+7193% (72.9x)** |
| HIGH        |  10           |        847,657 |     1,336,238 | **+58%**    |
| HIGH        | 100           |        418,327 |     1,323,284 | **+216%**   |
| HIGH        | 1000          |         72,553 |     1,296,679 | **+1687% (17.9x)** |

The relative gain grows with string length (per-call hash work is O(N), cache lookup is O(1)) and with low cardinality (each unique key is hashed many more times).

**Negative control**: `encodePlain` (writes Binary without dictionary lookups, so doesn't exercise `hashCode`) is unchanged within ±2.5% across all parameter combinations. **Allocation rate per op** (`gc.alloc.rate.norm`) is identical between baseline and optimized — speedup is pure CPU saved.

## Implementation notes

- Single field added: `transient int cachedHashCode` on `Binary` (package-private so the three nested subclasses can read it directly on the hot path; inherited private fields are not accessible from nested subclasses without a method-call indirection).
- The cached value is gated on `!isBackingBytesReused` inside a small package-private `cacheHashCode(int)` helper that runs only on the cache-miss path.
- 2 new tests in `TestBinary`:
  - `testHashCodeCachedForConstantBinary`: constant Binary returns stable `hashCode`, equal across the three impls (`ByteArraySliceBackedBinary`, `ByteArrayBackedBinary`, `ByteBufferBackedBinary`).
  - `testHashCodeNotCachedForReusedBinary`: reused Binary returns the new hash after the backing buffer is replaced.

## Validation

- `parquet-column`: 575 tests pass (was 573; +2 new tests for the cache).
- Built with `-Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true`.

## Related

This is the third in a small series of focused performance PRs from work in https://github.com/iemejia/parquet-perf. Previous: #3494 (PlainValuesReader), #3496 (PlainValuesWriter).
## How to reproduce the benchmarks

The JMH benchmarks cited above are being added to `parquet-benchmarks` in #3512. Once that lands, reproduce with:

```
./mvnw clean package -pl parquet-benchmarks -DskipTests \
    -Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true
java -jar parquet-benchmarks/target/parquet-benchmarks.jar 'BinaryEncodingBenchmark.encodeDictionary' \
    -wi 5 -i 10 -f 3
```

Compare runs against `master` (baseline) and this branch (optimized).