### PR TITLE
GH-3501: Speed up `DictionaryValuesWriter.shouldFallBack()`

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/DictionaryValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/DictionaryValuesWriter.java
@@ -79,6 +79,10 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
   /* will become true if the dictionary becomes too big */
   protected boolean dictionaryTooBig;
 
+  /* set to true when the dictionary exceeds maxDictionaryByteSize or MAX_DICTIONARY_ENTRIES,
+   * checked by shouldFallBack() to avoid repeated virtual dispatch to getDictionarySize() on every write */
+  private boolean dictionarySizeExceeded;
+
   /* current size in bytes the dictionary will take once serialized */
   protected long dictionaryByteSize;
 
@@ -121,8 +125,20 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
 
   @Override
   public boolean shouldFallBack() {
-    // if the dictionary reaches the max byte size or the values can not be encoded on 4 bytes anymore.
-    return dictionaryByteSize > maxDictionaryByteSize || getDictionarySize() > MAX_DICTIONARY_ENTRIES;
+    return dictionarySizeExceeded;
+  }
+
+  /**
+   * Called by subclass write methods after adding a new dictionary entry to check if the dictionary
+   * has exceeded its size limits. This avoids the per-value virtual dispatch overhead of calling
+   * getDictionarySize() on every write -- the check only runs when a new entry is actually added.
+   *
+   * @param newDictionarySize the current dictionary size after adding the new entry
+   */
+  protected void checkDictionarySizeLimit(int newDictionarySize) {
+    if (dictionaryByteSize > maxDictionaryByteSize || newDictionarySize > MAX_DICTIONARY_ENTRIES) {
+      dictionarySizeExceeded = true;
+    }
   }
 
   @Override
@@ -208,6 +224,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
     lastUsedDictionaryByteSize = 0;
     lastUsedDictionarySize = 0;
     dictionaryTooBig = false;
+    dictionarySizeExceeded = false;
     clearDictionaryContent();
   }
 
@@ -250,6 +267,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
         binaryDictionaryContent.put(v.copy(), id);
         // length as int (4 bytes) + actual bytes
         dictionaryByteSize += 4L + v.length();
+        checkDictionarySizeLimit(id + 1);
       }
       encodedValues.add(id);
     }
@@ -320,6 +338,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
         id = binaryDictionaryContent.size();
         binaryDictionaryContent.put(value.copy(), id);
         dictionaryByteSize += length;
+        checkDictionarySizeLimit(id + 1);
       }
       encodedValues.add(id);
     }
@@ -364,6 +383,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
         id = longDictionaryContent.size();
         longDictionaryContent.put(v, id);
         dictionaryByteSize += 8;
+        checkDictionarySizeLimit(id + 1);
       }
       encodedValues.add(id);
     }
@@ -435,6 +455,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
         id = doubleDictionaryContent.size();
         doubleDictionaryContent.put(v, id);
         dictionaryByteSize += 8;
+        checkDictionarySizeLimit(id + 1);
       }
       encodedValues.add(id);
     }
@@ -506,6 +527,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
         id = intDictionaryContent.size();
         intDictionaryContent.put(v, id);
         dictionaryByteSize += 4;
+        checkDictionarySizeLimit(id + 1);
       }
       encodedValues.add(id);
     }
@@ -578,6 +600,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
         id = floatDictionaryContent.size();
         floatDictionaryContent.put(v, id);
         dictionaryByteSize += 4;
+        checkDictionarySizeLimit(id + 1);
       }
       encodedValues.add(id);
     }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/DictionaryValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/DictionaryValuesWriter.java
@@ -135,7 +135,7 @@ public abstract class DictionaryValuesWriter extends ValuesWriter implements Req
    *
    * @param newDictionarySize the current dictionary size after adding the new entry
    */
-  protected void checkDictionarySizeLimit(int newDictionarySize) {
+  void checkDictionarySizeLimit(int newDictionarySize) {
     if (dictionaryByteSize > maxDictionaryByteSize || newDictionarySize > MAX_DICTIONARY_ENTRIES) {
       dictionarySizeExceeded = true;
     }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
@@ -682,6 +682,29 @@ public class TestDictionary {
   }
 
   @Test
+  public void testCheckDictionarySizeLimitExceedsByEntryCount() {
+    // Use a large maxDictionaryByteSize so only the entry-count limit can trigger
+    int maxDictionaryByteSize = Integer.MAX_VALUE;
+    try (PlainIntegerDictionaryValuesWriter writer = new PlainIntegerDictionaryValuesWriter(
+        maxDictionaryByteSize, PLAIN_DICTIONARY, PLAIN_DICTIONARY, allocator)) {
+
+      assertFalse("should not fall back initially", writer.shouldFallBack());
+
+      // At the limit (Integer.MAX_VALUE - 1 entries): should NOT trigger
+      writer.checkDictionarySizeLimit(Integer.MAX_VALUE - 1);
+      assertFalse("should not fall back when entry count equals MAX_DICTIONARY_ENTRIES", writer.shouldFallBack());
+
+      // Exceeding the limit (Integer.MAX_VALUE entries): should trigger
+      writer.checkDictionarySizeLimit(Integer.MAX_VALUE);
+      assertTrue("should fall back when entry count exceeds MAX_DICTIONARY_ENTRIES", writer.shouldFallBack());
+
+      // resetDictionary clears the flag
+      writer.resetDictionary();
+      assertFalse("should not fall back after resetDictionary", writer.shouldFallBack());
+    }
+  }
+
+  @Test
   public void testBooleanDictionary() throws IOException {
     // Create a dictionary page with boolean values (false, true)
     // Bit-packed: bit 0 = false (0), bit 1 = true (1) => byte = 0b00000010 = 0x02


### PR DESCRIPTION
### Rationale for this change

`DictionaryValuesWriter.shouldFallBack()` is called by `FallbackValuesWriter.checkFallback()` after every single value write. The current implementation dispatches a virtual call to `getDictionarySize()` on every invocation, even for duplicate values that do not grow the dictionary. Both `dictionaryByteSize` and the dictionary entry count can only increase when a new entry is added (inside the `if (id == -1)` branch), so the size-exceeded condition can only transition from false to true at that exact point. The per-write virtual dispatch is redundant work for the common case.

### What changes are included in this PR?

Single file change to DictionaryValuesWriter.java:
- Add a private boolean `dictionarySizeExceeded` field, reset in `resetDictionary()`.
- Add a protected void `checkDictionarySizeLimit(int newDictionarySize)` method that sets the flag when `dictionaryByteSize > maxDictionaryByteSize || newDictionarySize > MAX_DICTIONARY_ENTRIES`.
- Each subclass write method (Binary, FixedLenArray, Long, Double, Integer, Float) calls `checkDictionarySizeLimit(id + 1)` after inserting a new dictionary entry.
- `shouldFallBack()` becomes return `dictionarySizeExceeded`, a simple field read with no virtual dispatch.

### Are these changes tested?

Yes. All existing tests in `TestDictionary` pass without modification, confirming semantic equivalence. The new test `testCheckDictionarySizeLimitExceedsByEntryCount` directly exercises the previously untested `MAX_DICTIONARY_ENTRIES` boundary in `checkDictionarySizeLimit`, verifying correct trigger and reset behavior.

### Are there any user-facing changes?

No. This is an internal optimization with no API, behavior, or configuration changes.

Closes #3501
