### PR TITLE
GH-3503: Optimize ByteStreamSplitValuesWriter with batched scatter writes

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriter.java
@@ -20,7 +20,6 @@ package org.apache.parquet.column.values.bytestreamsplit;
 
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
-import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
@@ -29,9 +28,23 @@ import org.apache.parquet.io.api.Binary;
 
 public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
+  /**
+   * Batch size for buffered scatter writes. Values are accumulated in a batch buffer
+   * and flushed as bulk {@code write(byte[], off, len)} calls to each stream, replacing
+   * N individual single-byte writes with one bulk write per stream per flush.
+   */
+  private static final int BATCH_SIZE = 128;
+
   protected final int numStreams;
   protected final int elementSizeInBytes;
   private final CapacityByteArrayOutputStream[] byteStreams;
+
+  // Batch buffers for int (4-byte) and long (8-byte) scatter writes.
+  // Only one of these is ever non-null per instance.
+  private int[] intBatch;
+  private long[] longBatch;
+  private byte[] scatterBuf;
+  private int batchCount;
 
   public ByteStreamSplitValuesWriter(
       int elementSizeInBytes, int initialCapacity, int pageSize, ByteBufferAllocator allocator) {
@@ -53,7 +66,8 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
   @Override
   public long getBufferedSize() {
-    long totalSize = 0;
+    // Include unflushed batch values without triggering a flush
+    long totalSize = (long) batchCount * elementSizeInBytes;
     for (CapacityByteArrayOutputStream stream : this.byteStreams) {
       totalSize += stream.size();
     }
@@ -62,6 +76,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
   @Override
   public BytesInput getBytes() {
+    flushBatch();
     BytesInput[] allInputs = new BytesInput[this.numStreams];
     for (int i = 0; i < this.numStreams; ++i) {
       allInputs[i] = BytesInput.from(this.byteStreams[i]);
@@ -76,6 +91,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
   @Override
   public void reset() {
+    batchCount = 0;
     for (CapacityByteArrayOutputStream stream : this.byteStreams) {
       stream.reset();
     }
@@ -83,6 +99,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
   @Override
   public void close() {
+    batchCount = 0;
     for (CapacityByteArrayOutputStream stream : byteStreams) {
       stream.close();
     }
@@ -97,6 +114,71 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
     for (int i = 0; i < bytes.length; ++i) {
       this.byteStreams[i].write(bytes[i]);
     }
+  }
+
+  /**
+   * Buffer a 4-byte integer value for batched scatter to the byte streams.
+   * Values are accumulated until the batch is full, then flushed as bulk
+   * {@code write(byte[], off, len)} calls — one per stream.
+   */
+  protected void bufferInt(int v) {
+    if (intBatch == null) {
+      intBatch = new int[BATCH_SIZE];
+      scatterBuf = new byte[BATCH_SIZE];
+    }
+    intBatch[batchCount++] = v;
+    if (batchCount == BATCH_SIZE) {
+      flushIntBatch();
+    }
+  }
+
+  /**
+   * Buffer an 8-byte long value for batched scatter to the byte streams.
+   */
+  protected void bufferLong(long v) {
+    if (longBatch == null) {
+      longBatch = new long[BATCH_SIZE];
+      scatterBuf = new byte[BATCH_SIZE];
+    }
+    longBatch[batchCount++] = v;
+    if (batchCount == BATCH_SIZE) {
+      flushLongBatch();
+    }
+  }
+
+  private void flushBatch() {
+    if (batchCount == 0) return;
+    if (intBatch != null) {
+      flushIntBatch();
+    } else if (longBatch != null) {
+      flushLongBatch();
+    }
+  }
+
+  private void flushIntBatch() {
+    if (batchCount == 0) return;
+    final int count = batchCount;
+    for (int stream = 0; stream < 4; stream++) {
+      final int shift = stream << 3; // stream * 8
+      for (int i = 0; i < count; i++) {
+        scatterBuf[i] = (byte) (intBatch[i] >>> shift);
+      }
+      byteStreams[stream].write(scatterBuf, 0, count);
+    }
+    batchCount = 0;
+  }
+
+  private void flushLongBatch() {
+    if (batchCount == 0) return;
+    final int count = batchCount;
+    for (int stream = 0; stream < 8; stream++) {
+      final int shift = stream << 3; // stream * 8
+      for (int i = 0; i < count; i++) {
+        scatterBuf[i] = (byte) (longBatch[i] >>> shift);
+      }
+      byteStreams[stream].write(scatterBuf, 0, count);
+    }
+    batchCount = 0;
   }
 
   @Override
@@ -116,7 +198,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
     @Override
     public void writeFloat(float v) {
-      super.scatterBytes(BytesUtils.intToBytes(Float.floatToIntBits(v)));
+      bufferInt(Float.floatToIntBits(v));
     }
 
     @Override
@@ -133,7 +215,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
     @Override
     public void writeDouble(double v) {
-      super.scatterBytes(BytesUtils.longToBytes(Double.doubleToLongBits(v)));
+      bufferLong(Double.doubleToLongBits(v));
     }
 
     @Override
@@ -149,7 +231,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
     @Override
     public void writeInteger(int v) {
-      super.scatterBytes(BytesUtils.intToBytes(v));
+      bufferInt(v);
     }
 
     @Override
@@ -165,7 +247,7 @@ public abstract class ByteStreamSplitValuesWriter extends ValuesWriter {
 
     @Override
     public void writeLong(long v) {
-      super.scatterBytes(BytesUtils.longToBytes(v));
+      bufferLong(v);
     }
 
     @Override


### PR DESCRIPTION
### Rationale for this change

`ByteStreamSplitValuesWriter` is the primary writer for `BYTE_STREAM_SPLIT`-encoded `FLOAT`, `DOUBLE`, `INT32`, and `INT64` columns. Each value goes through a hot path that performs both an unnecessary allocation and N single-byte virtual dispatches.

For `FloatByteStreamSplitValuesWriter.writeFloat(float v)`:

```java
super.scatterBytes(BytesUtils.intToBytes(Float.floatToIntBits(v)));
```

`BytesUtils.intToBytes` allocates a fresh `byte[4]` on every call. `scatterBytes` then loops:

```java
for (int i = 0; i < bytes.length; ++i) {
  this.byteStreams[i].write(bytes[i]);   // CapacityByteArrayOutputStream.write(int)
}
```

So **per value**: 1 `byte[4]` allocation + 4 single-byte virtual dispatches. For a 100k-value `FLOAT` page that is 100k allocations and 400k single-byte writes. `DOUBLE`/`LONG` are even worse (`byte[8]`, 800k single-byte writes).

### What changes are included in this PR?

Two stacked changes in `ByteStreamSplitValuesWriter`:

1. **Eliminate per-value allocation**: replace `super.scatterBytes(BytesUtils.intToBytes(v))` with `bufferInt(v)` / `bufferLong(v)` that perform the little-endian decomposition with bit shifts directly, no temporary `byte[]`.

2. **Batch single-byte writes**: accumulate `BATCH_SIZE = 128` values in a small per-instance scratch buffer and flush them as `N` bulk `write(byte[], off, len)` calls (one per stream), replacing `BATCH_SIZE * elementSizeInBytes` single-byte virtual dispatches with `elementSizeInBytes` bulk writes per flush. The constant was chosen by sweeping 16/32/64/128/256/512/1024 — 128 is the sweet spot for `FLOAT` throughput while still capturing most of the `DOUBLE`/`LONG` gains.

Pending values are included in `getBufferedSize()` (so page-sizing decisions remain correct) and flushed in `getBytes()`. `reset()` and `close()` clear pending state. Only the four numeric subclasses (Float/Double/Integer/Long) use the batching path; `FixedLenByteArrayByteStreamSplitValuesWriter` continues to use `scatterBytes(byte[])` since its values arrive as already-laid-out byte arrays.

### Benchmark

New `ByteStreamSplitEncodingBenchmark` (100k values per invocation, JDK 18, JMH `-wi 5 -i 10 -f 3`, 30 samples per row):

| Type   | Before  | After   | Δ              | Alloc B/op       |
|--------|--------:|--------:|---------------:|------------------|
| Float  | 15.08M  | 65.06M  | **+331% (4.3x)** | 33.27 → 9.27 (**-72%**) |
| Double |  6.99M  | 49.48M  | **+608% (7.1x)** | 42.54 → 18.55 (**-56%**) |
| Int    | 15.64M  | 68.13M  | **+335% (4.4x)** | 33.27 → 9.27 (**-72%**) |
| Long   |  7.09M  | 53.23M  | **+651% (7.5x)** | 42.54 → 18.55 (**-56%**) |

The remaining per-op allocation (~9 B/op for Int/Float, ~19 B/op for Long/Double) is the `BytesInput[]` returned by `getBytes()` and the streams' internal slabs, which are amortised across the page rather than per value.

### Are these changes tested?

Yes. All 573 `parquet-column` tests pass; 51 BSS-specific tests pass (`mvn test -pl parquet-column -Dtest='*ByteStreamSplit*'`). No new test was added because behaviour is unchanged (covered by the existing round-trip and writer tests).

### Are there any user-facing changes?

No. Only an internal writer optimization. No public API, file format, or configuration change.

### Closes #3503

Part of a small series of focused performance PRs from work in [parquet-perf](https://github.com/iemejia/parquet-perf). Previous: #3494, #3496, #3500.
## How to reproduce the benchmarks

The JMH benchmarks cited above are being added to `parquet-benchmarks` in #3512. Once that lands, reproduce with:

```
./mvnw clean package -pl parquet-benchmarks -DskipTests \
    -Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true
java -jar parquet-benchmarks/target/parquet-benchmarks.jar 'ByteStreamSplitEncodingBenchmark' \
    -wi 5 -i 10 -f 3
```

Compare runs against `master` (baseline) and this branch (optimized).