### PR TITLE
GH-3507: Reduce allocation overhead of no-op `GeospatialStatistics.Builder`

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/statistics/geospatial/GeospatialStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/statistics/geospatial/GeospatialStatistics.java
@@ -43,7 +43,7 @@ public class GeospatialStatistics {
   public static class Builder {
     private BoundingBox boundingBox;
     private GeospatialTypes geospatialTypes;
-    private final WKBReader reader = new WKBReader();
+    private WKBReader reader;
 
     /**
      * Create a builder to create a GeospatialStatistics.
@@ -51,6 +51,14 @@ public class GeospatialStatistics {
     public Builder() {
       this.boundingBox = new BoundingBox();
       this.geospatialTypes = new GeospatialTypes();
+      this.reader = new WKBReader();
+    }
+
+    /**
+     * Internal constructor that skips field initialization for subclasses that don't need it.
+     */
+    Builder(boolean noop) {
+      // Fields intentionally left null for NoopBuilder
     }
 
     public void update(Binary value) {
@@ -183,13 +191,19 @@ public class GeospatialStatistics {
   /**
    * Creates a no-op geospatial statistics builder that collects no data.
    * Used when geospatial statistics collection is disabled.
+   * This is a singleton since all methods are no-ops and it carries no state.
    */
   private static class NoopBuilder extends Builder {
-    private NoopBuilder() {}
+    private static final NoopBuilder INSTANCE = new NoopBuilder();
+    private static final GeospatialStatistics EMPTY = new GeospatialStatistics(null, null);
+
+    private NoopBuilder() {
+      super(true);
+    }
 
     @Override
     public GeospatialStatistics build() {
-      return new GeospatialStatistics(null, null);
+      return EMPTY;
     }
 
     @Override
@@ -207,6 +221,6 @@ public class GeospatialStatistics {
    * Creates a builder that doesn't collect any statistics.
    */
   public static Builder noopBuilder() {
-    return new NoopBuilder();
+    return NoopBuilder.INSTANCE;
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/geospatial/TestGeospatialStatistics.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/geospatial/TestGeospatialStatistics.java
@@ -169,4 +169,30 @@ public class TestGeospatialStatistics {
     GeospatialStatistics statistics = builder.build();
     Assert.assertFalse(statistics.isValid());
   }
+
+  @Test
+  public void testNoopBuilderIsSingleton() {
+    GeospatialStatistics.Builder builder1 = GeospatialStatistics.noopBuilder();
+    GeospatialStatistics.Builder builder2 = GeospatialStatistics.noopBuilder();
+    Assert.assertSame("noopBuilder() should return the same instance", builder1, builder2);
+    Assert.assertSame("build() should return the same instance", builder1.build(), builder2.build());
+  }
+
+  @Test
+  public void testNoopBuilderUpdateAndAbortAreNoOps() {
+    GeospatialStatistics.Builder builder = GeospatialStatistics.noopBuilder();
+
+    // update with non-null value should not throw
+    builder.update(Binary.fromConstantByteArray(new byte[] {0x01, 0x02, 0x03}));
+    // update with null should not throw
+    builder.update(null);
+    // abort should not throw
+    builder.abort();
+
+    // builder still produces an invalid (empty) result
+    GeospatialStatistics statistics = builder.build();
+    Assert.assertFalse(statistics.isValid());
+    Assert.assertNull(statistics.getBoundingBox());
+    Assert.assertNull(statistics.getGeospatialTypes());
+  }
 }


### PR DESCRIPTION
### Rationale for this change

`GeospatialStatistics.noopBuilder()` is called for every non-geometry column in every row group. Each call allocates a new `NoopBuilder` along with a `WKBReader`, `BoundingBox`, and `GeospatialTypes` that are never used. Each subsequent `build()` allocates a new `GeospatialStatistics(null, null)` that is equally throwaway. On wide schemas with many columns, this creates unnecessary GC pressure on the write path.

### What changes are included in this PR?

- Make `NoopBuilder` a singleton via a static `INSTANCE` field returned by `noopBuilder()`
- Cache the `build()` result as a static `EMPTY` instance, since it is stateless (null fields, with merge/abort guarded by null checks)
- Add a package-private `Builder(boolean)` constructor that skips field initialization so the singleton does not allocate unused `WKBReader`, `BoundingBox`, and `GeospatialTypes` objects
- Move `WKBReader` initialization from the field declaration into the public `Builder()` constructor, so only real builders pay the cost

### Are these changes tested?

Yes. Two new tests were added to `TestGeospatialStatistics`:
- `testNoopBuilderIsSingleton`: verifies `noopBuilder()` returns the same builder instance and `build()` returns the same cached result
- `testNoopBuilderUpdateAndAbortAreNoOps`: exercises `update(nonNull)`, `update(null)`, and `abort()` on the noop builder to confirm none throw, and asserts the built result remains invalid with null fields

### Are there any user-facing changes?

No. This is an internal optimization with no API or behavioral changes.

Closes #3507
