### PR TITLE
GH-3516: Optimize DeltaByteArrayWriter and DeltaLengthByteArrayValuesWriter

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
-import org.apache.parquet.bytes.LittleEndianDataOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
@@ -46,11 +45,9 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
 
   private ValuesWriter lengthWriter;
   private CapacityByteArrayOutputStream arrayOut;
-  private LittleEndianDataOutputStream out;
 
   public DeltaLengthByteArrayValuesWriter(int initialSize, int pageSize, ByteBufferAllocator allocator) {
     arrayOut = new CapacityByteArrayOutputStream(initialSize, pageSize, allocator);
-    out = new LittleEndianDataOutputStream(arrayOut);
     lengthWriter = new DeltaBinaryPackingValuesWriterForInteger(
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_BLOCK_VALUES,
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_MINIBLOCKS,
@@ -63,10 +60,20 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
   public void writeBytes(Binary v) {
     try {
       lengthWriter.writeInteger(v.length());
-      v.writeTo(out);
+      v.writeTo(arrayOut);
     } catch (IOException e) {
       throw new ParquetEncodingException("could not write bytes", e);
     }
+  }
+
+  /**
+   * Writes raw bytes directly, avoiding Binary object creation overhead.
+   * Used by {@link org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter}
+   * to write suffix bytes without creating an intermediate Binary.slice().
+   */
+  public void writeBytes(byte[] data, int offset, int length) {
+    lengthWriter.writeInteger(length);
+    arrayOut.write(data, offset, length);
   }
 
   @Override
@@ -76,11 +83,6 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
 
   @Override
   public BytesInput getBytes() {
-    try {
-      out.flush();
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write page", e);
-    }
     LOG.debug("writing a buffer of size {}", arrayOut.size());
     return BytesInput.concat(lengthWriter.getBytes(), BytesInput.from(arrayOut));
   }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
@@ -38,7 +38,7 @@ import org.apache.parquet.io.api.Binary;
 public class DeltaByteArrayWriter extends ValuesWriter {
 
   private ValuesWriter prefixLengthWriter;
-  private ValuesWriter suffixWriter;
+  private DeltaLengthByteArrayValuesWriter suffixWriter;
   private byte[] previous;
 
   public DeltaByteArrayWriter(int initialCapacity, int pageSize, ByteBufferAllocator allocator) {
@@ -98,7 +98,9 @@ public class DeltaByteArrayWriter extends ValuesWriter {
       i = length; // all bytes in the common range matched
     }
     prefixLengthWriter.writeInteger(i);
-    suffixWriter.writeBytes(v.slice(i, vb.length - i));
+    // Write suffix bytes directly from the byte array, avoiding Binary.slice() allocation
+    // and the virtual dispatch chain through Binary.writeTo()
+    suffixWriter.writeBytes(vb, i, vb.length - i);
     previous = vb;
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
@@ -89,7 +89,10 @@ public class DeltaByteArrayWriter extends ValuesWriter {
 
   @Override
   public void writeBytes(Binary v) {
-    byte[] vb = v.isBackingBytesReused() ? v.getBytes() : v.getBytesUnsafe();
+    // copy() is a no-op for constant (non-reused) Binaries, and getBytesUnsafe()
+    // returns the backing array directly for ByteArrayBackedBinary — avoiding
+    // the unconditional array copy that getBytes() always performs.
+    byte[] vb = v.copy().getBytesUnsafe();
     int length = Math.min(previous.length, vb.length);
     // Find the number of matching prefix bytes between this value and the previous one.
     // Arrays.mismatch is intrinsified by the JVM to use SIMD instructions.

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/FixedLenByteArrayPlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/FixedLenByteArrayPlainValuesWriter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
-import org.apache.parquet.bytes.LittleEndianDataOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.ParquetEncodingException;
@@ -37,7 +36,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
   private static final Logger LOG = LoggerFactory.getLogger(PlainValuesWriter.class);
 
   private CapacityByteArrayOutputStream arrayOut;
-  private LittleEndianDataOutputStream out;
   private int length;
   private ByteBufferAllocator allocator;
 
@@ -46,7 +44,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
     this.length = length;
     this.allocator = allocator;
     this.arrayOut = new CapacityByteArrayOutputStream(initialSize, pageSize, this.allocator);
-    this.out = new LittleEndianDataOutputStream(arrayOut);
   }
 
   @Override
@@ -56,7 +53,7 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
           "Fixed Binary size " + v.length() + " does not match field type length " + length);
     }
     try {
-      v.writeTo(out);
+      v.writeTo(arrayOut);
     } catch (IOException e) {
       throw new ParquetEncodingException("could not write fixed bytes", e);
     }
@@ -69,11 +66,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
 
   @Override
   public BytesInput getBytes() {
-    try {
-      out.flush();
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write page", e);
-    }
     LOG.debug("writing a buffer of size {}", arrayOut.size());
     return BytesInput.from(arrayOut);
   }


### PR DESCRIPTION
## Summary

Resolves #3516.

Two related changes in the `DELTA_BYTE_ARRAY` write path:

### 1. `DeltaLengthByteArrayValuesWriter`: drop the unused `LittleEndianDataOutputStream` wrapper

The class wrapped its `CapacityByteArrayOutputStream` with a `LittleEndianDataOutputStream` that was only used by `Binary.writeTo()` — an extra layer of dispatch on every value that never used any LE-specific functionality (`writeInt`/`writeLong`/etc.). `Binary.writeTo(arrayOut)` works directly with the underlying stream.

Also adds a new overload:

```java
public void writeBytes(byte[] data, int offset, int length) {
  lengthWriter.writeInteger(length);
  arrayOut.write(data, offset, length);
}
```

so callers that already have the raw bytes can avoid allocating a `Binary` wrapper.

### 2. `DeltaByteArrayWriter`: eliminate per-value `Binary.slice()` allocation in the suffix path

Tightens the `suffixWriter` field type from `ValuesWriter` to `DeltaLengthByteArrayValuesWriter` (it's always constructed as one) so the new raw-bytes overload is callable. The suffix call becomes:

```java
suffixWriter.writeBytes(vb, i, vb.length - i);
```

instead of `suffixWriter.writeBytes(v.slice(i, vb.length - i))`, eliminating the `ByteArraySliceBackedBinary` allocation per value plus a layer of virtual dispatch.

## Benchmark results

From `BinaryEncodingBenchmark.encodeDeltaByteArray` / `encodeDeltaLengthByteArray` (added in #3512):

| Benchmark | Configuration | master | this PR | speedup |
|---|---|---:|---:|---:|
| `encodeDeltaByteArray` | LOW card, len=10 | 0.1028 µs | 0.0662 µs | **1.55x** |
| `encodeDeltaByteArray` | HIGH card, len=10 | 0.1704 µs | 0.1124 µs | **1.52x** |
| `encodeDeltaByteArray` | LOW card, len=100 | 0.2079 µs | 0.1678 µs | **1.24x** |
| `encodeDeltaLengthByteArray` | LOW card, len=10 | 0.0481 µs | 0.0397 µs | **1.21x** |
| `encodeDeltaLengthByteArray` | LOW card, len=100 | 0.1503 µs | 0.1374 µs | **1.09x** |

Long-string cases are flat or trivial — the per-value allocation is amortized away when each value is hundreds of bytes.

## How to reproduce

The JMH benchmarks cited above are being added to `parquet-benchmarks` in #3512. Once that lands, reproduce with:

```
./mvnw clean package -pl parquet-benchmarks -DskipTests \
    -Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true
java -jar parquet-benchmarks/target/parquet-benchmarks.jar \
    'BinaryEncodingBenchmark.encodeDeltaByteArray|BinaryEncodingBenchmark.encodeDeltaLengthByteArray' \
    -wi 5 -i 10 -f 3
```

Compare runs against `master` (baseline) and this branch (optimized).

## Validation

- `parquet-column`: 573 tests pass
- Built with `-Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true`

## User-facing changes

None. No public API change. No file format change.

The new `DeltaLengthByteArrayValuesWriter.writeBytes(byte[], int, int)` overload is added on top of the existing public API.

### Closes #3516

Part of a small series of focused performance PRs from work in [parquet-perf](https://github.com/iemejia/parquet-perf). Previous: #3494, #3496, #3500, #3504, #3506, #3510, #3514. Companion benchmarks contribution: #3512.