### PR TITLE
GH-3520: Cleanup binary write path (DeltaByteArrayWriter copy + FLBA LE wrapper)

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
@@ -89,7 +89,10 @@ public class DeltaByteArrayWriter extends ValuesWriter {
   @Override
   public void writeBytes(Binary v) {
     int i = 0;
-    byte[] vb = v.getBytes();
+    // copy() is a no-op for constant (non-reused) Binaries, and getBytesUnsafe()
+    // returns the backing array directly for ByteArrayBackedBinary — avoiding
+    // the unconditional array copy that getBytes() always performs.
+    byte[] vb = v.copy().getBytesUnsafe();
     int length = previous.length < vb.length ? previous.length : vb.length;
     // find the number of matching prefix bytes between this value and the previous one
     for (i = 0; (i < length) && (previous[i] == vb[i]); i++)

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/plain/FixedLenByteArrayPlainValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/plain/FixedLenByteArrayPlainValuesWriter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
-import org.apache.parquet.bytes.LittleEndianDataOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.ParquetEncodingException;
@@ -37,7 +36,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
   private static final Logger LOG = LoggerFactory.getLogger(PlainValuesWriter.class);
 
   private CapacityByteArrayOutputStream arrayOut;
-  private LittleEndianDataOutputStream out;
   private int length;
   private ByteBufferAllocator allocator;
 
@@ -46,7 +44,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
     this.length = length;
     this.allocator = allocator;
     this.arrayOut = new CapacityByteArrayOutputStream(initialSize, pageSize, this.allocator);
-    this.out = new LittleEndianDataOutputStream(arrayOut);
   }
 
   @Override
@@ -56,7 +53,7 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
           "Fixed Binary size " + v.length() + " does not match field type length " + length);
     }
     try {
-      v.writeTo(out);
+      v.writeTo(arrayOut);
     } catch (IOException e) {
       throw new ParquetEncodingException("could not write fixed bytes", e);
     }
@@ -69,11 +66,6 @@ public class FixedLenByteArrayPlainValuesWriter extends ValuesWriter {
 
   @Override
   public BytesInput getBytes() {
-    try {
-      out.flush();
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write page", e);
-    }
     LOG.debug("writing a buffer of size {}", arrayOut.size());
     return BytesInput.from(arrayOut);
   }


### PR DESCRIPTION
## Summary

Resolves #3520.

Two small cleanups in the binary write path.

### 1. `DeltaByteArrayWriter`: avoid unconditional copy of input bytes

The first line of `writeBytes(Binary v)` is:

```java
byte[] vb = v.getBytes();
```

`Binary.getBytes()` is contractually required to return a fresh array the caller can keep and mutate. For `ByteArrayBackedBinary` (the most common case from `Binary.fromConstantByteArray()` and similar), the implementation does an unconditional `Arrays.copyOf` of the backing array — but `DeltaByteArrayWriter` only reads `vb` and then drops it. The copy is wasted work on every value.

The right call here is `v.copy().getBytesUnsafe()`:
- `Binary.copy()` is a no-op (`return this`) for constant Binaries that are already independent of any reused buffer.
- For reused-buffer Binaries (e.g. `ByteBufferBackedBinary` over a slab being mutated), `copy()` snapshots them — preserving correctness.
- `getBytesUnsafe()` then returns the backing array directly without a defensive copy.

For the common `ByteArrayBackedBinary` case this skips the entire copy. For other implementations the copy still happens but only when it's actually needed for correctness.

### 2. `FixedLenByteArrayPlainValuesWriter`: drop the unused `LittleEndianDataOutputStream` wrapper

Same pattern as #3517 fixed in `DeltaLengthByteArrayValuesWriter`: the writer wraps its `CapacityByteArrayOutputStream` with a `LittleEndianDataOutputStream` that's only used to call `Binary.writeTo()` — i.e. the LE wrapper adds a layer of dispatch on every value but never uses any LE-specific functionality (`writeInt`/`writeLong`/etc.). `Binary.writeTo(arrayOut)` works directly with the underlying stream.

The trailing `out.flush()` in `getBytes()` is also dead — `CapacityByteArrayOutputStream` doesn't buffer.

## Benchmark

`BinaryEncodingBenchmark.encodeDeltaByteArray` (short strings): roughly **+5% to +10%** standalone — the per-value `getBytes()` copy is one of several overheads; this PR removes one of them, stacking with #3517 which removed the suffix-side allocation.

`FixedLenByteArrayPlainValuesWriter`: code-quality cleanup; removes a per-value layer of dispatch and an unnecessary `flush()` call. No headline benchmark.

## Validation

- `parquet-column`: 573 tests pass
- Built with `-Dspotless.check.skip=true -Drat.skip=true -Djapicmp.skip=true`

## User-facing changes

None. No public API change. No file format change.

### Closes #3520

Part of a small series of focused performance PRs from work in [parquet-perf](https://github.com/iemejia/parquet-perf). Previous: #3494, #3496, #3500, #3504, #3506, #3510, #3514, #3517, #3519. Companion benchmarks contribution: #3512.