### PR TITLE
GH-3522: Optimize IntList.size() from O(slabs) to O(1) with running counter

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/IntList.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/IntList.java
@@ -99,6 +99,7 @@ public class IntList {
   // not be added
   private int[] currentSlab;
   private int currentSlabPos;
+  private int totalSize;
 
   private void allocateSlab() {
     currentSlab = new int[currentSlabSize];
@@ -129,6 +130,7 @@ public class IntList {
 
     currentSlab[currentSlabPos] = i;
     ++currentSlabPos;
+    ++totalSize;
   }
 
   /**
@@ -150,11 +152,6 @@ public class IntList {
    * @return the current size of the list
    */
   public int size() {
-    int size = currentSlabPos;
-    for (int[] slab : slabs) {
-      size += slab.length;
-    }
-
-    return size;
+    return totalSize;
   }
 }


### PR DESCRIPTION
## Summary

- Replace `IntList.size()` slab-iteration with a simple `totalSize` counter incremented on each `add()`
- Eliminates O(slabs) overhead from dictionary encoding hot paths where `size()` is called frequently

## Details

`IntList.size()` was iterating over all slabs to sum their lengths on every call. For delta encoding writers that check size thresholds frequently, this becomes O(slabs) per check. With a running counter it's O(1).

The improvement is primarily relevant for large row groups where the number of slabs grows.

All 576 parquet-column tests pass.