### PR TITLE
GH-3522: Eliminate unnecessary page-size copies in compressed page assembly and CRC checksums

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -608,12 +608,42 @@ public abstract class BytesInput {
 
     @Override
     void writeInto(ByteBuffer buffer) {
-      buffer.put(arrayOut.toByteArray());
+      // Use writeTo() which writes directly from the internal buf[] array,
+      // avoiding the toByteArray() copy that would allocate a full-size byte[]
+      try {
+        arrayOut.writeTo(new ByteBufferBackedOutputStream(buffer));
+      } catch (IOException e) {
+        // ByteBufferBackedOutputStream does not throw IOException
+        throw new RuntimeException("Unexpected IOException writing to ByteBuffer", e);
+      }
     }
 
     @Override
     public long size() {
       return arrayOut.size();
+    }
+  }
+
+  /**
+   * Thin adapter that allows writing to a {@link ByteBuffer} via the {@link OutputStream} interface.
+   * Used by {@link BAOSBytesInput#writeInto(ByteBuffer)} to avoid the intermediate copy from
+   * {@link ByteArrayOutputStream#toByteArray()}.
+   */
+  private static class ByteBufferBackedOutputStream extends OutputStream {
+    private final ByteBuffer buffer;
+
+    ByteBufferBackedOutputStream(ByteBuffer buffer) {
+      this.buffer = buffer;
+    }
+
+    @Override
+    public void write(int b) {
+      buffer.put((byte) b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+      buffer.put(b, off, len);
     }
   }
 

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageWriteStore.java
@@ -20,6 +20,7 @@ package org.apache.parquet.hadoop;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -98,6 +99,28 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
 
     private final CRC32 crc;
     boolean pageWriteChecksumEnabled;
+
+    /**
+     * OutputStream adapter that feeds bytes directly to a CRC32 checksum.
+     * Used to compute CRC from BytesInput without the intermediate toByteArray() copy.
+     */
+    private static final class CRC32OutputStream extends OutputStream {
+      private final CRC32 crc;
+
+      CRC32OutputStream(CRC32 crc) {
+        this.crc = crc;
+      }
+
+      @Override
+      public void write(int b) {
+        crc.update(b);
+      }
+
+      @Override
+      public void write(byte[] b, int off, int len) {
+        crc.update(b, off, len);
+      }
+    }
 
     private final BlockCipher.Encryptor headerBlockEncryptor;
     private final BlockCipher.Encryptor pageBlockEncryptor;
@@ -217,7 +240,7 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       }
       if (pageWriteChecksumEnabled) {
         crc.reset();
-        crc.update(compressedBytes.toByteArray());
+        compressedBytes.writeAllTo(new CRC32OutputStream(crc));
         parquetMetadataConverter.writeDataPageV1Header(
             (int) uncompressedSize,
             (int) compressedSize,
@@ -321,14 +344,15 @@ public class ColumnChunkPageWriteStore implements PageWriteStore, BloomFilterWri
       }
       if (pageWriteChecksumEnabled) {
         crc.reset();
+        CRC32OutputStream crcOut = new CRC32OutputStream(crc);
         if (repetitionLevels.size() > 0) {
-          crc.update(repetitionLevels.toByteArray());
+          repetitionLevels.writeAllTo(crcOut);
         }
         if (definitionLevels.size() > 0) {
-          crc.update(definitionLevels.toByteArray());
+          definitionLevels.writeAllTo(crcOut);
         }
         if (compressedData.size() > 0) {
-          crc.update(compressedData.toByteArray());
+          compressedData.writeAllTo(crcOut);
         }
         parquetMetadataConverter.writeDataPageV2Header(
             uncompressedSize,


### PR DESCRIPTION
## Summary

- Eliminate full-page `toByteArray()` copy in `BAOSBytesInput.writeInto(ByteBuffer)` by streaming through a `ByteBufferBackedOutputStream` adapter
- Eliminate full-page `toByteArray()` copy in CRC32 checksum computation by streaming through a `CRC32OutputStream` adapter

## Details

Two sources of unnecessary full-page-size `byte[]` allocations:

1. `BAOSBytesInput.writeInto(ByteBuffer)` called `toByteArray()` which copies the entire internal buffer. Replace with `writeTo()` using a thin `ByteBufferBackedOutputStream` adapter that writes directly from the internal `buf[]` without allocation.

2. CRC32 checksum computation in `ColumnChunkPageWriteStore` called `toByteArray()` on each `BytesInput` to pass to `crc.update(byte[])`. Replace with `writeAllTo(CRC32OutputStream)` that streams bytes directly to `crc.update()` without intermediate copies.

For a typical 1MB page, this eliminates 1-3 full-page allocations per page during write (one per CRC computation + one for the ByteBuffer assembly). The benefit is reduced GC pressure and peak memory rather than steady-state throughput.

All TestBytesInput tests pass. Compiles clean.