### PR TITLE
GH-3545: Use parquet-java in SCM block

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
   <description>Parquet is a columnar storage format that supports nested data. This provides the java implementation.</description>
 
   <scm>
-    <connection>scm:git:git@github.com:apache/parquet-mr.git</connection>
-    <url>scm:git:git@github.com:apache/parquet-mr.git</url>
-    <developerConnection>scm:git:git@github.com:apache/parquet-mr.git</developerConnection>
+    <connection>scm:git:git@github.com:apache/parquet-java.git</connection>
+    <url>scm:git:git@github.com:apache/parquet-java.git</url>
+    <developerConnection>scm:git:git@github.com:apache/parquet-java.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION

### Rationale for this change
The repository was renamed from apache/parquet-mr to apache/parquet-java but the SCM block was never updated. Everything has been working because Github maintains the redirect from one url to the other but it's probably better that we don't rely on the redirect.

I noticed this while I was prototyping some release automation.


### What changes are included in this PR?
The parquet-mr is replaced with parquet-java

### Are these changes tested?
Checked that mvn validate still works and it does.

### Are there any user-facing changes?
No

Closes #3545
