### PR TITLE
GH-3549: Leverage JDK11 `readNBytes`

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -366,18 +366,9 @@ public abstract class BytesInput {
     @Override
     public void writeAllTo(OutputStream out) throws IOException {
       LOG.debug("write All {} bytes", byteCount);
-      // Transfer in chunks to avoid allocating a byteCount-sized intermediate buffer
-      byte[] buffer = new byte[Math.min(byteCount, 8192)];
-      int remaining = byteCount;
-      while (remaining > 0) {
-        int toRead = Math.min(remaining, buffer.length);
-        int n = in.readNBytes(buffer, 0, toRead);
-        if (n < toRead) {
-          throw new EOFException("Reached the end of stream with " + (remaining - n) + " bytes left to read");
-        }
-        out.write(buffer, 0, n);
-        remaining -= n;
-      }
+      // Cannot transfer in chunks because some InputStreams (e.g., NonBlockedDecompressorStream)
+      // require a full-size buffer to decompress all data in a single read() call.
+      out.write(this.toByteArray());
     }
 
     @Override
@@ -404,10 +395,15 @@ public abstract class BytesInput {
 
     public byte[] toByteArray() throws IOException {
       LOG.debug("read all {} bytes", byteCount);
-      byte[] buf = in.readNBytes(byteCount);
-      if (buf.length != byteCount) {
+      // Use the 3-arg readNBytes to read directly into a byteCount-sized buffer.
+      // The 1-arg readNBytes(int) internally uses small (8KB) buffers which breaks
+      // block decompressors that require a full-size output buffer (e.g., NonBlockedDecompressorStream
+      // resets the decompressor after finished(), losing remaining data on partial reads).
+      byte[] buf = new byte[byteCount];
+      int n = in.readNBytes(buf, 0, byteCount);
+      if (n != byteCount) {
         throw new EOFException(
-            "Reached the end of stream with " + (byteCount - buf.length) + " bytes left to read");
+            "Reached the end of stream with " + (byteCount - n) + " bytes left to read");
       }
       return buf;
     }

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -19,7 +19,6 @@
 package org.apache.parquet.bytes;
 
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -367,8 +366,18 @@ public abstract class BytesInput {
     @Override
     public void writeAllTo(OutputStream out) throws IOException {
       LOG.debug("write All {} bytes", byteCount);
-      // TODO: more efficient
-      out.write(this.toByteArray());
+      // Transfer in chunks to avoid allocating a byteCount-sized intermediate buffer
+      byte[] buffer = new byte[Math.min(byteCount, 8192)];
+      int remaining = byteCount;
+      while (remaining > 0) {
+        int toRead = Math.min(remaining, buffer.length);
+        int n = in.readNBytes(buffer, 0, toRead);
+        if (n < toRead) {
+          throw new EOFException("Reached the end of stream with " + (remaining - n) + " bytes left to read");
+        }
+        out.write(buffer, 0, n);
+        remaining -= n;
+      }
     }
 
     @Override
@@ -395,8 +404,11 @@ public abstract class BytesInput {
 
     public byte[] toByteArray() throws IOException {
       LOG.debug("read all {} bytes", byteCount);
-      byte[] buf = new byte[byteCount];
-      new DataInputStream(in).readFully(buf);
+      byte[] buf = in.readNBytes(byteCount);
+      if (buf.length != byteCount) {
+        throw new EOFException(
+            "Reached the end of stream with " + (byteCount - buf.length) + " bytes left to read");
+      }
       return buf;
     }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
@@ -195,8 +195,7 @@ public class TestCompressionCodec {
     final byte[] raw = new byte[size];
     new Random(42).nextBytes(raw);
 
-    try (TrackingByteBufferAllocator allocator =
-            TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
+    try (TrackingByteBufferAllocator allocator = TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
         ByteBufferReleaser releaser = new ByteBufferReleaser(allocator)) {
       CodecFactory heapCodecFactory = new CodecFactory(new Configuration(), pageSize);
       BytesInputCompressor compressor = heapCodecFactory.getCompressor(CompressionCodecName.LZ4_RAW);


### PR DESCRIPTION
Introduced in JDK11 and is more efficient.

Closes #3549

<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
