### PR TITLE
MINOR: Fix Spotless formatting in TestCompressionCodec

### DIFF
--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
@@ -195,8 +195,7 @@ public class TestCompressionCodec {
     final byte[] raw = new byte[size];
     new Random(42).nextBytes(raw);
 
-    try (TrackingByteBufferAllocator allocator =
-            TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
+    try (TrackingByteBufferAllocator allocator = TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
         ByteBufferReleaser releaser = new ByteBufferReleaser(allocator)) {
       CodecFactory heapCodecFactory = new CodecFactory(new Configuration(), pageSize);
       BytesInputCompressor compressor = heapCodecFactory.getCompressor(CompressionCodecName.LZ4_RAW);


### PR DESCRIPTION
## Summary

Master CI (Hadoop 3) has been red since #3486 landed because `parquet-hadoop`'s spotless:check is flagging `TestCompressionCodec.testLz4RawHeapDecompressorCanCopyLargePage`:

```
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.46.1:check (default) on project parquet-hadoop: The following files had format violations:
[ERROR]     src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
[ERROR]         @@ -195,8 +195,7 @@
...
[ERROR]         -    try (TrackingByteBufferAllocator allocator =
[ERROR]         -            TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
[ERROR]         +    try (TrackingByteBufferAllocator allocator = TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
```

This PR is just the output of `mvn spotless:apply` for that one line so the build can go green again.

## Test plan

- [x] `./mvnw spotless:check` passes locally across all modules with JDK 17