### PR TITLE
GH-3354: Override LocalInputFile.toString to return the path

### DIFF
--- a/parquet-common/src/main/java/org/apache/parquet/io/LocalInputFile.java
+++ b/parquet-common/src/main/java/org/apache/parquet/io/LocalInputFile.java
@@ -99,4 +99,9 @@ public class LocalInputFile implements InputFile {
       }
     };
   }
+
+  @Override
+  public String toString() {
+    return path.toString();
+  }
 }

--- a/parquet-common/src/test/java/org/apache/parquet/io/TestLocalInputOutput.java
+++ b/parquet-common/src/test/java/org/apache/parquet/io/TestLocalInputOutput.java
@@ -48,6 +48,17 @@ public class TestLocalInputOutput {
   }
 
   @Test
+  public void inputFileToStringReturnsPath() throws IOException {
+    Path path = Paths.get(createTempFile().getPath());
+    InputFile read = new LocalInputFile(path);
+    // toString() is used by ParquetFileReader when constructing error messages
+    // such as "<path> is not a Parquet file (length is too low: ...)". A
+    // path-bearing toString() keeps those error messages actionable for
+    // implementations that don't expose a more specific accessor.
+    assertEquals(path.toString(), read.toString());
+  }
+
+  @Test
   public void outputFileCreateFailsAsFileAlreadyExists() throws IOException {
     Path path = Paths.get(createTempFile().getPath());
     OutputFile write = new LocalOutputFile(path);


### PR DESCRIPTION
### Rationale for this change

When a non-Parquet file is opened through `LocalInputFile`, `ParquetFileReader.readFooter` builds the error message via `file.toString()`. `LocalInputFile` inherits the default `Object.toString()`, so the error reads:

```
org.apache.parquet.io.LocalInputFile@7852e922 is not a Parquet file (length is too low: 5)
```

`HadoopInputFile` already overrides `toString()` to return its `path.toString()`. This PR does the same for `LocalInputFile`. The reporter on #3354 saw this through Delta Kernel's `InputFile` impl, but parquet-java's own `LocalInputFile` has the identical shape and reproduces locally.

The broader fix, adding `default String getPath()` to the `InputFile` interface so `ParquetFileReader` can call it with a fallback for any third-party impl, is left for a follow-up if reviewers want it. This PR keeps scope to the built-in impl.

### What changes are included in this PR?

`LocalInputFile` now overrides `toString()` to return `path.toString()`. `TestLocalInputOutput` has a regression test, `inputFileToStringReturnsPath`, asserting `LocalInputFile.toString()` equals the underlying path string. It fails on master (`expected:</var/.../...tmp> but was:<org.apache.parquet.io.LocalInputFile@61443d8f>`) and passes with the fix.

### Are these changes tested?

New `inputFileToStringReturnsPath` test in `TestLocalInputOutput`. It fails before the fix and passes after. The pre-existing tests in the file continue to pass.

### Are there any user-facing changes?

The "is not a Parquet file" error now shows the path instead of the object hash. No API change.

Closes #3354
