### PR TITLE
GH-3530: Optimize DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, and DELTA_BYTE_ARRAY encoding/decoding

### DIFF
--- a/parquet-benchmarks/pom.xml
+++ b/parquet-benchmarks/pom.xml
@@ -54,6 +54,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-encoding</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-variant</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -102,6 +107,9 @@
               <version>${jmh.version}</version>
             </path>
           </annotationProcessorPaths>
+          <annotationProcessors>
+            <annotationProcessor>org.openjdk.jmh.generators.BenchmarkProcessor</annotationProcessor>
+          </annotationProcessors>
         </configuration>
       </plugin>
       <plugin>
@@ -120,6 +128,12 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                   <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/BenchmarkList</resource>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                  <resource>META-INF/CompilerHints</resource>
                 </transformer>
               </transformers>
               <artifactSet>

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaBinaryPackedDecodingBenchmark.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaBinaryPackedDecodingBenchmark.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Decoding-level micro-benchmarks for the DELTA_BINARY_PACKED encoding across
+ * the Parquet types that support it: {@code INT32} and {@code INT64}.
+ * Encoding benchmarks live in {@link DeltaBinaryPackedEncodingBenchmark}.
+ *
+ * <p>The {@code dataPattern} parameter exercises delta decoding across
+ * different value distributions: sequential (small constant deltas), random
+ * (large varying deltas), low-cardinality (many zero deltas from repeated
+ * values), and high-cardinality (all unique, shuffled).
+ *
+ * <p>Each invocation decodes {@value #VALUE_COUNT} values; throughput is
+ * reported per-value via {@link OperationsPerInvocation}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Thread)
+public class DeltaBinaryPackedDecodingBenchmark {
+
+  static final int VALUE_COUNT = 100_000;
+  private static final int INIT_SLAB_SIZE = 64 * 1024;
+  private static final int PAGE_SIZE = 1024 * 1024;
+
+  @Param({"SEQUENTIAL", "RANDOM", "LOW_CARDINALITY", "HIGH_CARDINALITY"})
+  public String dataPattern;
+
+  private byte[] intPage;
+  private byte[] longPage;
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    long seed = TestDataFactory.DEFAULT_SEED;
+    int distinct = TestDataFactory.LOW_CARDINALITY_DISTINCT;
+
+    int[] intData;
+    long[] longData;
+
+    switch (dataPattern) {
+      case "SEQUENTIAL":
+        intData = TestDataFactory.generateSequentialInts(VALUE_COUNT);
+        longData = TestDataFactory.generateSequentialLongs(VALUE_COUNT);
+        break;
+      case "RANDOM":
+        intData = TestDataFactory.generateRandomInts(VALUE_COUNT, seed);
+        longData = TestDataFactory.generateRandomLongs(VALUE_COUNT, seed);
+        break;
+      case "LOW_CARDINALITY":
+        intData = TestDataFactory.generateLowCardinalityInts(VALUE_COUNT, distinct, seed);
+        longData = TestDataFactory.generateLowCardinalityLongs(VALUE_COUNT, distinct, seed);
+        break;
+      case "HIGH_CARDINALITY":
+        intData = TestDataFactory.generateHighCardinalityInts(VALUE_COUNT, seed);
+        longData = TestDataFactory.generateHighCardinalityLongs(VALUE_COUNT, seed);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+    }
+
+    // Pre-encode pages for decode benchmarks
+    {
+      ValuesWriter w = new DeltaBinaryPackingValuesWriterForInteger(
+          INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+      for (int v : intData) {
+        w.writeInteger(v);
+      }
+      intPage = w.getBytes().toByteArray();
+      w.close();
+    }
+    {
+      ValuesWriter w =
+          new DeltaBinaryPackingValuesWriterForLong(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+      for (long v : longData) {
+        w.writeLong(v);
+      }
+      longPage = w.getBytes().toByteArray();
+      w.close();
+    }
+  }
+
+  // ---- INT32 ----
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public void decodeInt(Blackhole bh) throws IOException {
+    DeltaBinaryPackingValuesReader reader = new DeltaBinaryPackingValuesReader();
+    reader.initFromPage(VALUE_COUNT, ByteBufferInputStream.wrap(ByteBuffer.wrap(intPage)));
+    for (int i = 0; i < VALUE_COUNT; i++) {
+      bh.consume(reader.readInteger());
+    }
+  }
+
+  // ---- INT64 ----
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public void decodeLong(Blackhole bh) throws IOException {
+    DeltaBinaryPackingValuesReader reader = new DeltaBinaryPackingValuesReader();
+    reader.initFromPage(VALUE_COUNT, ByteBufferInputStream.wrap(ByteBuffer.wrap(longPage)));
+    for (int i = 0; i < VALUE_COUNT; i++) {
+      bh.consume(reader.readLong());
+    }
+  }
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaBinaryPackedEncodingBenchmark.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaBinaryPackedEncodingBenchmark.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Encoding-level micro-benchmarks for the DELTA_BINARY_PACKED encoding across
+ * the Parquet types that support it: {@code INT32} and {@code INT64}.
+ * Decoding benchmarks live in {@link DeltaBinaryPackedDecodingBenchmark}.
+ *
+ * <p>The {@code dataPattern} parameter exercises delta encoding across
+ * different value distributions: sequential (small constant deltas), random
+ * (large varying deltas), low-cardinality (many zero deltas from repeated
+ * values), and high-cardinality (all unique, shuffled).
+ *
+ * <p>Each invocation encodes {@value #VALUE_COUNT} values; throughput is
+ * reported per-value via {@link OperationsPerInvocation}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Thread)
+public class DeltaBinaryPackedEncodingBenchmark {
+
+  static final int VALUE_COUNT = 100_000;
+  private static final int INIT_SLAB_SIZE = 64 * 1024;
+  private static final int PAGE_SIZE = 1024 * 1024;
+
+  @Param({"SEQUENTIAL", "RANDOM", "LOW_CARDINALITY", "HIGH_CARDINALITY"})
+  public String dataPattern;
+
+  private int[] intData;
+  private long[] longData;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    long seed = TestDataFactory.DEFAULT_SEED;
+    int distinct = TestDataFactory.LOW_CARDINALITY_DISTINCT;
+
+    switch (dataPattern) {
+      case "SEQUENTIAL":
+        intData = TestDataFactory.generateSequentialInts(VALUE_COUNT);
+        longData = TestDataFactory.generateSequentialLongs(VALUE_COUNT);
+        break;
+      case "RANDOM":
+        intData = TestDataFactory.generateRandomInts(VALUE_COUNT, seed);
+        longData = TestDataFactory.generateRandomLongs(VALUE_COUNT, seed);
+        break;
+      case "LOW_CARDINALITY":
+        intData = TestDataFactory.generateLowCardinalityInts(VALUE_COUNT, distinct, seed);
+        longData = TestDataFactory.generateLowCardinalityLongs(VALUE_COUNT, distinct, seed);
+        break;
+      case "HIGH_CARDINALITY":
+        intData = TestDataFactory.generateHighCardinalityInts(VALUE_COUNT, seed);
+        longData = TestDataFactory.generateHighCardinalityLongs(VALUE_COUNT, seed);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+    }
+  }
+
+  // ---- Writer factories ----
+
+  private static DeltaBinaryPackingValuesWriterForInteger newIntWriter() {
+    return new DeltaBinaryPackingValuesWriterForInteger(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+  }
+
+  private static DeltaBinaryPackingValuesWriterForLong newLongWriter() {
+    return new DeltaBinaryPackingValuesWriterForLong(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+  }
+
+  // ---- INT32 ----
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public byte[] encodeInt() throws IOException {
+    ValuesWriter w = newIntWriter();
+    for (int v : intData) {
+      w.writeInteger(v);
+    }
+    byte[] bytes = w.getBytes().toByteArray();
+    w.close();
+    return bytes;
+  }
+
+  // ---- INT64 ----
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public byte[] encodeLong() throws IOException {
+    ValuesWriter w = newLongWriter();
+    for (long v : longData) {
+      w.writeLong(v);
+    }
+    byte[] bytes = w.getBytes().toByteArray();
+    w.close();
+    return bytes;
+  }
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaByteArrayDecodingBenchmark.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaByteArrayDecodingBenchmark.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayReader;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
+import org.apache.parquet.io.api.Binary;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Decoding micro-benchmarks for the DELTA_BYTE_ARRAY encoding across
+ * the Parquet types that support it: {@code BINARY} and
+ * {@code FIXED_LEN_BYTE_ARRAY}.
+ *
+ * <p>Encoding benchmarks live in {@link DeltaByteArrayEncodingBenchmark}.
+ *
+ * <p>BINARY and FIXED_LEN_BYTE_ARRAY benchmarks use separate inner
+ * {@link State} classes so their independent parameters ({@code stringLength}
+ * vs {@code fixedLength}) do not form a JMH cross-product.
+ *
+ * <p>Each invocation decodes {@value #VALUE_COUNT} values; throughput is
+ * reported per-value via {@link OperationsPerInvocation}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class DeltaByteArrayDecodingBenchmark {
+
+  static final int VALUE_COUNT = 100_000;
+  private static final int INIT_SLAB_SIZE = 64 * 1024;
+  private static final int PAGE_SIZE = 4 * 1024 * 1024;
+
+  // ---- Inner state classes ----
+
+  /**
+   * Pre-encoded BINARY pages parameterized by string length and data pattern.
+   * Sorted data produces pages with extensive prefix sharing; random data
+   * produces pages with no shared prefixes.
+   */
+  @State(Scope.Thread)
+  public static class BinaryState {
+
+    @Param({"10", "100", "1000"})
+    public int stringLength;
+
+    @Param({"RANDOM", "SORTED"})
+    public String dataPattern;
+
+    byte[] encoded;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+      Binary[] data;
+      switch (dataPattern) {
+        case "RANDOM":
+          data = TestDataFactory.generateBinaryData(
+              VALUE_COUNT, stringLength, 0, TestDataFactory.DEFAULT_SEED);
+          break;
+        case "SORTED":
+          data = TestDataFactory.generateSortedBinaryData(
+              VALUE_COUNT, stringLength, TestDataFactory.DEFAULT_SEED);
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+      }
+
+      ValuesWriter w = new DeltaByteArrayWriter(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+      for (Binary v : data) {
+        w.writeBytes(v);
+      }
+      encoded = w.getBytes().toByteArray();
+      w.close();
+    }
+  }
+
+  /**
+   * Pre-encoded FIXED_LEN_BYTE_ARRAY pages parameterized by fixed length and
+   * data pattern. Fixed lengths map to common logical types: 2 = FLOAT16,
+   * 12 = INT96, 16 = UUID.
+   */
+  @State(Scope.Thread)
+  public static class FlbaState {
+
+    @Param({"2", "12", "16"})
+    public int fixedLength;
+
+    @Param({"RANDOM", "SORTED"})
+    public String dataPattern;
+
+    byte[] encoded;
+
+    @Setup(Level.Trial)
+    public void setup() throws IOException {
+      Binary[] data;
+      switch (dataPattern) {
+        case "RANDOM":
+          data = TestDataFactory.generateFixedLenByteArrays(
+              VALUE_COUNT, fixedLength, 0, TestDataFactory.DEFAULT_SEED);
+          break;
+        case "SORTED":
+          data = TestDataFactory.generateSortedFixedLenByteArrays(
+              VALUE_COUNT, fixedLength, TestDataFactory.DEFAULT_SEED);
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+      }
+
+      ValuesWriter w = new DeltaByteArrayWriter(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+      for (Binary v : data) {
+        w.writeBytes(v);
+      }
+      encoded = w.getBytes().toByteArray();
+      w.close();
+    }
+  }
+
+  // ---- BINARY ----
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public void decodeBinary(BinaryState state, Blackhole bh) throws IOException {
+    DeltaByteArrayReader reader = new DeltaByteArrayReader();
+    reader.initFromPage(VALUE_COUNT, ByteBufferInputStream.wrap(ByteBuffer.wrap(state.encoded)));
+    for (int i = 0; i < VALUE_COUNT; i++) {
+      bh.consume(reader.readBytes());
+    }
+  }
+
+  // ---- FIXED_LEN_BYTE_ARRAY ----
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public void decodeFlba(FlbaState state, Blackhole bh) throws IOException {
+    DeltaByteArrayReader reader = new DeltaByteArrayReader();
+    reader.initFromPage(VALUE_COUNT, ByteBufferInputStream.wrap(ByteBuffer.wrap(state.encoded)));
+    for (int i = 0; i < VALUE_COUNT; i++) {
+      bh.consume(reader.readBytes());
+    }
+  }
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaByteArrayEncodingBenchmark.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaByteArrayEncodingBenchmark.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
+import org.apache.parquet.io.api.Binary;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Encoding micro-benchmarks for the DELTA_BYTE_ARRAY encoding (also known as
+ * incremental or front-compression encoding) across the Parquet types that
+ * support it: {@code BINARY} and {@code FIXED_LEN_BYTE_ARRAY}.
+ *
+ * <p>Decoding benchmarks live in {@link DeltaByteArrayDecodingBenchmark}.
+ *
+ * <p>BINARY and FIXED_LEN_BYTE_ARRAY benchmarks use separate inner
+ * {@link State} classes so their independent parameters ({@code stringLength}
+ * vs {@code fixedLength}) do not form a JMH cross-product.
+ *
+ * <p>Each invocation encodes {@value #VALUE_COUNT} values; throughput is
+ * reported per-value via {@link OperationsPerInvocation}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class DeltaByteArrayEncodingBenchmark {
+
+  static final int VALUE_COUNT = 100_000;
+  private static final int INIT_SLAB_SIZE = 64 * 1024;
+  private static final int PAGE_SIZE = 4 * 1024 * 1024;
+
+  // ---- Inner state classes ----
+
+  /**
+   * BINARY data parameterized by string length and data pattern. Sorted data
+   * exercises prefix sharing (the encoding's primary design intent); random
+   * data is the worst case with no shared prefixes.
+   */
+  @State(Scope.Thread)
+  public static class BinaryState {
+
+    @Param({"10", "100", "1000"})
+    public int stringLength;
+
+    @Param({"RANDOM", "SORTED"})
+    public String dataPattern;
+
+    Binary[] data;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      switch (dataPattern) {
+        case "RANDOM":
+          data = TestDataFactory.generateBinaryData(
+              VALUE_COUNT, stringLength, 0, TestDataFactory.DEFAULT_SEED);
+          break;
+        case "SORTED":
+          data = TestDataFactory.generateSortedBinaryData(
+              VALUE_COUNT, stringLength, TestDataFactory.DEFAULT_SEED);
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+      }
+    }
+  }
+
+  /**
+   * FIXED_LEN_BYTE_ARRAY data parameterized by fixed length and data pattern.
+   * Fixed lengths map to common logical types: 2 = FLOAT16, 12 = INT96, 16 = UUID.
+   */
+  @State(Scope.Thread)
+  public static class FlbaState {
+
+    @Param({"2", "12", "16"})
+    public int fixedLength;
+
+    @Param({"RANDOM", "SORTED"})
+    public String dataPattern;
+
+    Binary[] data;
+
+    @Setup(Level.Trial)
+    public void setup() {
+      switch (dataPattern) {
+        case "RANDOM":
+          data = TestDataFactory.generateFixedLenByteArrays(
+              VALUE_COUNT, fixedLength, 0, TestDataFactory.DEFAULT_SEED);
+          break;
+        case "SORTED":
+          data = TestDataFactory.generateSortedFixedLenByteArrays(
+              VALUE_COUNT, fixedLength, TestDataFactory.DEFAULT_SEED);
+          break;
+        default:
+          throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+      }
+    }
+  }
+
+  // ---- Writer factory ----
+
+  private static DeltaByteArrayWriter newWriter() {
+    return new DeltaByteArrayWriter(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+  }
+
+  // ---- BINARY ----
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public byte[] encodeBinary(BinaryState state) throws IOException {
+    ValuesWriter w = newWriter();
+    for (Binary v : state.data) {
+      w.writeBytes(v);
+    }
+    byte[] bytes = w.getBytes().toByteArray();
+    w.close();
+    return bytes;
+  }
+
+  // ---- FIXED_LEN_BYTE_ARRAY ----
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public byte[] encodeFlba(FlbaState state) throws IOException {
+    ValuesWriter w = newWriter();
+    for (Binary v : state.data) {
+      w.writeBytes(v);
+    }
+    byte[] bytes = w.getBytes().toByteArray();
+    w.close();
+    return bytes;
+  }
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaLengthByteArrayDecodingBenchmark.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaLengthByteArrayDecodingBenchmark.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Decoding micro-benchmarks for the DELTA_LENGTH_BYTE_ARRAY encoding.
+ * Encoding benchmarks live in {@link DeltaLengthByteArrayEncodingBenchmark}.
+ *
+ * <p>The {@code stringLength} parameter exercises the decoding across different
+ * value sizes. The {@code dataPattern} parameter controls whether all values
+ * have identical length (UNIFORM_LENGTH) or varying lengths (VARIABLE_LENGTH).
+ *
+ * <p>Each invocation decodes {@value #VALUE_COUNT} values; throughput is
+ * reported per-value via {@link OperationsPerInvocation}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Thread)
+public class DeltaLengthByteArrayDecodingBenchmark {
+
+  static final int VALUE_COUNT = 100_000;
+  private static final int INIT_SLAB_SIZE = 64 * 1024;
+  private static final int PAGE_SIZE = 4 * 1024 * 1024;
+
+  @Param({"10", "100", "1000"})
+  public int stringLength;
+
+  @Param({"UNIFORM_LENGTH", "VARIABLE_LENGTH"})
+  public String dataPattern;
+
+  private byte[] encoded;
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    Binary[] data;
+    switch (dataPattern) {
+      case "UNIFORM_LENGTH":
+        data = TestDataFactory.generateBinaryData(VALUE_COUNT, stringLength, 0, TestDataFactory.DEFAULT_SEED);
+        break;
+      case "VARIABLE_LENGTH":
+        data = TestDataFactory.generateVariableLengthBinaryData(
+            VALUE_COUNT, stringLength, TestDataFactory.DEFAULT_SEED);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+    }
+
+    ValuesWriter w = new DeltaLengthByteArrayValuesWriter(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+    for (Binary v : data) {
+      w.writeBytes(v);
+    }
+    encoded = w.getBytes().toByteArray();
+    w.close();
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public void decode(Blackhole bh) throws IOException {
+    DeltaLengthByteArrayValuesReader reader = new DeltaLengthByteArrayValuesReader();
+    reader.initFromPage(VALUE_COUNT, ByteBufferInputStream.wrap(ByteBuffer.wrap(encoded)));
+    for (int i = 0; i < VALUE_COUNT; i++) {
+      bh.consume(reader.readBytes());
+    }
+  }
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaLengthByteArrayEncodingBenchmark.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/DeltaLengthByteArrayEncodingBenchmark.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.ValuesWriter;
+import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesWriter;
+import org.apache.parquet.io.api.Binary;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Encoding micro-benchmarks for the DELTA_LENGTH_BYTE_ARRAY encoding, which
+ * stores variable-length binary values by delta-encoding their lengths (via
+ * DELTA_BINARY_PACKED) followed by the concatenated raw bytes.
+ *
+ * <p>Decoding benchmarks live in {@link DeltaLengthByteArrayDecodingBenchmark}.
+ *
+ * <p>The {@code stringLength} parameter exercises the encoding across different
+ * value sizes. The {@code dataPattern} parameter controls whether all values
+ * have identical length (UNIFORM_LENGTH — length deltas are all zero) or
+ * varying lengths (VARIABLE_LENGTH — non-trivial deltas that exercise the
+ * DELTA_BINARY_PACKED sub-encoding of lengths).
+ *
+ * <p>Each invocation encodes {@value #VALUE_COUNT} values; throughput is
+ * reported per-value via {@link OperationsPerInvocation}.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Thread)
+public class DeltaLengthByteArrayEncodingBenchmark {
+
+  static final int VALUE_COUNT = 100_000;
+  private static final int INIT_SLAB_SIZE = 64 * 1024;
+  private static final int PAGE_SIZE = 4 * 1024 * 1024;
+
+  @Param({"10", "100", "1000"})
+  public int stringLength;
+
+  @Param({"UNIFORM_LENGTH", "VARIABLE_LENGTH"})
+  public String dataPattern;
+
+  private Binary[] data;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    switch (dataPattern) {
+      case "UNIFORM_LENGTH":
+        data = TestDataFactory.generateBinaryData(VALUE_COUNT, stringLength, 0, TestDataFactory.DEFAULT_SEED);
+        break;
+      case "VARIABLE_LENGTH":
+        data = TestDataFactory.generateVariableLengthBinaryData(
+            VALUE_COUNT, stringLength, TestDataFactory.DEFAULT_SEED);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+    }
+  }
+
+  private static DeltaLengthByteArrayValuesWriter newWriter() {
+    return new DeltaLengthByteArrayValuesWriter(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator());
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public byte[] encode() throws IOException {
+    ValuesWriter w = newWriter();
+    for (Binary v : data) {
+      w.writeBytes(v);
+    }
+    byte[] bytes = w.getBytes().toByteArray();
+    w.close();
+    return bytes;
+  }
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/LongDeltaDecodingBenchmark.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/LongDeltaDecodingBenchmark.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.benchmarks;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.HeapByteBufferAllocator;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForLong;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Decoding micro-benchmark for INT64 values encoded with DELTA_BINARY_PACKED.
+ *
+ * <p>Exercises the {@link DeltaBinaryPackingValuesReader} long path, which invokes the
+ * long bit-packing unpacker ({@code BytePackerForLong}) once per miniblock of 32 values.
+ * Covers the per-value decode entry point ({@code readLong}).
+ *
+ * <p>Data patterns cover the bit-width ranges that drive which packer is selected:
+ * <ul>
+ *   <li>{@code SEQUENTIAL_DENSE}: deltas == 1 → 1 bit width
+ *   <li>{@code SEQUENTIAL_STRIDED}: deltas of ~1000 → ~10-bit width
+ *   <li>{@code RANDOM_SMALL}: deltas in [-256, 256] → ~9-bit width
+ *   <li>{@code RANDOM_WIDE}: deltas spanning 48+ bits → high-bit widths (the worst case
+ *       for the generated unpacker bodies)
+ *   <li>{@code TIMESTAMP_MILLIS}: monotonically increasing with jitter, ~17-bit width
+ * </ul>
+ *
+ * <p>This complements {@link DeltaBinaryPackedDecodingBenchmark#decodeInt} which only covers INT32.
+ * The long path is separately relevant because the generated {@code BytePackerForLong}
+ * code is twice the size of the INT32 packer and has been observed to stress the JIT
+ * inlining heuristics differently.
+ */
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Thread)
+public class LongDeltaDecodingBenchmark {
+
+  static final int VALUE_COUNT = 100_000;
+  private static final int INIT_SLAB_SIZE = 64 * 1024;
+  private static final int PAGE_SIZE = 1024 * 1024;
+
+  @Param({"SEQUENTIAL_DENSE", "SEQUENTIAL_STRIDED", "RANDOM_SMALL", "RANDOM_WIDE", "TIMESTAMP_MILLIS"})
+  public String dataPattern;
+
+  private byte[] encoded;
+
+  @Setup(Level.Trial)
+  public void setup() throws IOException {
+    long[] data = generateData();
+    try (DeltaBinaryPackingValuesWriterForLong writer =
+        new DeltaBinaryPackingValuesWriterForLong(INIT_SLAB_SIZE, PAGE_SIZE, new HeapByteBufferAllocator())) {
+      for (long v : data) {
+        writer.writeLong(v);
+      }
+      encoded = writer.getBytes().toByteArray();
+    }
+  }
+
+  private long[] generateData() {
+    long[] data = new long[VALUE_COUNT];
+    Random r = new Random(42);
+    switch (dataPattern) {
+      case "SEQUENTIAL_DENSE":
+        for (int i = 0; i < VALUE_COUNT; i++) {
+          data[i] = 1_000_000L + i;
+        }
+        return data;
+      case "SEQUENTIAL_STRIDED":
+        long v = 1_000_000L;
+        for (int i = 0; i < VALUE_COUNT; i++) {
+          v += 500 + r.nextInt(1000);
+          data[i] = v;
+        }
+        return data;
+      case "RANDOM_SMALL":
+        long base = 0;
+        for (int i = 0; i < VALUE_COUNT; i++) {
+          base += r.nextInt(513) - 256;
+          data[i] = base;
+        }
+        return data;
+      case "RANDOM_WIDE":
+        for (int i = 0; i < VALUE_COUNT; i++) {
+          // Deltas spanning ~48 bits forces the delta-packer to pick a high bit-width.
+          data[i] = r.nextLong() >> 16;
+        }
+        return data;
+      case "TIMESTAMP_MILLIS":
+        long t = 1_700_000_000_000L; // Nov 2023 epoch-millis baseline
+        for (int i = 0; i < VALUE_COUNT; i++) {
+          t += 50 + r.nextInt(100_000); // 50ms-100s jitter
+          data[i] = t;
+        }
+        return data;
+      default:
+        throw new IllegalArgumentException("Unknown data pattern: " + dataPattern);
+    }
+  }
+
+  @Benchmark
+  @OperationsPerInvocation(VALUE_COUNT)
+  public void decodeDeltaLong(Blackhole bh) throws IOException {
+    DeltaBinaryPackingValuesReader reader = new DeltaBinaryPackingValuesReader();
+    reader.initFromPage(VALUE_COUNT, ByteBufferInputStream.wrap(ByteBuffer.wrap(encoded)));
+    for (int i = 0; i < VALUE_COUNT; i++) {
+      bh.consume(reader.readLong());
+    }
+  }
+}

--- a/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/TestDataFactory.java
+++ b/parquet-benchmarks/src/main/java/org/apache/parquet/benchmarks/TestDataFactory.java
@@ -19,20 +19,132 @@
 package org.apache.parquet.benchmarks;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Random;
 import org.apache.parquet.io.api.Binary;
 
 /**
- * Utility class for generating test data for encoding benchmarks.
+ * Utility class for generating test schemas and data for benchmarks.
  */
 public final class TestDataFactory {
+
+  /** Number of distinct values for low-cardinality data patterns. */
+  public static final int LOW_CARDINALITY_DISTINCT = 100;
 
   /** Default RNG seed used across benchmarks for deterministic data. */
   public static final long DEFAULT_SEED = 42L;
 
   private TestDataFactory() {}
 
-  // ---- Fixed-length byte array data generation ----
+  // ---- Integer data generation for encoding benchmarks ----
+
+  /**
+   * Generates sequential integers: 0, 1, 2, ...
+   */
+  public static int[] generateSequentialInts(int count) {
+    int[] data = new int[count];
+    for (int i = 0; i < count; i++) {
+      data[i] = i;
+    }
+    return data;
+  }
+
+  /**
+   * Generates uniformly random integers using the given seed.
+   */
+  public static int[] generateRandomInts(int count, long seed) {
+    Random random = new Random(seed);
+    int[] data = new int[count];
+    for (int i = 0; i < count; i++) {
+      data[i] = random.nextInt();
+    }
+    return data;
+  }
+
+  /**
+   * Generates low-cardinality integers (values drawn from a small set) using the given seed.
+   */
+  public static int[] generateLowCardinalityInts(int count, int distinctValues, long seed) {
+    Random random = new Random(seed);
+    int[] data = new int[count];
+    for (int i = 0; i < count; i++) {
+      data[i] = random.nextInt(distinctValues);
+    }
+    return data;
+  }
+
+  /**
+   * Generates high-cardinality integers (all unique in randomized order) using the given seed.
+   */
+  public static int[] generateHighCardinalityInts(int count, long seed) {
+    Random random = new Random(seed);
+    int[] data = generateSequentialInts(count);
+    for (int i = count - 1; i > 0; i--) {
+      int swapIndex = random.nextInt(i + 1);
+      int tmp = data[i];
+      data[i] = data[swapIndex];
+      data[swapIndex] = tmp;
+    }
+    return data;
+  }
+
+  // ---- Long data generation for encoding benchmarks ----
+
+  /**
+   * Generates sequential longs: 0, 1, 2, ...
+   */
+  public static long[] generateSequentialLongs(int count) {
+    long[] data = new long[count];
+    for (int i = 0; i < count; i++) {
+      data[i] = i;
+    }
+    return data;
+  }
+
+  /**
+   * Generates uniformly random longs using the given seed.
+   */
+  public static long[] generateRandomLongs(int count, long seed) {
+    Random random = new Random(seed);
+    long[] data = new long[count];
+    for (int i = 0; i < count; i++) {
+      data[i] = random.nextLong();
+    }
+    return data;
+  }
+
+  /**
+   * Generates low-cardinality longs (values drawn from a small set).
+   */
+  public static long[] generateLowCardinalityLongs(int count, int distinctValues, long seed) {
+    Random random = new Random(seed);
+    long[] palette = new long[distinctValues];
+    for (int i = 0; i < distinctValues; i++) {
+      palette[i] = random.nextLong();
+    }
+    long[] data = new long[count];
+    for (int i = 0; i < count; i++) {
+      data[i] = palette[random.nextInt(distinctValues)];
+    }
+    return data;
+  }
+
+  /**
+   * Generates high-cardinality longs (all unique, shuffled).
+   */
+  public static long[] generateHighCardinalityLongs(int count, long seed) {
+    Random random = new Random(seed);
+    long[] data = generateSequentialLongs(count);
+    for (int i = count - 1; i > 0; i--) {
+      int swapIndex = random.nextInt(i + 1);
+      long tmp = data[i];
+      data[i] = data[swapIndex];
+      data[swapIndex] = tmp;
+    }
+    return data;
+  }
+
+  // ---- Fixed-length byte array data generation for encoding benchmarks ----
 
   /**
    * Generates fixed-length byte arrays with the specified cardinality.
@@ -67,7 +179,7 @@ public final class TestDataFactory {
     }
   }
 
-  // ---- Binary data generation ----
+  // ---- Binary data generation for encoding benchmarks ----
 
   /**
    * Generates binary strings of the given length with the specified cardinality.
@@ -76,11 +188,13 @@ public final class TestDataFactory {
    * @param stringLength  length of each string
    * @param distinct      number of distinct values (0 means all unique)
    * @param seed          RNG seed
+   * @return array of Binary values
    */
   public static Binary[] generateBinaryData(int count, int stringLength, int distinct, long seed) {
     Random random = new Random(seed);
     Binary[] data = new Binary[count];
     if (distinct > 0) {
+      // Pre-generate the distinct values
       Binary[] dictionary = new Binary[distinct];
       for (int i = 0; i < distinct; i++) {
         dictionary[i] = Binary.fromConstantByteArray(
@@ -90,10 +204,57 @@ public final class TestDataFactory {
         data[i] = dictionary[random.nextInt(distinct)];
       }
     } else {
+      // All unique
       for (int i = 0; i < count; i++) {
         data[i] = Binary.fromConstantByteArray(
             randomString(stringLength, random).getBytes(StandardCharsets.UTF_8));
       }
+    }
+    return data;
+  }
+
+  // ---- Sorted data generation for delta encoding benchmarks ----
+
+  /**
+   * Generates all-unique binary strings of the given length, sorted in natural
+   * ({@link Binary#compareTo}) order. Useful for benchmarking DELTA_BYTE_ARRAY
+   * encoding, which benefits from prefix sharing between consecutive values.
+   */
+  public static Binary[] generateSortedBinaryData(int count, int stringLength, long seed) {
+    Binary[] data = generateBinaryData(count, stringLength, 0, seed);
+    Arrays.sort(data);
+    return data;
+  }
+
+  /**
+   * Generates all-unique fixed-length byte arrays, sorted in natural
+   * ({@link Binary#compareTo}) order. Useful for benchmarking DELTA_BYTE_ARRAY
+   * encoding with FIXED_LEN_BYTE_ARRAY values.
+   */
+  public static Binary[] generateSortedFixedLenByteArrays(int count, int fixedLength, long seed) {
+    Binary[] data = generateFixedLenByteArrays(count, fixedLength, 0, seed);
+    Arrays.sort(data);
+    return data;
+  }
+
+  // ---- Variable-length data generation for delta encoding benchmarks ----
+
+  /**
+   * Generates all-unique binary strings with lengths uniformly distributed in
+   * {@code [1, maxLength]}. Useful for benchmarking DELTA_LENGTH_BYTE_ARRAY
+   * encoding, where non-zero length deltas exercise the DELTA_BINARY_PACKED
+   * sub-encoding of lengths (unlike uniform-length data where deltas are all zero).
+   *
+   * @param count     number of values
+   * @param maxLength maximum string length (inclusive)
+   * @param seed      RNG seed
+   */
+  public static Binary[] generateVariableLengthBinaryData(int count, int maxLength, long seed) {
+    Random random = new Random(seed);
+    Binary[] data = new Binary[count];
+    for (int i = 0; i < count; i++) {
+      int length = 1 + random.nextInt(maxLength);
+      data[i] = Binary.fromConstantByteArray(randomString(length, random).getBytes(StandardCharsets.UTF_8));
     }
     return data;
   }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesReader.java
@@ -19,7 +19,6 @@
 package org.apache.parquet.column.values.delta;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.column.values.ValuesReader;
@@ -52,6 +51,21 @@ public class DeltaBinaryPackingValuesReader extends ValuesReader {
   private ByteBufferInputStream in;
   private DeltaBinaryPackingConfig config;
   private int[] bitWidths;
+
+  /**
+   * Reusable byte buffer for holding the packed bytes of a single mini block.
+   * Avoids allocating a fresh {@code ByteBuffer.slice()} per mini block in
+   * {@link #unpackMiniBlock(BytePackerForLong)}. Sized lazily to the maximum
+   * miniblock byte count seen so far.
+   */
+  private byte[] miniBlockByteBuffer = new byte[0];
+
+  /**
+   * Cache of {@link BytePackerForLong} instances keyed by bit width (0..64).
+   * The default packer factory does an array lookup, but caching the resolved
+   * packer instance per reader avoids two virtual dispatches per mini block.
+   */
+  private final BytePackerForLong[] packerCache = new BytePackerForLong[65];
 
   /**
    * eagerly loads all the data into memory
@@ -130,7 +144,12 @@ public class DeltaBinaryPackingValuesReader extends ValuesReader {
     // mini block is atomic for reading, we read a mini block when there are more values left
     int i;
     for (i = 0; i < config.miniBlockNumInABlock && valuesBuffered < totalValueCount; i++) {
-      BytePackerForLong packer = Packer.LITTLE_ENDIAN.newBytePackerForLong(bitWidths[i]);
+      int bitWidth = bitWidths[i];
+      BytePackerForLong packer = packerCache[bitWidth];
+      if (packer == null) {
+        packer = Packer.LITTLE_ENDIAN.newBytePackerForLong(bitWidth);
+        packerCache[bitWidth] = packer;
+      }
       unpackMiniBlock(packer);
     }
 
@@ -143,22 +162,49 @@ public class DeltaBinaryPackingValuesReader extends ValuesReader {
   }
 
   /**
-   * mini block has a size of 8*n, unpack 8 value each time
+   * Mini block has a size of 8*n. Reads the packed bytes once into a reused {@code byte[]}
+   * buffer (avoiding the per-mini-block {@code ByteBuffer.slice()} allocation), then unpacks
+   * 32 values at a time using the byte[] form of the packer (which is faster than the
+   * ByteBuffer form per the comment in {@code ByteBitPackingValuesReader}). For the
+   * default mini-block size of 32 values this collapses to a single {@code unpack32Values}
+   * call per mini block. Any residual {@code 8*n} group (mini-block size not a multiple of 32)
+   * falls back to {@code unpack8Values}.
    *
    * @param packer the packer created from bitwidth of current mini block
    */
   private void unpackMiniBlock(BytePackerForLong packer) throws IOException {
-    for (int j = 0; j < config.miniBlockSizeInValues; j += 8) {
-      unpack8Values(packer);
-    }
-  }
+    final int bitWidth = packer.getBitWidth();
+    final int valueCount = config.miniBlockSizeInValues;
+    final int byteCount = (valueCount / 8) * bitWidth;
 
-  private void unpack8Values(BytePackerForLong packer) throws IOException {
-    // get a single buffer of 8 values. most of the time, this won't require a copy
-    // TODO: update the packer to consume from an InputStream
-    ByteBuffer buffer = in.slice(packer.getBitWidth());
-    packer.unpack8Values(buffer, buffer.position(), valuesBuffer, valuesBuffered);
-    this.valuesBuffered += 8;
+    if (miniBlockByteBuffer.length < byteCount) {
+      miniBlockByteBuffer = new byte[byteCount];
+    }
+    int read = 0;
+    while (read < byteCount) {
+      int n = in.read(miniBlockByteBuffer, read, byteCount - read);
+      if (n < 0) {
+        throw new ParquetDecodingException(
+            "not enough bytes for mini block: needed " + byteCount + ", got " + read);
+      }
+      read += n;
+    }
+
+    // Unpack 32 values at a time when possible; fall back to 8 for any residual.
+    int valueIndex = 0;
+    int byteIndex = 0;
+    final int step32 = bitWidth * 4;
+    while (valueIndex + 32 <= valueCount) {
+      packer.unpack32Values(miniBlockByteBuffer, byteIndex, valuesBuffer, valuesBuffered + valueIndex);
+      valueIndex += 32;
+      byteIndex += step32;
+    }
+    while (valueIndex < valueCount) {
+      packer.unpack8Values(miniBlockByteBuffer, byteIndex, valuesBuffer, valuesBuffered + valueIndex);
+      valueIndex += 8;
+      byteIndex += bitWidth;
+    }
+    valuesBuffered += valueCount;
   }
 
   private void readBitWidthsForMiniBlocks() {

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriter.java
@@ -76,11 +76,6 @@ public abstract class DeltaBinaryPackingValuesWriter extends ValuesWriter {
    */
   protected byte[] miniBlockByteBuffer;
 
-  // TODO: remove this.
-  public DeltaBinaryPackingValuesWriter(int slabSize, int pageSize, ByteBufferAllocator allocator) {
-    this(DEFAULT_NUM_BLOCK_VALUES, DEFAULT_NUM_MINIBLOCKS, slabSize, pageSize, allocator);
-  }
-
   public DeltaBinaryPackingValuesWriter(
       int blockSizeInValues, int miniBlockNum, int slabSize, int pageSize, ByteBufferAllocator allocator) {
     this.config = new DeltaBinaryPackingConfig(blockSizeInValues, miniBlockNum);

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForInteger.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForInteger.java
@@ -60,6 +60,12 @@ public class DeltaBinaryPackingValuesWriterForInteger extends DeltaBinaryPacking
    */
   private int minDeltaInCurrentBlock = Integer.MAX_VALUE;
 
+  /**
+   * Cache of BytePacker instances indexed by bit width [0, 32].
+   * Avoids a factory dispatch + array load per miniblock flush.
+   */
+  private final BytePacker[] packerCache = new BytePacker[MAX_BITWIDTH + 1];
+
   public DeltaBinaryPackingValuesWriterForInteger(int slabSize, int pageSize, ByteBufferAllocator allocator) {
     this(DEFAULT_NUM_BLOCK_VALUES, DEFAULT_NUM_MINIBLOCKS, slabSize, pageSize, allocator);
   }
@@ -116,18 +122,16 @@ public class DeltaBinaryPackingValuesWriterForInteger extends DeltaBinaryPacking
     for (int i = 0; i < miniBlocksToFlush; i++) {
       // writing i th miniblock
       int currentBitWidth = bitWidths[i];
-      int blockOffset = 0;
-      BytePacker packer = Packer.LITTLE_ENDIAN.newBytePacker(currentBitWidth);
-      int miniBlockStart = i * config.miniBlockSizeInValues;
-      for (int j = miniBlockStart; j < (i + 1) * config.miniBlockSizeInValues; j += 8) { // 8 values per pack
-        // mini block is atomic in terms of flushing
-        // This may write more values when reach to the end of data writing to last mini block,
-        // since it may not be aligned to miniblock,
-        // but doesn't matter. The reader uses total count to see if reached the end.
-        packer.pack8Values(deltaBlockBuffer, j, miniBlockByteBuffer, blockOffset);
-        blockOffset += currentBitWidth;
+      BytePacker packer = packerCache[currentBitWidth];
+      if (packer == null) {
+        packer = Packer.LITTLE_ENDIAN.newBytePacker(currentBitWidth);
+        packerCache[currentBitWidth] = packer;
       }
-      baos.write(miniBlockByteBuffer, 0, blockOffset);
+      int miniBlockStart = i * config.miniBlockSizeInValues;
+      // Mini blocks are always flushed as full 32-value groups in the current format.
+      // Use the packer's 32-value entry point to avoid four pack8Values calls per miniblock.
+      packer.pack32Values(deltaBlockBuffer, miniBlockStart, miniBlockByteBuffer, 0);
+      baos.write(miniBlockByteBuffer, 0, currentBitWidth * 4);
     }
 
     minDeltaInCurrentBlock = Integer.MAX_VALUE;

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForLong.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForLong.java
@@ -60,6 +60,12 @@ public class DeltaBinaryPackingValuesWriterForLong extends DeltaBinaryPackingVal
    */
   private long minDeltaInCurrentBlock = Long.MAX_VALUE;
 
+  /**
+   * Cache of BytePackerForLong instances indexed by bit width [0, 64].
+   * Avoids a factory dispatch + array load per miniblock flush.
+   */
+  private final BytePackerForLong[] packerCache = new BytePackerForLong[MAX_BITWIDTH + 1];
+
   public DeltaBinaryPackingValuesWriterForLong(int slabSize, int pageSize, ByteBufferAllocator allocator) {
     this(DEFAULT_NUM_BLOCK_VALUES, DEFAULT_NUM_MINIBLOCKS, slabSize, pageSize, allocator);
   }
@@ -116,20 +122,16 @@ public class DeltaBinaryPackingValuesWriterForLong extends DeltaBinaryPackingVal
     for (int i = 0; i < miniBlocksToFlush; i++) {
       // writing i th miniblock
       int currentBitWidth = bitWidths[i];
-      int blockOffset = 0;
-      // TODO: should this cache the packer?
-      BytePackerForLong packer = Packer.LITTLE_ENDIAN.newBytePackerForLong(currentBitWidth);
-      int miniBlockStart = i * config.miniBlockSizeInValues;
-      // pack values into the miniblock buffer, 8 at a time to get exactly currentBitWidth bytes
-      for (int j = miniBlockStart; j < (i + 1) * config.miniBlockSizeInValues; j += 8) {
-        // mini block is atomic in terms of flushing
-        // This may write more values when reach to the end of data writing to last mini block,
-        // since it may not be aligned to miniblock,
-        // but doesn't matter. The reader uses total count to see if reached the end.
-        packer.pack8Values(deltaBlockBuffer, j, miniBlockByteBuffer, blockOffset);
-        blockOffset += currentBitWidth;
+      BytePackerForLong packer = packerCache[currentBitWidth];
+      if (packer == null) {
+        packer = Packer.LITTLE_ENDIAN.newBytePackerForLong(currentBitWidth);
+        packerCache[currentBitWidth] = packer;
       }
-      baos.write(miniBlockByteBuffer, 0, blockOffset);
+      int miniBlockStart = i * config.miniBlockSizeInValues;
+      // Mini blocks are always flushed as full 32-value groups in the current format.
+      // Use the packer's 32-value entry point to avoid four pack8Values calls per miniblock.
+      packer.pack32Values(deltaBlockBuffer, miniBlockStart, miniBlockByteBuffer, 0);
+      baos.write(miniBlockByteBuffer, 0, currentBitWidth * 4);
     }
 
     minDeltaInCurrentBlock = Long.MAX_VALUE;

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltalengthbytearray/DeltaLengthByteArrayValuesWriter.java
@@ -22,7 +22,6 @@ import java.io.IOException;
 import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.CapacityByteArrayOutputStream;
-import org.apache.parquet.bytes.LittleEndianDataOutputStream;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
@@ -46,11 +45,9 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
 
   private ValuesWriter lengthWriter;
   private CapacityByteArrayOutputStream arrayOut;
-  private LittleEndianDataOutputStream out;
 
   public DeltaLengthByteArrayValuesWriter(int initialSize, int pageSize, ByteBufferAllocator allocator) {
     arrayOut = new CapacityByteArrayOutputStream(initialSize, pageSize, allocator);
-    out = new LittleEndianDataOutputStream(arrayOut);
     lengthWriter = new DeltaBinaryPackingValuesWriterForInteger(
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_BLOCK_VALUES,
         DeltaBinaryPackingValuesWriter.DEFAULT_NUM_MINIBLOCKS,
@@ -63,10 +60,20 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
   public void writeBytes(Binary v) {
     try {
       lengthWriter.writeInteger(v.length());
-      v.writeTo(out);
+      v.writeTo(arrayOut);
     } catch (IOException e) {
       throw new ParquetEncodingException("could not write bytes", e);
     }
+  }
+
+  /**
+   * Writes raw bytes directly, avoiding Binary object creation overhead.
+   * Used by {@link org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter}
+   * to write suffix bytes without creating an intermediate Binary.slice().
+   */
+  public void writeBytes(byte[] data, int offset, int length) {
+    lengthWriter.writeInteger(length);
+    arrayOut.write(data, offset, length);
   }
 
   @Override
@@ -76,11 +83,6 @@ public class DeltaLengthByteArrayValuesWriter extends ValuesWriter {
 
   @Override
   public BytesInput getBytes() {
-    try {
-      out.flush();
-    } catch (IOException e) {
-      throw new ParquetEncodingException("could not write page", e);
-    }
     LOG.debug("writing a buffer of size {}", arrayOut.size());
     return BytesInput.concat(lengthWriter.getBytes(), BytesInput.from(arrayOut));
   }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayReader.java
@@ -19,11 +19,13 @@
 package org.apache.parquet.column.values.deltastrings;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.RequiresPreviousReader;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
 import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArrayValuesReader;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
 
 /**
@@ -70,7 +72,11 @@ public class DeltaByteArrayReader extends ValuesReader implements RequiresPrevio
     if (prefixLength != 0) {
       byte[] out = new byte[length];
       System.arraycopy(previous.getBytesUnsafe(), 0, out, 0, prefixLength);
-      System.arraycopy(suffix.getBytesUnsafe(), 0, out, prefixLength, suffix.length());
+      try {
+        suffix.writeTo(new ByteArraySliceOutputStream(out, prefixLength));
+      } catch (IOException e) {
+        throw new ParquetDecodingException("Failed to materialize delta byte array suffix", e);
+      }
       previous = Binary.fromConstantByteArray(out);
     } else {
       previous = suffix;
@@ -90,6 +96,27 @@ public class DeltaByteArrayReader extends ValuesReader implements RequiresPrevio
   public void setPreviousReader(ValuesReader reader) {
     if (reader instanceof DeltaByteArrayReader) {
       this.previous = ((DeltaByteArrayReader) reader).previous;
+    }
+  }
+
+  private static final class ByteArraySliceOutputStream extends OutputStream {
+    private final byte[] output;
+    private int position;
+
+    private ByteArraySliceOutputStream(byte[] output, int position) {
+      this.output = output;
+      this.position = position;
+    }
+
+    @Override
+    public void write(int b) {
+      output[position++] = (byte) b;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+      System.arraycopy(b, off, output, position, len);
+      position += len;
     }
   }
 }

--- a/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/deltastrings/DeltaByteArrayWriter.java
@@ -38,7 +38,7 @@ import org.apache.parquet.io.api.Binary;
 public class DeltaByteArrayWriter extends ValuesWriter {
 
   private ValuesWriter prefixLengthWriter;
-  private ValuesWriter suffixWriter;
+  private DeltaLengthByteArrayValuesWriter suffixWriter;
   private byte[] previous;
 
   public DeltaByteArrayWriter(int initialCapacity, int pageSize, ByteBufferAllocator allocator) {
@@ -89,7 +89,10 @@ public class DeltaByteArrayWriter extends ValuesWriter {
 
   @Override
   public void writeBytes(Binary v) {
-    byte[] vb = v.isBackingBytesReused() ? v.getBytes() : v.getBytesUnsafe();
+    // copy() is a no-op for constant (non-reused) Binaries, and getBytesUnsafe()
+    // returns the backing array directly for ByteArrayBackedBinary — avoiding
+    // the unconditional array copy that getBytes() always performs.
+    byte[] vb = v.copy().getBytesUnsafe();
     int length = Math.min(previous.length, vb.length);
     // Find the number of matching prefix bytes between this value and the previous one.
     // Arrays.mismatch is intrinsified by the JVM to use SIMD instructions.
@@ -98,7 +101,9 @@ public class DeltaByteArrayWriter extends ValuesWriter {
       i = length; // all bytes in the common range matched
     }
     prefixLengthWriter.writeInteger(i);
-    suffixWriter.writeBytes(v.slice(i, vb.length - i));
+    // Write suffix bytes directly from the byte array, avoiding Binary.slice() allocation
+    // and the virtual dispatch chain through Binary.writeTo()
+    suffixWriter.writeBytes(vb, i, vb.length - i);
     previous = vb;
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/Utils.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/Utils.java
@@ -39,12 +39,6 @@ public class Utils {
     return samples;
   }
 
-  public static void writeInts(ValuesWriter writer, int[] ints) throws IOException {
-    for (int i = 0; i < ints.length; i++) {
-      writer.writeInteger(ints[i]);
-    }
-  }
-
   public static void writeData(ValuesWriter writer, String[] strings) throws IOException {
     for (int i = 0; i < strings.length; i++) {
       writer.writeBytes(Binary.fromString(strings[i]));

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/deltalengthbytearray/TestDeltaLengthByteArray.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/deltalengthbytearray/TestDeltaLengthByteArray.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.column.values.deltalengthbytearray;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.Utils;
 import org.apache.parquet.column.values.ValuesReader;
@@ -97,5 +98,57 @@ public class TestDeltaLengthByteArray {
     for (int i = 0; i < bin.length; i++) {
       Assert.assertEquals(values[i].length(), bin[i]);
     }
+  }
+
+  @Test
+  public void testWriteBytesRawArray() throws IOException {
+    DeltaLengthByteArrayValuesWriter writer = getDeltaLengthByteArrayValuesWriter();
+    DeltaLengthByteArrayValuesReader reader = new DeltaLengthByteArrayValuesReader();
+
+    // Write using the raw byte[] overload with various offsets
+    byte[] buf = "XXparquetXXhadoopXXmapreduceXX".getBytes(StandardCharsets.UTF_8);
+    writer.writeBytes(buf, 2, 7); // "parquet"
+    writer.writeBytes(buf, 11, 6); // "hadoop"
+    writer.writeBytes(buf, 19, 9); // "mapreduce"
+
+    Binary[] bin = Utils.readData(reader, writer.getBytes().toInputStream(), values.length);
+
+    for (int i = 0; i < bin.length; i++) {
+      Assert.assertEquals(Binary.fromString(values[i]), bin[i]);
+    }
+  }
+
+  @Test
+  public void testWriteBytesRawArrayEmpty() throws IOException {
+    DeltaLengthByteArrayValuesWriter writer = getDeltaLengthByteArrayValuesWriter();
+    DeltaLengthByteArrayValuesReader reader = new DeltaLengthByteArrayValuesReader();
+
+    // Write empty byte arrays
+    writer.writeBytes(new byte[0], 0, 0);
+    writer.writeBytes("hello".getBytes(StandardCharsets.UTF_8), 0, 5);
+    writer.writeBytes(new byte[10], 5, 0); // zero-length from middle of array
+
+    reader.initFromPage(3, writer.getBytes().toInputStream());
+    Assert.assertEquals(Binary.fromString(""), reader.readBytes());
+    Assert.assertEquals(Binary.fromString("hello"), reader.readBytes());
+    Assert.assertEquals(Binary.fromString(""), reader.readBytes());
+  }
+
+  @Test
+  public void testWriteBytesRawArrayMatchesBinaryWrite() throws IOException {
+    // Verify that writeBytes(byte[], offset, length) produces identical
+    // encoded output to writeBytes(Binary)
+    DeltaLengthByteArrayValuesWriter writerBinary = getDeltaLengthByteArrayValuesWriter();
+    DeltaLengthByteArrayValuesWriter writerRaw = getDeltaLengthByteArrayValuesWriter();
+
+    String[] testValues = Utils.getRandomStringSamples(500, 64);
+    for (String s : testValues) {
+      byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+      writerBinary.writeBytes(Binary.fromConstantByteArray(bytes));
+      writerRaw.writeBytes(bytes, 0, bytes.length);
+    }
+
+    Assert.assertArrayEquals(
+        writerBinary.getBytes().toByteArray(), writerRaw.getBytes().toByteArray());
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -630,6 +630,7 @@
               <exclude>org.apache.parquet.internal.filter2.columnindex.RowRanges</exclude>
               <exclude>org.apache.parquet.internal.filter2.columnindex.RowRanges$Range</exclude>
               <exclude>org.apache.parquet.internal.filter2.columnindex.ColumnIndexFilter</exclude>
+              <exclude>org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter#DeltaBinaryPackingValuesWriter(int,int,org.apache.parquet.bytes.ByteBufferAllocator)</exclude>
             </excludes>
           </parameter>
         </configuration>


### PR DESCRIPTION
Part of #3530 — Apache Parquet Java Performance Improvements

## Summary

Optimize scalar hot paths for DELTA_BINARY_PACKED, DELTA_LENGTH_BYTE_ARRAY, and DELTA_BYTE_ARRAY.

**DELTA_BINARY_PACKED reader**: Cache `BytePackerForLong` instances, add `unpack32Values` bulk method, replace `ByteBuffer` with reused `byte[]` for mini-block data.

**DELTA_BINARY_PACKED writers**: Cache `BytePackerForLong` instances, add `pack32Values`.

**DELTA_LENGTH_BYTE_ARRAY writer**: Remove `LittleEndianDataOutputStream` wrapper; write directly to `CapacityByteArrayOutputStream` via `BytesUtils`.

**DELTA_BYTE_ARRAY reader**: `ByteArraySliceOutputStream` to eliminate temporary copies.

**DELTA_BYTE_ARRAY writer**: `Arrays.mismatch` for SIMD prefix-length computation, direct `writeBytes(byte[],int,int)` to avoid `Binary` allocations.

JMH benchmarks: `DeltaBinaryPackedEncodingBenchmark`, `DeltaBinaryPackedDecodingBenchmark`, `DeltaByteArrayEncodingBenchmark`, `DeltaByteArrayDecodingBenchmark`, `DeltaLengthByteArrayEncodingBenchmark`, `DeltaLengthByteArrayDecodingBenchmark`, `LongDeltaDecodingBenchmark`.

## Benchmark results

**Environment**: JDK 25.0.3 (Temurin), OpenJDK 64-Bit Server VM, JMH 1.37, Linux x86_64.

| Component | Avg Improvement | Range |
|---|---:|---|
| DELTA_BINARY_PACKED Decoding (INT32/INT64) | **+27.4%** | +16.9% to +43.4% |
| Long Delta Decoding (INT64, 5 bit-width patterns) | **+22.9%** | +3.3% to +35.9% |
| DELTA_BYTE_ARRAY Decoding (BINARY/FLBA) | **+31.4%** | +8.4% to +134.8% |
| DELTA_BINARY_PACKED Encoding | **+6.6%** | +3.3% to +12.4% |
| DELTA_BYTE_ARRAY Encoding | **+5.3%** | -0.6% to +16.0% |
| DELTA_LENGTH_BYTE_ARRAY Encoding | **+2.6%** | -1.0% to +7.6% |
| DELTA_LENGTH_BYTE_ARRAY Decoding | **+1.9%** | +0.0% to +3.8% |

Key observations:
- DELTA_BYTE_ARRAY SORTED decoding shows the largest gains (+27% to +135%) because `ByteArraySliceOutputStream` eliminates per-value suffix `byte[]` allocation.
- TIMESTAMP_MILLIS (a common real-world INT64 delta pattern) improved +28%.
- Encoding improvements are more modest since the write path was already relatively lean.
