### PR TITLE
GH-3574: parquet-hadoop: Statistics.toParquetStatistics: always set null_count

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -800,12 +800,14 @@ public class ParquetMetadataConverter {
   public static Statistics toParquetStatistics(
       org.apache.parquet.column.statistics.Statistics stats, int truncateLength) {
     Statistics formatStats = new Statistics();
+    if (!stats.isEmpty()) {
+      formatStats.setNull_count(stats.getNumNulls());
+    }
     // Don't write stats larger than the max size rather than truncating. The
     // rationale is that some engines may use the minimum value in the page as
     // the true minimum for aggregations and there is no way to mark that a
     // value has been truncated and is a lower bound and not in the page.
     if (!stats.isEmpty() && withinLimit(stats, truncateLength)) {
-      formatStats.setNull_count(stats.getNumNulls());
       if (stats.hasNonNullValue()) {
         byte[] min;
         byte[] max;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -807,7 +807,7 @@ public class TestParquetMetadataConverter {
     }
     Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
 
-    // convert to empty stats because the values are too large
+    // min/max are not written because the values are too large, but null count is always written
     stats.setMinMaxFromBytes(max, max);
 
     formatStats = helper.toParquetStatistics(stats);
@@ -816,7 +816,7 @@ public class TestParquetMetadataConverter {
     Assert.assertFalse("Max should not be set", formatStats.isSetMax());
     Assert.assertFalse("Min_value should not be set", formatStats.isSetMin_value());
     Assert.assertFalse("Max_value should not be set", formatStats.isSetMax_value());
-    Assert.assertFalse("Num nulls should not be set", formatStats.isSetNull_count());
+    Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
 
     Statistics roundTripStats = ParquetMetadataConverter.fromParquetStatisticsInternal(
         Version.FULL_VERSION,
@@ -824,7 +824,8 @@ public class TestParquetMetadataConverter {
         new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.BINARY, ""),
         ParquetMetadataConverter.SortOrder.SIGNED);
 
-    Assert.assertTrue(roundTripStats.isEmpty());
+    Assert.assertFalse("Round-trip stats should not be empty (null count is set)", roundTripStats.isEmpty());
+    Assert.assertEquals("Round-trip null count should match", 3004, roundTripStats.getNumNulls());
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

Missing `null_count` statistics for columns in parquet files can cause issues with downstream consumers of these files. It is not necessary to omit this statistic for columns which are larger than the truncation configuration, since despite the truncation, their nullability can be asserted with confidence. It is reasonable to keep omitting min/max statistics due to the rationale explained in the comment in the code.

### What changes are included in this PR?

Always add `null_count` statistics for columns in parquet files, unconditional of their size.

### Are these changes tested?

Yes, `TestParquetMetadataConverter.java` has been updated to reflect these changes

### Are there any user-facing changes?

I think we can consider the additional `null_count` statistic's appearance as a user-facing change

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #3574 
