### PR TITLE
GH-3573: Fix VariantUtil string decoding to use explicit UTF-8 charset

### DIFF
--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import org.apache.parquet.Preconditions;
@@ -657,12 +658,12 @@ class VariantUtil {
       checkIndex(start + length - 1, value.limit());
       if (value.hasArray()) {
         // If the buffer is backed by an array, we can use the array directly.
-        return new String(value.array(), value.arrayOffset() + start, length);
+        return new String(value.array(), value.arrayOffset() + start, length, StandardCharsets.UTF_8);
       } else {
         // If the buffer is not backed by an array, we need to copy the bytes into a new array.
         byte[] valueArray = new byte[length];
         slice(value, start).get(valueArray);
-        return new String(valueArray);
+        return new String(valueArray, StandardCharsets.UTF_8);
       }
     }
     throw unexpectedType(Variant.Type.STRING, value);
@@ -825,12 +826,13 @@ class VariantUtil {
     }
     checkIndex(dataPos + nextOffset - 1, metadata.limit());
     if (metadata.hasArray() && !metadata.isReadOnly()) {
-      return new String(metadata.array(), metadata.arrayOffset() + dataPos + offset, nextOffset - offset);
+      return new String(
+          metadata.array(), metadata.arrayOffset() + dataPos + offset, nextOffset - offset, StandardCharsets.UTF_8);
     } else {
       // ByteBuffer does not have an array, so we need to use the `get` method to read the bytes.
       byte[] metadataArray = new byte[nextOffset - offset];
       slice(metadata, dataPos + offset).get(metadataArray);
-      return new String(metadataArray);
+      return new String(metadataArray, StandardCharsets.UTF_8);
     }
   }
 
@@ -861,13 +863,14 @@ class VariantUtil {
             new String(
                 metadata.array(),
                 metadata.arrayOffset() + pos + stringStart + offset,
-                nextOffset - offset),
+                nextOffset - offset,
+                StandardCharsets.UTF_8),
             id);
       } else {
         // ByteBuffer does not have an array, so we need to use the `get` method to read the bytes.
         byte[] metadataArray = new byte[nextOffset - offset];
         slice(metadata, pos + stringStart + offset).get(metadataArray);
-        result.put(new String(metadataArray), id);
+        result.put(new String(metadataArray, StandardCharsets.UTF_8), id);
       }
       offset = nextOffset;
     }

--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
@@ -827,7 +827,10 @@ class VariantUtil {
     checkIndex(dataPos + nextOffset - 1, metadata.limit());
     if (metadata.hasArray() && !metadata.isReadOnly()) {
       return new String(
-          metadata.array(), metadata.arrayOffset() + dataPos + offset, nextOffset - offset, StandardCharsets.UTF_8);
+          metadata.array(),
+          metadata.arrayOffset() + dataPos + offset,
+          nextOffset - offset,
+          StandardCharsets.UTF_8);
     } else {
       // ByteBuffer does not have an array, so we need to use the `get` method to read the bytes.
       byte[] metadataArray = new byte[nextOffset - offset];

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
@@ -406,4 +406,29 @@ public class TestVariantObject {
     Assert.assertEquals(0, immutableMetadata.getOrInsert("name"));
     Assert.assertEquals(1, immutableMetadata.getOrInsert("age"));
   }
+
+  @Test
+  public void testMetadataMapWithUnicodeKeys() {
+    // Build a variant whose metadata dictionary contains non-ASCII keys.
+    VariantBuilder vb = new VariantBuilder();
+    VariantObjectBuilder obj = vb.startObject();
+    obj.appendKey("élève");
+    obj.appendInt(1);
+    obj.appendKey("中文");
+    obj.appendInt(2);
+    vb.endObject();
+    Variant variant = vb.build();
+
+    ByteBuffer metaBuf = variant.getMetadataBuffer();
+
+    // hasArray branch
+    ImmutableMetadata writable = new ImmutableMetadata(metaBuf);
+    Assert.assertEquals(0, writable.getOrInsert("élève"));
+    Assert.assertEquals(1, writable.getOrInsert("中文"));
+
+    // read-only branch (else path in getMetadataMap): asReadOnlyBuffer() makes isReadOnly() true
+    ImmutableMetadata readOnly = new ImmutableMetadata(metaBuf.asReadOnlyBuffer());
+    Assert.assertEquals(0, readOnly.getOrInsert("élève"));
+    Assert.assertEquals(1, readOnly.getOrInsert("中文"));
+  }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantParseJson.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantParseJson.java
@@ -242,6 +242,15 @@ public class TestVariantParseJson {
   }
 
   @Test
+  public void testParseUnicodeKey() throws IOException {
+    Variant v = VariantJsonParser.parseJson("{\"\\u00e9l\\u00e8ve\": 42}");
+    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
+    Variant value = v.getFieldByKey("élève");
+    Assert.assertNotNull(value);
+    Assert.assertEquals(42, value.getInt());
+  }
+
+  @Test
   public void testParseEscapedString() throws IOException {
     Variant v = VariantJsonParser.parseJson("\"hello\\nworld\"");
     Assert.assertEquals(Variant.Type.STRING, v.getType());


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

`VariantUtil.getString()`, `getMetadataKey()`, and `getMetadataMap()` used `new String(byte[], ...)` without a charset, relying on the JVM platform default. On JDK <= 17 with `LC_ALL=C` (the build invocation recommended in the README), the platform default becomes `US-ASCII`, causing multi-byte UTF-8 sequences in Variant string values and metadata keys to be decoded as multiple characters instead of one.

The [Variant binary encoding spec](https://github.com/apache/parquet-format/blob/master/VariantEncoding.md) mandates UTF-8 for all string data. The write path already uses `StandardCharsets.UTF_8` explicitly, this PR aligns the read path to match.

### What changes are included in this PR?

`VariantUtil.java`: add `StandardCharsets.UTF_8` to six `new String(byte[], ...)` call sites across `getString()`, `getMetadataKey()`, and `getMetadataMap()`.

### Are these changes tested?

Yes, the existing `testParseUnicodeString` test in `TestVariantParseJson` covers this. It was already written to catch this exact case but only failed when running under `LC_ALL=C` (i.e. on JDK <= 17 with the README-recommended build invocation). With this fix, `LC_ALL=C ./mvnw test -pl parquet-variant` passes cleanly.

### Are there any user-facing changes?

No API changes. Behavior change only for JVMs running with a non-UTF-8 default charset, where string values containing non-ASCII characters were previously silently corrupted on read.

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #3573
