### PR TITLE
Simplify CI: collapse codec matrix and add zstd coverage

### DIFF
--- a/.github/workflows/ci-hadoop3.yml
+++ b/.github/workflows/ci-hadoop3.yml
@@ -27,8 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         java: [ { setup: '11', maven: '11' }, { setup: '17', maven: '17' } ]
-        codes: [ 'uncompressed,brotli', 'gzip,snappy' ]
-    name: Build Parquet with JDK ${{ matrix.java.setup }} and ${{ matrix.codes }}
+    name: Build Parquet with JDK ${{ matrix.java.setup }}
 
     steps:
       - uses: actions/checkout@master
@@ -49,7 +48,7 @@ jobs:
           ./mvnw install --batch-mode -DskipTests=true -Dmaven.javadoc.skip=true -Dsource.skip=true -Djava.version=${{ matrix.java.maven }}
       - name: verify
         env:
-          TEST_CODECS: ${{ matrix.codes }}
+          TEST_CODECS: 'uncompressed,brotli,gzip,snappy,zstd'
           JAVA_VERSION: ${{ matrix.java.setup }}
         run: |
           EXTRA_JAVA_TEST_ARGS=$(./mvnw help:evaluate -Dexpression=extraJavaTestArgs -q -DforceStdout)


### PR DESCRIPTION
## Summary

Remove the codec matrix dimension from the CI Hadoop 3 workflow. The codec split only parameterized a single integration test (`FileEncodingsIT`) while duplicating the entire build+test suite across 4 jobs instead of 2.

## Motivation

Analysis of recent CI runs shows:
- The `verify` step takes ~12 min (JDK 17) / ~16 min (JDK 11) **regardless of which codecs are set**
- The difference between codec variants for the same JDK is <1 minute
- Each redundant job wastes ~6 min of `before_install` + `install` overhead
- Total savings: **~46% fewer billable CI minutes** (from ~81 to ~44 min per run)

## Changes

- Remove the `codes` matrix dimension (was: `['uncompressed,brotli', 'gzip,snappy']`)
- Set `TEST_CODECS` to all codecs in a single string: `uncompressed,brotli,gzip,snappy,zstd`
- Add `zstd` to the tested codecs (was previously missing)
- Jobs go from 4 (2 JDKs x 2 codec groups) to 2 (2 JDKs)

## Impact

- Wall-clock CI time: unchanged (jobs already ran in parallel)
- Billable minutes: ~46% reduction
- Test coverage: improved (adds zstd)
- `FileEncodingsIT` now tests 8 types x 5 codecs = 40 parameterized cases in one shot

R: @Fokko 