### PR TITLE
GH-3587: Fix `parquet.thrift.string.size.limit` validation

### DIFF
--- a/parquet-format-structures/src/main/java/org/apache/parquet/format/Util.java
+++ b/parquet-format-structures/src/main/java/org/apache/parquet/format/Util.java
@@ -417,8 +417,8 @@ public class Util {
       // Set to default 100 MB
       maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
     }
-    if (configuredMaxMessageSize <= 0) {
-      throw new NumberFormatException("Max message size must be positive: " + configuredMaxMessageSize);
+    if (maxMessageSize <= 0) {
+      throw new NumberFormatException("Max message size must be positive: " + maxMessageSize);
     }
 
     TConfiguration config = t.getConfiguration();

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileReaderMaxMessageSize.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileReaderMaxMessageSize.java
@@ -143,4 +143,52 @@ public class TestParquetFileReaderMaxMessageSize {
               || e.getCause().getMessage().contains("MaxMessageSize reached"));
     }
   }
+
+  /**
+   * The -1 sentinel must be honored as "use the default max message size",
+   * not rejected as a non-positive value.
+   */
+  @Test
+  public void testReadAcceptsMinusOneAsDefaultMaxMessageSize() throws IOException {
+    Configuration readConf = new Configuration();
+    readConf.setInt("parquet.thrift.string.size.limit", -1);
+    ParquetReadOptions options = HadoopReadOptions.builder(readConf).build();
+
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
+      ParquetMetadata metadata = reader.getFooter();
+      assertNotNull(metadata);
+      assertEquals(schema, metadata.getFileMetaData().getSchema());
+    }
+  }
+
+  @Test
+  public void testReadRejectsZeroMaxMessageSize() throws IOException {
+    assertRejectsNonPositiveMaxMessageSize(0);
+  }
+
+  @Test
+  public void testReadRejectsInvalidNegativeMaxMessageSize() throws IOException {
+    assertRejectsNonPositiveMaxMessageSize(-5);
+  }
+
+  private void assertRejectsNonPositiveMaxMessageSize(int maxMessageSize) throws IOException {
+    Configuration readConf = new Configuration();
+    readConf.setInt("parquet.thrift.string.size.limit", maxMessageSize);
+    ParquetReadOptions options = HadoopReadOptions.builder(readConf).build();
+
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
+      fail("Expected failure for non-positive max message size: " + maxMessageSize);
+    } catch (RuntimeException | IOException e) {
+      String message = e.getMessage() == null ? "" : e.getMessage();
+      String causeMessage = e.getCause() == null || e.getCause().getMessage() == null
+          ? ""
+          : e.getCause().getMessage();
+      assertTrue(
+          "Expected 'Max message size must be positive' in " + message + " / " + causeMessage,
+          message.contains("Max message size must be positive")
+              || causeMessage.contains("Max message size must be positive"));
+    }
+  }
 }


### PR DESCRIPTION
### Rationale for this change
This PR fixes a small bug in `parquet.thrift.string.size.limit` validation [here](https://github.com/apache/parquet-java/blob/8931c1c55f1fba399dd75139f75bcde0b84137c0/parquet-format-structures/src/main/java/org/apache/parquet/format/Util.java#L420). If this config is explicitly set to -1, the code indicates that the default max message size should be used, but also throws an exception.


### What changes are included in this PR?
If `parquet.thrift.string.size.limit == -1`, use the default value and do not fail validation.


### Are these changes tested?
Yes, there are new regression tests added to `TestParquetFileReaderMaxMessageSize`.


### Are there any user-facing changes?
No.


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
Closes #GH-3587
