### PR TITLE
GH-3572: Bump thrift to 0.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,23 @@ Parquet-Java uses Maven to build and depends on the thrift compiler (protoc is n
 To build and install the thrift compiler, run:
 
 ```
-wget -nv https://archive.apache.org/dist/thrift/0.22.0/thrift-0.22.0.tar.gz
-tar xzf thrift-0.22.0.tar.gz
-cd thrift-0.22.0
+wget -nv https://archive.apache.org/dist/thrift/0.23.0/thrift-0.23.0.tar.gz
+tar xzf thrift-0.23.0.tar.gz
+cd thrift-0.23.0
 chmod +x ./configure
 ./configure --disable-libs
 sudo make install -j
 ```
 
-If you're on OSX and use homebrew, you can instead install Thrift 0.22.0 with `brew` and ensure that it comes first in your `PATH`.
+Note: if you wish to verify the signature and checksum of a release:
+1. The GPG and sha checksums can be found under https://archive.apache.org/dist/thrift/0.23.0/
+2. Validate the signature of the artifact against the [Thrift committer KEYS](https://downloads.apache.org/thrift/KEYS).
+
+If you're on OSX and use homebrew, you can instead install Thrift 0.23.0 with `brew` and ensure that it comes first in your `PATH`.
 
 ```
 brew install thrift
-export PATH="/usr/local/opt/thrift@0.22.0/bin:$PATH"
+export PATH="/usr/local/opt/thrift@0.23.0/bin:$PATH"
 ```
 
 ### Build Parquet with Maven

--- a/dev/ci-before_install.sh
+++ b/dev/ci-before_install.sh
@@ -20,7 +20,7 @@
 # This script gets invoked by the CI system in a "before install" step
 ################################################################################
 
-export THRIFT_VERSION=0.22.0
+export THRIFT_VERSION=0.23.0
 
 set -e
 set -o pipefail

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/BufferedProtocolReadToWrite.java
@@ -579,7 +579,7 @@ public class BufferedProtocolReadToWrite implements ProtocolPipe {
   class NullProtocol extends TProtocol {
 
     public NullProtocol() {
-      super(null);
+      super(StubTTransport.INSTANCE);
     }
 
     @Override

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/ParquetProtocol.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/ParquetProtocol.java
@@ -38,7 +38,7 @@ public abstract class ParquetProtocol extends TProtocol {
   private String name;
 
   ParquetProtocol() {
-    super(null);
+    super(StubTTransport.INSTANCE);
   }
 
   private String getClassInfo() {
@@ -54,7 +54,7 @@ public abstract class ParquetProtocol extends TProtocol {
    * @param name a meaningful debugging name for anonymous inner classes
    */
   public ParquetProtocol(String name) {
-    super(null);
+    super(StubTTransport.INSTANCE);
     this.name = name;
   }
 

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/StubTTransport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/StubTTransport.java
@@ -26,14 +26,14 @@ import org.apache.thrift.transport.TTransportException;
  * A stub transport which implements the minimum amount needed for range/depth
  * validation within the thrift library to succeed.
  */
-public final class StubTTransport extends TTransport {
+final class StubTTransport extends TTransport {
 
-  public static final StubTTransport INSTANCE = new StubTTransport();
+  static final StubTTransport INSTANCE = new StubTTransport();
 
   /**
    * There's no limits on recursion depth.
    */
-  private final TConfiguration conf = new TConfiguration(
+  private static final TConfiguration CONFIGURATION = new TConfiguration(
       TConfiguration.DEFAULT_MAX_FRAME_SIZE, TConfiguration.DEFAULT_MAX_MESSAGE_SIZE, Integer.MAX_VALUE);
 
   private StubTTransport() {}
@@ -66,7 +66,7 @@ public final class StubTTransport extends TTransport {
 
   @Override
   public TConfiguration getConfiguration() {
-    return conf;
+    return CONFIGURATION;
   }
 
   @Override

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/StubTTransport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/StubTTransport.java
@@ -34,16 +34,12 @@ public final class StubTTransport extends TTransport {
    * There's no limits on recursion depth.
    */
   private final TConfiguration conf = new TConfiguration(
-      TConfiguration.DEFAULT_MAX_FRAME_SIZE,
-      TConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
-      Integer.MAX_VALUE);
+      TConfiguration.DEFAULT_MAX_FRAME_SIZE, TConfiguration.DEFAULT_MAX_MESSAGE_SIZE, Integer.MAX_VALUE);
 
-  private StubTTransport() {
-  }
+  private StubTTransport() {}
 
   @Override
-  public void checkReadBytesAvailable(long l) {
-  }
+  public void checkReadBytesAvailable(long l) {}
 
   @Override
   public boolean isOpen() {
@@ -56,8 +52,7 @@ public final class StubTTransport extends TTransport {
   }
 
   @Override
-  public void close() {
-  }
+  public void close() {}
 
   @Override
   public int read(byte[] bytes, int i, int i1) throws TTransportException {
@@ -75,6 +70,5 @@ public final class StubTTransport extends TTransport {
   }
 
   @Override
-  public void updateKnownMessageSize(long l) {
-  }
+  public void updateKnownMessageSize(long l) {}
 }

--- a/parquet-thrift/src/main/java/org/apache/parquet/thrift/StubTTransport.java
+++ b/parquet-thrift/src/main/java/org/apache/parquet/thrift/StubTTransport.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.parquet.thrift;
+
+import org.apache.thrift.TConfiguration;
+import org.apache.thrift.transport.TTransport;
+import org.apache.thrift.transport.TTransportException;
+
+/**
+ * A stub transport which implements the minimum amount needed for range/depth
+ * validation within the thrift library to succeed.
+ */
+public final class StubTTransport extends TTransport {
+
+  public static final StubTTransport INSTANCE = new StubTTransport();
+
+  /**
+   * There's no limits on recursion depth.
+   */
+  private final TConfiguration conf = new TConfiguration(
+      TConfiguration.DEFAULT_MAX_FRAME_SIZE,
+      TConfiguration.DEFAULT_MAX_MESSAGE_SIZE,
+      Integer.MAX_VALUE);
+
+  private StubTTransport() {
+  }
+
+  @Override
+  public void checkReadBytesAvailable(long l) {
+  }
+
+  @Override
+  public boolean isOpen() {
+    return true;
+  }
+
+  @Override
+  public void open() throws TTransportException {
+    throw new TTransportException("unsupported");
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public int read(byte[] bytes, int i, int i1) throws TTransportException {
+    throw new TTransportException("unsupported");
+  }
+
+  @Override
+  public void write(byte[] bytes, int i, int i1) throws TTransportException {
+    throw new TTransportException("unsupported");
+  }
+
+  @Override
+  public TConfiguration getConfiguration() {
+    return conf;
+  }
+
+  @Override
+  public void updateKnownMessageSize(long l) {
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>${thrift.executable}</format.thrift.executable>
     <thrift-maven-plugin.version>0.10.0</thrift-maven-plugin.version>
-    <thrift.version>0.22.0</thrift.version>
+    <thrift.version>0.23.0</thrift.version>
     <format.thrift.version>${thrift.version}</format.thrift.version>
     <fastutil.version>8.5.18</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>


### PR DESCRIPTION
### Rationale for this change

There's a new Thrift release out.

Changes include a fix for the CVE https://github.com/advisories/GHSA-526f-jxpj-jmg2
This is server side and only affect thrift javascript code. While parquet is unaffected, security scanner tools aren't necessarily going to be that nuanced.


### What changes are included in this PR?

* updated build files/scripts with thrift version declarations
* updated references in README.md
* Added instructions in README as to where to find the gpg/sha signatures and a link to the thrift team KEYS file.

### Are these changes tested?

* Expecting PR CI to do the tests.
* It compiles!
* I manually ran the modified wget command in the README to verify the path to the tarball is valid.

### Are there any user-facing changes?

No

Closes #3572 
