### PR TITLE
MINOR: Remove Java 8 direct buffer cleaner path

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A helper class that uses {@code sun.misc.Unsafe#invokeCleaner(ByteBuffer)}
- * reflectively to clean up direct buffers on Java 9+ runtimes.
+ * reflectively to clean up direct buffers.
  * <p>
  * Strongly inspired by:
  * <a href="https://github.com/apache/tomcat/blob/master/java/org/apache/tomcat/util/buf/ByteBufferUtils.java">Tomcat ByteBufferUtils</a>

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/codec/CleanUtil.java
@@ -26,68 +26,40 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * A Helper class which use reflections to clean up DirectBuffer. It's implemented for
- * better compatibility with both java8 and java9+, because the Cleaner class is moved to
- * another place since java9+.
+ * A helper class that uses {@code sun.misc.Unsafe#invokeCleaner(ByteBuffer)}
+ * reflectively to clean up direct buffers on Java 9+ runtimes.
  * <p>
  * Strongly inspired by:
- * https://github.com/apache/tomcat/blob/master/java/org/apache/tomcat/util/buf/ByteBufferUtils.java
+ * <a href="https://github.com/apache/tomcat/blob/master/java/org/apache/tomcat/util/buf/ByteBufferUtils.java">Tomcat ByteBufferUtils</a>
  */
 public class CleanUtil {
   private static final Logger logger = LoggerFactory.getLogger(CleanUtil.class);
 
   private static final Object unsafe;
-  private static final Method cleanerMethod;
-  private static final Method cleanMethod;
   private static final Method invokeCleanerMethod;
-
-  private static final int majorVersion =
-      Integer.parseInt(System.getProperty("java.version").split("\\D+")[0]);
 
   static {
     final ByteBuffer tempBuffer = ByteBuffer.allocateDirect(0);
-    Method cleanerMethodLocal = null;
-    Method cleanMethodLocal = null;
     Object unsafeLocal = null;
     Method invokeCleanerMethodLocal = null;
-    if (majorVersion >= 9) {
-      try {
-        final Class<?> clazz = Class.forName("sun.misc.Unsafe");
-        final Field theUnsafe = clazz.getDeclaredField("theUnsafe");
-        theUnsafe.setAccessible(true);
-        unsafeLocal = theUnsafe.get(null);
-        invokeCleanerMethodLocal = clazz.getMethod("invokeCleaner", ByteBuffer.class);
-        invokeCleanerMethodLocal.invoke(unsafeLocal, tempBuffer);
-      } catch (IllegalAccessException
-          | IllegalArgumentException
-          | InvocationTargetException
-          | NoSuchMethodException
-          | SecurityException
-          | ClassNotFoundException
-          | NoSuchFieldException e) {
-        logger.warn("Cannot use direct ByteBuffer cleaner, memory leaking may occur", e);
-        unsafeLocal = null;
-        invokeCleanerMethodLocal = null;
-      }
-    } else {
-      try {
-        cleanerMethodLocal = tempBuffer.getClass().getMethod("cleaner");
-        cleanerMethodLocal.setAccessible(true);
-        final Object cleanerObject = cleanerMethodLocal.invoke(tempBuffer);
-        cleanMethodLocal = cleanerObject.getClass().getMethod("clean");
-        cleanMethodLocal.invoke(cleanerObject);
-      } catch (NoSuchMethodException
-          | SecurityException
-          | IllegalAccessException
-          | IllegalArgumentException
-          | InvocationTargetException e) {
-        logger.warn("Cannot use direct ByteBuffer cleaner, memory leaking may occur", e);
-        cleanerMethodLocal = null;
-        cleanMethodLocal = null;
-      }
+    try {
+      final Class<?> clazz = Class.forName("sun.misc.Unsafe");
+      final Field theUnsafe = clazz.getDeclaredField("theUnsafe");
+      theUnsafe.setAccessible(true);
+      unsafeLocal = theUnsafe.get(null);
+      invokeCleanerMethodLocal = clazz.getMethod("invokeCleaner", ByteBuffer.class);
+      invokeCleanerMethodLocal.invoke(unsafeLocal, tempBuffer);
+    } catch (IllegalAccessException
+        | IllegalArgumentException
+        | InvocationTargetException
+        | NoSuchMethodException
+        | SecurityException
+        | ClassNotFoundException
+        | NoSuchFieldException e) {
+      logger.warn("Cannot use direct ByteBuffer cleaner, memory leaking may occur", e);
+      unsafeLocal = null;
+      invokeCleanerMethodLocal = null;
     }
-    cleanerMethod = cleanerMethodLocal;
-    cleanMethod = cleanMethodLocal;
     unsafe = unsafeLocal;
     invokeCleanerMethod = invokeCleanerMethodLocal;
   }
@@ -97,16 +69,7 @@ public class CleanUtil {
   }
 
   public static void cleanDirectBuffer(ByteBuffer buf) {
-    if (cleanMethod != null) {
-      try {
-        cleanMethod.invoke(cleanerMethod.invoke(buf));
-      } catch (IllegalAccessException
-          | IllegalArgumentException
-          | InvocationTargetException
-          | SecurityException e) {
-        logger.warn("Error while cleaning up the DirectBuffer", e);
-      }
-    } else if (invokeCleanerMethod != null) {
+    if (invokeCleanerMethod != null) {
       try {
         invokeCleanerMethod.invoke(unsafe, buf);
       } catch (IllegalAccessException


### PR DESCRIPTION
Since Java 8 is no longer supported, we don't need to support its specific reflection requirements here.

(Codex was used to create this PR)