### PR TITLE
GH-3601: Avoid repeated created_by parsing in footer metadata conversion

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java
@@ -47,20 +47,25 @@ public class CorruptStatistics {
   private static final SemanticVersion CDH_5_PARQUET_251_FIXED_END = new SemanticVersion(1, 5, 0);
 
   /**
-   * Decides if the statistics from a file created by createdBy (the created_by field from parquet format)
-   * should be ignored because they are potentially corrupt.
+   * Returns whether the given column type is one of the types affected by the PARQUET-251 bug
+   * (BINARY or FIXED_LEN_BYTE_ARRAY).
    *
-   * @param createdBy  the created-by string from a file footer
-   * @param columnType the type of the column that this is checking
-   * @return true if the statistics may be invalid and should be ignored, false otherwise
+   * @param columnType the primitive type of the column
+   * @return true if this column type could have corrupt statistics
    */
-  public static boolean shouldIgnoreStatistics(String createdBy, PrimitiveTypeName columnType) {
+  public static boolean isCorruptStatisticsColumnType(PrimitiveTypeName columnType) {
+    return columnType == PrimitiveTypeName.BINARY || columnType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
+  }
 
-    if (columnType != PrimitiveTypeName.BINARY && columnType != PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
-      // the bug only applies to binary columns
-      return false;
-    }
-
+  /**
+   * Determines whether a file (identified by its created_by string) was written by a version of
+   * parquet-mr that had the PARQUET-251 statistics bug. This is a file-level check that does not
+   * consider column type.
+   *
+   * @param createdBy the created-by string from a file footer
+   * @return true if the file was written by a version with the corrupt statistics bug
+   */
+  public static boolean fileHasCorruptStatistics(String createdBy) {
     if (Strings.isNullOrEmpty(createdBy)) {
       // created_by is not populated, which could have been caused by
       // parquet-mr during the same time as PARQUET-251, see PARQUET-297
@@ -101,6 +106,22 @@ public class CorruptStatistics {
       warnParseErrorOnce(createdBy, e);
       return true;
     }
+  }
+
+  /**
+   * Decides if the statistics from a file created by createdBy (the created_by field from parquet format)
+   * should be ignored because they are potentially corrupt.
+   *
+   * @param createdBy  the created-by string from a file footer
+   * @param columnType the type of the column that this is checking
+   * @return true if the statistics may be invalid and should be ignored, false otherwise
+   */
+  public static boolean shouldIgnoreStatistics(String createdBy, PrimitiveTypeName columnType) {
+    if (!isCorruptStatisticsColumnType(columnType)) {
+      // the bug only applies to binary columns
+      return false;
+    }
+    return fileHasCorruptStatistics(createdBy);
   }
 
   private static void warnParseErrorOnce(String createdBy, Throwable e) {

--- a/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java
+++ b/parquet-column/src/main/java/org/apache/parquet/CorruptStatistics.java
@@ -49,23 +49,20 @@ public class CorruptStatistics {
   /**
    * Returns whether the given column type is one of the types affected by the PARQUET-251 bug
    * (BINARY or FIXED_LEN_BYTE_ARRAY).
-   *
-   * @param columnType the primitive type of the column
-   * @return true if this column type could have corrupt statistics
    */
-  public static boolean isCorruptStatisticsColumnType(PrimitiveTypeName columnType) {
+  private static boolean isCorruptStatisticsColumnType(PrimitiveTypeName columnType) {
     return columnType == PrimitiveTypeName.BINARY || columnType == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
   }
 
   /**
-   * Determines whether a file (identified by its created_by string) was written by a version of
-   * parquet-mr that had the PARQUET-251 statistics bug. This is a file-level check that does not
-   * consider column type.
+   * Determines whether a file (identified by its created_by string) may have been written by a
+   * version of parquet-mr that had the PARQUET-251 statistics bug. This is a file-level check
+   * that does not consider column type.
    *
    * @param createdBy the created-by string from a file footer
-   * @return true if the file was written by a version with the corrupt statistics bug
+   * @return true if the file may have been written by a version with the corrupt statistics bug
    */
-  public static boolean fileHasCorruptStatistics(String createdBy) {
+  public static boolean mayHaveCorruptStatistics(String createdBy) {
     if (Strings.isNullOrEmpty(createdBy)) {
       // created_by is not populated, which could have been caused by
       // parquet-mr during the same time as PARQUET-251, see PARQUET-297
@@ -121,7 +118,7 @@ public class CorruptStatistics {
       // the bug only applies to binary columns
       return false;
     }
-    return fileHasCorruptStatistics(createdBy);
+    return mayHaveCorruptStatistics(createdBy);
   }
 
   private static void warnParseErrorOnce(String createdBy, Throwable e) {

--- a/parquet-column/src/test/java/org/apache/parquet/CorruptStatisticsTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/CorruptStatisticsTest.java
@@ -124,4 +124,34 @@ public class CorruptStatisticsTest {
     assertTrue(CorruptStatistics.shouldIgnoreStatistics(
         "parquet-mr version 1.7.0 (build abcd)", PrimitiveTypeName.BINARY));
   }
+
+  @Test
+  public void testIsCorruptStatisticsColumnType() {
+    assertTrue(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.BINARY));
+    assertTrue(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY));
+    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.INT32));
+    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.INT64));
+    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.DOUBLE));
+    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.FLOAT));
+    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.BOOLEAN));
+    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.INT96));
+  }
+
+  @Test
+  public void testFileHasCorruptStatistics() {
+    // Corrupt versions
+    assertTrue(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 1.6.0 (build abcd)"));
+    assertTrue(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 1.4.2 (build abcd)"));
+    assertTrue(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 1.7.999 (build abcd)"));
+    // Null/empty
+    assertTrue(CorruptStatistics.fileHasCorruptStatistics(null));
+    assertTrue(CorruptStatistics.fileHasCorruptStatistics(""));
+    // Unparseable
+    assertTrue(CorruptStatistics.fileHasCorruptStatistics("unparseable string"));
+    // Fixed versions
+    assertFalse(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 1.8.0 (build abcd)"));
+    assertFalse(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 2.0.0 (build abcd)"));
+    // Non-parquet-mr applications
+    assertFalse(CorruptStatistics.fileHasCorruptStatistics("impala version 1.6.0 (build abcd)"));
+  }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/CorruptStatisticsTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/CorruptStatisticsTest.java
@@ -126,32 +126,35 @@ public class CorruptStatisticsTest {
   }
 
   @Test
-  public void testIsCorruptStatisticsColumnType() {
-    assertTrue(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.BINARY));
-    assertTrue(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY));
-    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.INT32));
-    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.INT64));
-    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.DOUBLE));
-    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.FLOAT));
-    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.BOOLEAN));
-    assertFalse(CorruptStatistics.isCorruptStatisticsColumnType(PrimitiveTypeName.INT96));
+  public void testCorruptStatisticsColumnType() {
+    // These column types are affected by the PARQUET-251 bug
+    String corruptVersion = "parquet-mr version 1.6.0 (build abcd)";
+    assertTrue(CorruptStatistics.shouldIgnoreStatistics(corruptVersion, PrimitiveTypeName.BINARY));
+    assertTrue(CorruptStatistics.shouldIgnoreStatistics(corruptVersion, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY));
+    // These column types are NOT affected
+    assertFalse(CorruptStatistics.shouldIgnoreStatistics(corruptVersion, PrimitiveTypeName.INT32));
+    assertFalse(CorruptStatistics.shouldIgnoreStatistics(corruptVersion, PrimitiveTypeName.INT64));
+    assertFalse(CorruptStatistics.shouldIgnoreStatistics(corruptVersion, PrimitiveTypeName.DOUBLE));
+    assertFalse(CorruptStatistics.shouldIgnoreStatistics(corruptVersion, PrimitiveTypeName.FLOAT));
+    assertFalse(CorruptStatistics.shouldIgnoreStatistics(corruptVersion, PrimitiveTypeName.BOOLEAN));
+    assertFalse(CorruptStatistics.shouldIgnoreStatistics(corruptVersion, PrimitiveTypeName.INT96));
   }
 
   @Test
-  public void testFileHasCorruptStatistics() {
+  public void testMayHaveCorruptStatistics() {
     // Corrupt versions
-    assertTrue(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 1.6.0 (build abcd)"));
-    assertTrue(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 1.4.2 (build abcd)"));
-    assertTrue(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 1.7.999 (build abcd)"));
+    assertTrue(CorruptStatistics.mayHaveCorruptStatistics("parquet-mr version 1.6.0 (build abcd)"));
+    assertTrue(CorruptStatistics.mayHaveCorruptStatistics("parquet-mr version 1.4.2 (build abcd)"));
+    assertTrue(CorruptStatistics.mayHaveCorruptStatistics("parquet-mr version 1.7.999 (build abcd)"));
     // Null/empty
-    assertTrue(CorruptStatistics.fileHasCorruptStatistics(null));
-    assertTrue(CorruptStatistics.fileHasCorruptStatistics(""));
+    assertTrue(CorruptStatistics.mayHaveCorruptStatistics(null));
+    assertTrue(CorruptStatistics.mayHaveCorruptStatistics(""));
     // Unparseable
-    assertTrue(CorruptStatistics.fileHasCorruptStatistics("unparseable string"));
+    assertTrue(CorruptStatistics.mayHaveCorruptStatistics("unparseable string"));
     // Fixed versions
-    assertFalse(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 1.8.0 (build abcd)"));
-    assertFalse(CorruptStatistics.fileHasCorruptStatistics("parquet-mr version 2.0.0 (build abcd)"));
+    assertFalse(CorruptStatistics.mayHaveCorruptStatistics("parquet-mr version 1.8.0 (build abcd)"));
+    assertFalse(CorruptStatistics.mayHaveCorruptStatistics("parquet-mr version 2.0.0 (build abcd)"));
     // Non-parquet-mr applications
-    assertFalse(CorruptStatistics.fileHasCorruptStatistics("impala version 1.6.0 (build abcd)"));
+    assertFalse(CorruptStatistics.mayHaveCorruptStatistics("impala version 1.6.0 (build abcd)"));
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -947,6 +947,13 @@ public class ParquetMetadataConverter {
   // Visible for testing
   static org.apache.parquet.column.statistics.Statistics fromParquetStatisticsInternal(
       String createdBy, Statistics formatStats, PrimitiveType type, SortOrder typeSortOrder) {
+    boolean fileHasCorruptStats = CorruptStatistics.fileHasCorruptStatistics(createdBy);
+    return fromParquetStatisticsInternal(formatStats, type, typeSortOrder, fileHasCorruptStats);
+  }
+
+  // Core implementation using pre-computed file-level corrupt stats flag
+  static org.apache.parquet.column.statistics.Statistics fromParquetStatisticsInternal(
+      Statistics formatStats, PrimitiveType type, SortOrder typeSortOrder, boolean fileHasCorruptStats) {
     // create stats object based on the column type
     org.apache.parquet.column.statistics.Statistics.Builder statsBuilder =
         org.apache.parquet.column.statistics.Statistics.getBuilderForReading(type);
@@ -969,8 +976,10 @@ public class ParquetMetadataConverter {
         // valid with the type's sort order. In previous releases, all stats were
         // aggregated using a signed byte-wise ordering, which isn't valid for all the
         // types (e.g. strings, decimals etc.).
-        if (!CorruptStatistics.shouldIgnoreStatistics(createdBy, type.getPrimitiveTypeName())
-            && (sortOrdersMatch || maxEqualsMin)) {
+        // The fileHasCorruptStats flag applies only to BINARY and FIXED_LEN_BYTE_ARRAY columns.
+        boolean ignoreForThisColumn =
+            fileHasCorruptStats && CorruptStatistics.isCorruptStatisticsColumnType(type.getPrimitiveTypeName());
+        if (!ignoreForThisColumn && (sortOrdersMatch || maxEqualsMin)) {
           if (isSet) {
             statsBuilder.withMin(formatStats.min.array());
             statsBuilder.withMax(formatStats.max.array());
@@ -992,46 +1001,6 @@ public class ParquetMetadataConverter {
       String createdBy, Statistics statistics, PrimitiveType type) {
     SortOrder expectedOrder = overrideSortOrderToSigned(type) ? SortOrder.SIGNED : sortOrder(type);
     return fromParquetStatisticsInternal(createdBy, statistics, type, expectedOrder);
-  }
-
-  // Overload that uses a pre-computed shouldIgnoreCorruptStats flag to avoid redundant parsing
-  private org.apache.parquet.column.statistics.Statistics fromParquetStatisticsInternal(
-      String createdBy, Statistics formatStats, PrimitiveType type, boolean shouldIgnoreCorruptStats) {
-    SortOrder typeSortOrder = overrideSortOrderToSigned(type) ? SortOrder.SIGNED : sortOrder(type);
-    org.apache.parquet.column.statistics.Statistics.Builder statsBuilder =
-        org.apache.parquet.column.statistics.Statistics.getBuilderForReading(type);
-
-    if (formatStats != null) {
-      if (formatStats.isSetMin_value() && formatStats.isSetMax_value()) {
-        byte[] min = formatStats.min_value.array();
-        byte[] max = formatStats.max_value.array();
-        if (isMinMaxStatsSupported(type) || Arrays.equals(min, max)) {
-          statsBuilder.withMin(min);
-          statsBuilder.withMax(max);
-        }
-      } else {
-        boolean isSet = formatStats.isSetMax() && formatStats.isSetMin();
-        boolean maxEqualsMin = isSet ? Arrays.equals(formatStats.getMin(), formatStats.getMax()) : false;
-        boolean sortOrdersMatch = SortOrder.SIGNED == typeSortOrder;
-        // The shouldIgnoreCorruptStats flag applies only to BINARY and FIXED_LEN_BYTE_ARRAY.
-        // For other types, shouldIgnoreStatistics always returns false, so we only guard those.
-        PrimitiveTypeName primitiveTypeName = type.getPrimitiveTypeName();
-        boolean ignoreForThisColumn = shouldIgnoreCorruptStats
-            && (primitiveTypeName == PrimitiveTypeName.BINARY
-                || primitiveTypeName == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
-        if (!ignoreForThisColumn && (sortOrdersMatch || maxEqualsMin)) {
-          if (isSet) {
-            statsBuilder.withMin(formatStats.min.array());
-            statsBuilder.withMax(formatStats.max.array());
-          }
-        }
-      }
-
-      if (formatStats.isSetNull_count()) {
-        statsBuilder.withNumNulls(formatStats.null_count);
-      }
-    }
-    return statsBuilder.build();
   }
 
   GeospatialStatistics toParquetGeospatialStatistics(
@@ -1858,24 +1827,23 @@ public class ParquetMetadataConverter {
 
   public ColumnChunkMetaData buildColumnChunkMetaData(
       ColumnMetaData metaData, ColumnPath columnPath, PrimitiveType type, String createdBy) {
-    boolean shouldIgnoreCorruptStats =
-        CorruptStatistics.shouldIgnoreStatistics(createdBy, PrimitiveTypeName.BINARY);
-    return buildColumnChunkMetaData(metaData, columnPath, type, createdBy, shouldIgnoreCorruptStats);
+    boolean fileHasCorruptStats = CorruptStatistics.fileHasCorruptStatistics(createdBy);
+    return buildColumnChunkMetaData(metaData, columnPath, type, fileHasCorruptStats);
   }
 
   ColumnChunkMetaData buildColumnChunkMetaData(
       ColumnMetaData metaData,
       ColumnPath columnPath,
       PrimitiveType type,
-      String createdBy,
-      boolean shouldIgnoreCorruptStats) {
+      boolean fileHasCorruptStats) {
+    SortOrder typeSortOrder = overrideSortOrderToSigned(type) ? SortOrder.SIGNED : sortOrder(type);
     return ColumnChunkMetaData.get(
         columnPath,
         type,
         fromFormatCodec(metaData.codec),
         convertEncodingStats(metaData.getEncoding_stats()),
         fromFormatEncodings(metaData.encodings),
-        fromParquetStatisticsInternal(createdBy, metaData.statistics, type, shouldIgnoreCorruptStats),
+        fromParquetStatisticsInternal(metaData.statistics, type, typeSortOrder, fileHasCorruptStats),
         metaData.data_page_offset,
         metaData.dictionary_page_offset,
         metaData.num_values,
@@ -1904,10 +1872,11 @@ public class ParquetMetadataConverter {
     MessageType messageType = fromParquetSchema(parquetMetadata.getSchema(), parquetMetadata.getColumn_orders());
     List<BlockMetaData> blocks = new ArrayList<BlockMetaData>();
     List<RowGroup> row_groups = parquetMetadata.getRow_groups();
-    // Compute once per file: the result is the same for BINARY and FIXED_LEN_BYTE_ARRAY
-    // (the only types affected by PARQUET-251), and always false for other types.
-    boolean shouldIgnoreCorruptStats =
-        CorruptStatistics.shouldIgnoreStatistics(parquetMetadata.getCreated_by(), PrimitiveTypeName.BINARY);
+    // Compute once per file: whether this file was written by a version with the PARQUET-251 bug.
+    // Only parse created_by if the schema has columns affected by the bug (BINARY/FIXED_LEN_BYTE_ARRAY).
+    // The per-column type check is applied later when statistics are actually read.
+    boolean fileHasCorruptStats = schemaHasCorruptStatisticsColumnType(messageType)
+        && CorruptStatistics.fileHasCorruptStatistics(parquetMetadata.getCreated_by());
 
     if (row_groups != null) {
       for (RowGroup rowGroup : row_groups) {
@@ -1988,8 +1957,7 @@ public class ParquetMetadataConverter {
                 metaData,
                 columnPath,
                 messageType.getType(columnPath.toArray()).asPrimitiveType(),
-                createdBy,
-                shouldIgnoreCorruptStats);
+                fileHasCorruptStats);
             column.setRowGroupOrdinal(rowGroup.getOrdinal());
             if (metaData.isSetBloom_filter_offset()) {
               column.setBloomFilterOffset(metaData.getBloom_filter_offset());
@@ -2066,6 +2034,18 @@ public class ParquetMetadataConverter {
   private static ColumnPath getPath(ColumnMetaData metaData) {
     String[] path = metaData.path_in_schema.toArray(new String[0]);
     return ColumnPath.get(path);
+  }
+
+  /**
+   * Returns true if the schema contains at least one column with a type affected by the PARQUET-251 bug.
+   */
+  private static boolean schemaHasCorruptStatisticsColumnType(MessageType schema) {
+    for (ColumnDescriptor column : schema.getColumns()) {
+      if (CorruptStatistics.isCorruptStatisticsColumnType(column.getPrimitiveType().getPrimitiveTypeName())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // Visible for testing

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -994,6 +994,46 @@ public class ParquetMetadataConverter {
     return fromParquetStatisticsInternal(createdBy, statistics, type, expectedOrder);
   }
 
+  // Overload that uses a pre-computed shouldIgnoreCorruptStats flag to avoid redundant parsing
+  private org.apache.parquet.column.statistics.Statistics fromParquetStatisticsInternal(
+      String createdBy, Statistics formatStats, PrimitiveType type, boolean shouldIgnoreCorruptStats) {
+    SortOrder typeSortOrder = overrideSortOrderToSigned(type) ? SortOrder.SIGNED : sortOrder(type);
+    org.apache.parquet.column.statistics.Statistics.Builder statsBuilder =
+        org.apache.parquet.column.statistics.Statistics.getBuilderForReading(type);
+
+    if (formatStats != null) {
+      if (formatStats.isSetMin_value() && formatStats.isSetMax_value()) {
+        byte[] min = formatStats.min_value.array();
+        byte[] max = formatStats.max_value.array();
+        if (isMinMaxStatsSupported(type) || Arrays.equals(min, max)) {
+          statsBuilder.withMin(min);
+          statsBuilder.withMax(max);
+        }
+      } else {
+        boolean isSet = formatStats.isSetMax() && formatStats.isSetMin();
+        boolean maxEqualsMin = isSet ? Arrays.equals(formatStats.getMin(), formatStats.getMax()) : false;
+        boolean sortOrdersMatch = SortOrder.SIGNED == typeSortOrder;
+        // The shouldIgnoreCorruptStats flag applies only to BINARY and FIXED_LEN_BYTE_ARRAY.
+        // For other types, shouldIgnoreStatistics always returns false, so we only guard those.
+        PrimitiveTypeName primitiveTypeName = type.getPrimitiveTypeName();
+        boolean ignoreForThisColumn = shouldIgnoreCorruptStats
+            && (primitiveTypeName == PrimitiveTypeName.BINARY
+                || primitiveTypeName == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+        if (!ignoreForThisColumn && (sortOrdersMatch || maxEqualsMin)) {
+          if (isSet) {
+            statsBuilder.withMin(formatStats.min.array());
+            statsBuilder.withMax(formatStats.max.array());
+          }
+        }
+      }
+
+      if (formatStats.isSetNull_count()) {
+        statsBuilder.withNumNulls(formatStats.null_count);
+      }
+    }
+    return statsBuilder.build();
+  }
+
   GeospatialStatistics toParquetGeospatialStatistics(
       org.apache.parquet.column.statistics.geospatial.GeospatialStatistics geospatialStatistics) {
     if (geospatialStatistics == null) {
@@ -1818,13 +1858,24 @@ public class ParquetMetadataConverter {
 
   public ColumnChunkMetaData buildColumnChunkMetaData(
       ColumnMetaData metaData, ColumnPath columnPath, PrimitiveType type, String createdBy) {
+    boolean shouldIgnoreCorruptStats =
+        CorruptStatistics.shouldIgnoreStatistics(createdBy, PrimitiveTypeName.BINARY);
+    return buildColumnChunkMetaData(metaData, columnPath, type, createdBy, shouldIgnoreCorruptStats);
+  }
+
+  ColumnChunkMetaData buildColumnChunkMetaData(
+      ColumnMetaData metaData,
+      ColumnPath columnPath,
+      PrimitiveType type,
+      String createdBy,
+      boolean shouldIgnoreCorruptStats) {
     return ColumnChunkMetaData.get(
         columnPath,
         type,
         fromFormatCodec(metaData.codec),
         convertEncodingStats(metaData.getEncoding_stats()),
         fromFormatEncodings(metaData.encodings),
-        fromParquetStatistics(createdBy, metaData.statistics, type),
+        fromParquetStatisticsInternal(createdBy, metaData.statistics, type, shouldIgnoreCorruptStats),
         metaData.data_page_offset,
         metaData.dictionary_page_offset,
         metaData.num_values,
@@ -1853,6 +1904,10 @@ public class ParquetMetadataConverter {
     MessageType messageType = fromParquetSchema(parquetMetadata.getSchema(), parquetMetadata.getColumn_orders());
     List<BlockMetaData> blocks = new ArrayList<BlockMetaData>();
     List<RowGroup> row_groups = parquetMetadata.getRow_groups();
+    // Compute once per file: the result is the same for BINARY and FIXED_LEN_BYTE_ARRAY
+    // (the only types affected by PARQUET-251), and always false for other types.
+    boolean shouldIgnoreCorruptStats =
+        CorruptStatistics.shouldIgnoreStatistics(parquetMetadata.getCreated_by(), PrimitiveTypeName.BINARY);
 
     if (row_groups != null) {
       for (RowGroup rowGroup : row_groups) {
@@ -1933,7 +1988,8 @@ public class ParquetMetadataConverter {
                 metaData,
                 columnPath,
                 messageType.getType(columnPath.toArray()).asPrimitiveType(),
-                createdBy);
+                createdBy,
+                shouldIgnoreCorruptStats);
             column.setRowGroupOrdinal(rowGroup.getOrdinal());
             if (metaData.isSetBloom_filter_offset()) {
               column.setBloomFilterOffset(metaData.getBloom_filter_offset());

--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -947,7 +947,7 @@ public class ParquetMetadataConverter {
   // Visible for testing
   static org.apache.parquet.column.statistics.Statistics fromParquetStatisticsInternal(
       String createdBy, Statistics formatStats, PrimitiveType type, SortOrder typeSortOrder) {
-    boolean fileHasCorruptStats = CorruptStatistics.fileHasCorruptStatistics(createdBy);
+    boolean fileHasCorruptStats = CorruptStatistics.mayHaveCorruptStatistics(createdBy);
     return fromParquetStatisticsInternal(formatStats, type, typeSortOrder, fileHasCorruptStats);
   }
 
@@ -977,8 +977,9 @@ public class ParquetMetadataConverter {
         // aggregated using a signed byte-wise ordering, which isn't valid for all the
         // types (e.g. strings, decimals etc.).
         // The fileHasCorruptStats flag applies only to BINARY and FIXED_LEN_BYTE_ARRAY columns.
-        boolean ignoreForThisColumn =
-            fileHasCorruptStats && CorruptStatistics.isCorruptStatisticsColumnType(type.getPrimitiveTypeName());
+        boolean ignoreForThisColumn = fileHasCorruptStats
+            && (type.getPrimitiveTypeName() == PrimitiveTypeName.BINARY
+                || type.getPrimitiveTypeName() == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
         if (!ignoreForThisColumn && (sortOrdersMatch || maxEqualsMin)) {
           if (isSet) {
             statsBuilder.withMin(formatStats.min.array());
@@ -1827,15 +1828,12 @@ public class ParquetMetadataConverter {
 
   public ColumnChunkMetaData buildColumnChunkMetaData(
       ColumnMetaData metaData, ColumnPath columnPath, PrimitiveType type, String createdBy) {
-    boolean fileHasCorruptStats = CorruptStatistics.fileHasCorruptStatistics(createdBy);
+    boolean fileHasCorruptStats = CorruptStatistics.mayHaveCorruptStatistics(createdBy);
     return buildColumnChunkMetaData(metaData, columnPath, type, fileHasCorruptStats);
   }
 
   ColumnChunkMetaData buildColumnChunkMetaData(
-      ColumnMetaData metaData,
-      ColumnPath columnPath,
-      PrimitiveType type,
-      boolean fileHasCorruptStats) {
+      ColumnMetaData metaData, ColumnPath columnPath, PrimitiveType type, boolean fileHasCorruptStats) {
     SortOrder typeSortOrder = overrideSortOrderToSigned(type) ? SortOrder.SIGNED : sortOrder(type);
     return ColumnChunkMetaData.get(
         columnPath,
@@ -1876,7 +1874,7 @@ public class ParquetMetadataConverter {
     // Only parse created_by if the schema has columns affected by the bug (BINARY/FIXED_LEN_BYTE_ARRAY).
     // The per-column type check is applied later when statistics are actually read.
     boolean fileHasCorruptStats = schemaHasCorruptStatisticsColumnType(messageType)
-        && CorruptStatistics.fileHasCorruptStatistics(parquetMetadata.getCreated_by());
+        && CorruptStatistics.mayHaveCorruptStatistics(parquetMetadata.getCreated_by());
 
     if (row_groups != null) {
       for (RowGroup rowGroup : row_groups) {
@@ -2041,7 +2039,8 @@ public class ParquetMetadataConverter {
    */
   private static boolean schemaHasCorruptStatisticsColumnType(MessageType schema) {
     for (ColumnDescriptor column : schema.getColumns()) {
-      if (CorruptStatistics.isCorruptStatisticsColumnType(column.getPrimitiveType().getPrimitiveTypeName())) {
+      PrimitiveTypeName typeName = column.getPrimitiveType().getPrimitiveTypeName();
+      if (typeName == PrimitiveTypeName.BINARY || typeName == PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY) {
         return true;
       }
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -2158,7 +2158,9 @@ public class TestParquetMetadataConverter {
     ColumnIndex roundTrip = ParquetMetadataConverter.fromParquetColumnIndex(type, parquetColumnIndex);
     assertNotNull(roundTrip);
     assertEquals(List.of(1L, 0L, 0L), roundTrip.getNanCounts());
+  }
 
+  @Test
   public void testCorruptStatsPerColumnGate() {
     // A created_by string from a version known to have the PARQUET-251 bug
     String corruptCreatedBy = "parquet-mr version 1.6.0 (build abcd)";
@@ -2220,8 +2222,10 @@ public class TestParquetMetadataConverter {
     String corruptCreatedBy = "parquet-mr version 1.6.0 (build abcd)";
 
     MessageType intOnlySchema = Types.buildMessage()
-        .required(PrimitiveTypeName.INT32).named("id")
-        .required(PrimitiveTypeName.INT64).named("ts")
+        .required(PrimitiveTypeName.INT32)
+        .named("id")
+        .required(PrimitiveTypeName.INT64)
+        .named("ts")
         .named("msg");
 
     ParquetMetadataConverter converter = new ParquetMetadataConverter();
@@ -2238,7 +2242,10 @@ public class TestParquetMetadataConverter {
         Collections.<org.apache.parquet.format.Encoding>emptyList(),
         Collections.singletonList("id"),
         UNCOMPRESSED,
-        100L, 200L, 100L, 0L);
+        100L,
+        200L,
+        100L,
+        0L);
     cmd.setStatistics(stats);
 
     ColumnChunk cc = new ColumnChunk(0L);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -2158,5 +2158,104 @@ public class TestParquetMetadataConverter {
     ColumnIndex roundTrip = ParquetMetadataConverter.fromParquetColumnIndex(type, parquetColumnIndex);
     assertNotNull(roundTrip);
     assertEquals(List.of(1L, 0L, 0L), roundTrip.getNanCounts());
+
+  public void testCorruptStatsPerColumnGate() {
+    // A created_by string from a version known to have the PARQUET-251 bug
+    String corruptCreatedBy = "parquet-mr version 1.6.0 (build abcd)";
+
+    // Set up legacy V1 statistics with min/max (not min_value/max_value)
+    org.apache.parquet.format.Statistics formatStats = new org.apache.parquet.format.Statistics();
+    byte[] minBytes = new byte[] {0, 1, 2, 3};
+    byte[] maxBytes = new byte[] {4, 5, 6, 7};
+    formatStats.setMin(minBytes);
+    formatStats.setMax(maxBytes);
+    formatStats.setNull_count(5);
+
+    // For BINARY column: stats should be ignored (only null_count preserved)
+    PrimitiveType binaryType = new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.BINARY, "bin_col");
+    Statistics binaryStats = ParquetMetadataConverter.fromParquetStatisticsInternal(
+        corruptCreatedBy, formatStats, binaryType, ParquetMetadataConverter.SortOrder.SIGNED);
+    assertFalse("BINARY min/max should be ignored for corrupt file", binaryStats.hasNonNullValue());
+    assertEquals(5, binaryStats.getNumNulls());
+
+    // For FIXED_LEN_BYTE_ARRAY column: stats should also be ignored
+    PrimitiveType fixedType =
+        new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, 4, "fixed_col");
+    Statistics fixedStats = ParquetMetadataConverter.fromParquetStatisticsInternal(
+        corruptCreatedBy, formatStats, fixedType, ParquetMetadataConverter.SortOrder.SIGNED);
+    assertFalse("FIXED_LEN_BYTE_ARRAY min/max should be ignored for corrupt file", fixedStats.hasNonNullValue());
+    assertEquals(5, fixedStats.getNumNulls());
+
+    // For INT32 column: stats should NOT be ignored (per-column gate)
+    PrimitiveType int32Type = new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.INT32, "int_col");
+    Statistics int32Stats = ParquetMetadataConverter.fromParquetStatisticsInternal(
+        corruptCreatedBy, formatStats, int32Type, ParquetMetadataConverter.SortOrder.SIGNED);
+    assertTrue("INT32 min/max should NOT be ignored for corrupt file", int32Stats.hasNonNullValue());
+    assertEquals(5, int32Stats.getNumNulls());
+
+    // For INT64 column: stats should NOT be ignored
+    org.apache.parquet.format.Statistics formatStatsLong = new org.apache.parquet.format.Statistics();
+    byte[] minLong = new byte[] {0, 0, 0, 0, 0, 0, 0, 1};
+    byte[] maxLong = new byte[] {0, 0, 0, 0, 0, 0, 0, 7};
+    formatStatsLong.setMin(minLong);
+    formatStatsLong.setMax(maxLong);
+    formatStatsLong.setNull_count(5);
+    PrimitiveType int64Type = new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.INT64, "long_col");
+    Statistics int64Stats = ParquetMetadataConverter.fromParquetStatisticsInternal(
+        corruptCreatedBy, formatStatsLong, int64Type, ParquetMetadataConverter.SortOrder.SIGNED);
+    assertTrue("INT64 min/max should NOT be ignored for corrupt file", int64Stats.hasNonNullValue());
+    assertEquals(5, int64Stats.getNumNulls());
+
+    // For a non-corrupt file, BINARY stats should be preserved
+    String goodCreatedBy = "parquet-mr version 1.8.0 (build abcd)";
+    Statistics binaryStatsGood = ParquetMetadataConverter.fromParquetStatisticsInternal(
+        goodCreatedBy, formatStats, binaryType, ParquetMetadataConverter.SortOrder.SIGNED);
+    assertTrue("BINARY min/max should be kept for non-corrupt file", binaryStatsGood.hasNonNullValue());
+  }
+
+  @Test
+  public void testSchemaGateSkipsCorruptStatsCheckForNonBinarySchema() throws Exception {
+    // A file with ONLY INT32/INT64 columns should never trigger corrupt stats detection,
+    // even with a known-corrupt createdBy string.
+    String corruptCreatedBy = "parquet-mr version 1.6.0 (build abcd)";
+
+    MessageType intOnlySchema = Types.buildMessage()
+        .required(PrimitiveTypeName.INT32).named("id")
+        .required(PrimitiveTypeName.INT64).named("ts")
+        .named("msg");
+
+    ParquetMetadataConverter converter = new ParquetMetadataConverter();
+    List<SchemaElement> schemaElements = converter.toParquetSchema(intOnlySchema);
+
+    // Build ColumnMetaData with V1 statistics for the INT32 column
+    org.apache.parquet.format.Statistics stats = new org.apache.parquet.format.Statistics();
+    stats.setMin(new byte[] {0, 0, 0, 1});
+    stats.setMax(new byte[] {0, 0, 0, 7});
+    stats.setNull_count(0);
+
+    ColumnMetaData cmd = new ColumnMetaData(
+        Type.INT32,
+        Collections.<org.apache.parquet.format.Encoding>emptyList(),
+        Collections.singletonList("id"),
+        UNCOMPRESSED,
+        100L, 200L, 100L, 0L);
+    cmd.setStatistics(stats);
+
+    ColumnChunk cc = new ColumnChunk(0L);
+    cc.setMeta_data(cmd);
+    RowGroup rg = new RowGroup(List.of(cc), 100L, 1);
+
+    FileMetaData fmd = new FileMetaData(1, schemaElements, 1, List.of(rg));
+    fmd.setCreated_by(corruptCreatedBy);
+
+    // Parse via fromParquetMetadata – the schema gate should prevent fileHasCorruptStats
+    ParquetMetadata metadata = converter.fromParquetMetadata(fmd);
+    Statistics<?> columnStats =
+        metadata.getBlocks().get(0).getColumns().get(0).getStatistics();
+
+    // Stats should be preserved (not ignored) because schema has no BINARY/FIXED columns
+    assertTrue(
+        "INT32 stats should be preserved when schema has no corrupt-stats-affected columns",
+        columnStats.hasNonNullValue());
   }
 }


### PR DESCRIPTION
## Summary

Footer conversion previously evaluated `CorruptStatistics.shouldIgnoreStatistics(createdBy, columnType)` per (row-group x column), re-parsing the `created_by` version string on every call.

This PR factors `CorruptStatistics` into two orthogonal checks:
- `fileHasCorruptStatistics(createdBy)` - file-level, parsed once
- `isCorruptStatisticsColumnType(columnType)` - per-column type gate

The file-level corrupt-stats flag is precomputed once in `fromParquetMetadata`, gated on the schema containing at least one affected column type (BINARY or FIXED_LEN_BYTE_ARRAY), so binary-free files skip the `created_by` parsing entirely and avoid spurious PARQUET-251 warnings. The boolean is threaded through `buildColumnChunkMetaData`/`fromParquetStatisticsInternal` instead of re-parsing `created_by` per column.

Note: an earlier process-wide cache approach was dropped per review feedback.

## Tests
- `CorruptStatisticsTest`: unit tests for the factored methods (`fileHasCorruptStatistics`, `isCorruptStatisticsColumnType`)
- `TestParquetMetadataConverter#testCorruptStatsPerColumnGate`: verifies per-column gate behavior with corrupt/non-corrupt files
- `TestParquetMetadataConverter#testSchemaGateSkipsCorruptStatsCheckForNonBinarySchema`: verifies that an INT-only schema with a known-corrupt `created_by` preserves statistics (schema gate prevents unnecessary parsing)

Closes #3601