### PR TITLE
Bump parquet-format to 2.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
     <hadoop.version>3.3.0</hadoop.version>
-    <parquet.format.version>2.12.0</parquet.format.version>
+    <parquet.format.version>2.13.0</parquet.format.version>
     <previous.version>1.17.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>${thrift.executable}</format.thrift.executable>


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/parquet-format/releases/tag/apache-parquet-format-2.13.0 has been released.

### What changes are included in this PR?

Bump parquet-format to 2.13.0

### Are these changes tested?

Pass CI.

### Are there any user-facing changes?

No.