### PR TITLE
GH-3615: Use assertThat checks in parquet-variant tests

### DIFF
--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
@@ -18,10 +18,12 @@
  */
 package org.apache.parquet.variant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.LocalDate;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -77,7 +79,7 @@ public class TestVariantArray {
     Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b0011, 0x00}), VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(0, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(0);
     });
   }
 
@@ -87,7 +89,7 @@ public class TestVariantArray {
         ByteBuffer.wrap(new byte[] {0b10011, 0x00, 0x00, 0x00, 0x00}), VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(0, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(0);
     });
   }
 
@@ -98,7 +100,7 @@ public class TestVariantArray {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(511, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(511);
     });
   }
 
@@ -111,26 +113,24 @@ public class TestVariantArray {
 
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(5, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(5);
       VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.DATE);
-      Assert.assertEquals(
-          LocalDate.parse("2025-04-17"),
-          LocalDate.ofEpochDay(v.getElementAtIndex(0).getInt()));
+      assertThat(LocalDate.ofEpochDay(v.getElementAtIndex(0).getInt())).isEqualTo(LocalDate.parse("2025-04-17"));
       VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
+      assertThat(v.getElementAtIndex(1).getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getInt());
+      assertThat(v.getElementAtIndex(2).getInt()).isEqualTo(1234567890);
       VariantTestUtil.checkType(v.getElementAtIndex(3), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals("variant", v.getElementAtIndex(3).getString());
+      assertThat(v.getElementAtIndex(3).getString()).isEqualTo("variant");
       VariantTestUtil.checkType(v.getElementAtIndex(4), VariantUtil.ARRAY, Variant.Type.ARRAY);
 
       Variant nestedV = v.getElementAtIndex(4);
-      Assert.assertEquals(3, nestedV.numArrayElements());
+      assertThat(nestedV.numArrayElements()).isEqualTo(3);
       VariantTestUtil.checkType(nestedV.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, nestedV.getElementAtIndex(0).getInt());
+      assertThat(nestedV.getElementAtIndex(0).getInt()).isEqualTo(1234567890);
       VariantTestUtil.checkType(nestedV.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.NULL);
       VariantTestUtil.checkType(nestedV.getElementAtIndex(2), VariantUtil.SHORT_STR, Variant.Type.STRING);
-      Assert.assertEquals("c", nestedV.getElementAtIndex(2).getString());
+      assertThat(nestedV.getElementAtIndex(2).getString()).isEqualTo("c");
     });
   }
 
@@ -141,13 +141,13 @@ public class TestVariantArray {
 
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(3, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(3);
       VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals(randomString, v.getElementAtIndex(0).getString());
+      assertThat(v.getElementAtIndex(0).getString()).isEqualTo(randomString);
       VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
+      assertThat(v.getElementAtIndex(1).getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getInt());
+      assertThat(v.getElementAtIndex(2).getInt()).isEqualTo(1234567890);
     });
   }
 
@@ -171,13 +171,10 @@ public class TestVariantArray {
 
   @Test
   public void testInvalidArray() {
-    try {
-      // An object header
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b1000010}), VariantTestUtil.EMPTY_METADATA);
-      value.numArrayElements();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read OBJECT value as ARRAY", e.getMessage());
-    }
+    // An object header
+    Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b1000010}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::numArrayElements)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read OBJECT value as ARRAY");
   }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArrayBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArrayBuilder.java
@@ -18,10 +18,12 @@
  */
 package org.apache.parquet.variant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.UUID;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,13 +49,13 @@ public class TestVariantArrayBuilder {
 
     VariantTestUtil.testVariant(builder.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(3, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(3);
       VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1, v.getElementAtIndex(0).getInt());
+      assertThat(v.getElementAtIndex(0).getInt()).isEqualTo(1);
       VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.UUID);
-      Assert.assertEquals(expected, v.getElementAtIndex(1).getUUID());
+      assertThat(v.getElementAtIndex(1).getUUID()).isEqualTo(expected);
       VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(2, v.getElementAtIndex(2).getInt());
+      assertThat(v.getElementAtIndex(2).getInt()).isEqualTo(2);
     });
   }
 
@@ -64,7 +66,7 @@ public class TestVariantArrayBuilder {
     b.endArray();
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(0, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(0);
     });
   }
 
@@ -78,10 +80,10 @@ public class TestVariantArrayBuilder {
     b.endArray();
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(511, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(511);
       for (int i = 0; i < 511; i++) {
         VariantTestUtil.checkType(v.getElementAtIndex(i), VariantUtil.PRIMITIVE, Variant.Type.INT);
-        Assert.assertEquals(i, v.getElementAtIndex(i).getInt());
+        assertThat(v.getElementAtIndex(i).getInt()).isEqualTo(i);
       }
     });
   }
@@ -113,28 +115,28 @@ public class TestVariantArrayBuilder {
 
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(4, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(4);
       VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getElementAtIndex(0).getBoolean());
+      assertThat(v.getElementAtIndex(0).getBoolean()).isTrue();
 
       VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1, v.getElementAtIndex(1).numObjectElements());
+      assertThat(v.getElementAtIndex(1).numObjectElements()).isEqualTo(1);
       VariantTestUtil.checkType(
           v.getElementAtIndex(1).getFieldByKey("key"), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(321, v.getElementAtIndex(1).getFieldByKey("key").getInt());
+      assertThat(v.getElementAtIndex(1).getFieldByKey("key").getInt()).isEqualTo(321);
 
       VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getLong());
+      assertThat(v.getElementAtIndex(2).getLong()).isEqualTo(1234567890);
 
       VariantTestUtil.checkType(v.getElementAtIndex(3), VariantUtil.ARRAY, Variant.Type.ARRAY);
       Variant nested = v.getElementAtIndex(3);
-      Assert.assertEquals(3, nested.numArrayElements());
+      assertThat(nested.numArrayElements()).isEqualTo(3);
       VariantTestUtil.checkType(nested.getElementAtIndex(0), VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(0, nested.getElementAtIndex(0).numArrayElements());
+      assertThat(nested.getElementAtIndex(0).numArrayElements()).isEqualTo(0);
       VariantTestUtil.checkType(nested.getElementAtIndex(1), VariantUtil.SHORT_STR, Variant.Type.STRING);
-      Assert.assertEquals("variant", nested.getElementAtIndex(1).getString());
+      assertThat(nested.getElementAtIndex(1).getString()).isEqualTo("variant");
       VariantTestUtil.checkType(nested.getElementAtIndex(2), VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, nested.getElementAtIndex(2).numObjectElements());
+      assertThat(nested.getElementAtIndex(2).numObjectElements()).isEqualTo(0);
     });
   }
 
@@ -157,11 +159,11 @@ public class TestVariantArrayBuilder {
       for (int i = 1000; i >= 0; i--) {
         VariantTestUtil.checkType(curr, VariantUtil.ARRAY, Variant.Type.ARRAY);
         if (i == 0) {
-          Assert.assertEquals(0, curr.numArrayElements());
+          assertThat(curr.numArrayElements()).isEqualTo(0);
         } else {
-          Assert.assertEquals(2, curr.numArrayElements());
+          assertThat(curr.numArrayElements()).isEqualTo(2);
           VariantTestUtil.checkType(curr.getElementAtIndex(0), VariantUtil.SHORT_STR, Variant.Type.STRING);
-          Assert.assertEquals("str" + i, curr.getElementAtIndex(0).getString());
+          assertThat(curr.getElementAtIndex(0).getString()).isEqualTo("str" + i);
           curr = curr.getElementAtIndex(1);
         }
       }
@@ -178,13 +180,13 @@ public class TestVariantArrayBuilder {
 
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(3, v.numArrayElements());
+      assertThat(v.numArrayElements()).isEqualTo(3);
       VariantTestUtil.checkType(v.getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals(randomString, v.getElementAtIndex(0).getString());
+      assertThat(v.getElementAtIndex(0).getString()).isEqualTo(randomString);
       VariantTestUtil.checkType(v.getElementAtIndex(1), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getElementAtIndex(1).getBoolean());
+      assertThat(v.getElementAtIndex(1).getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getElementAtIndex(2), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-      Assert.assertEquals(1234567890, v.getElementAtIndex(2).getLong());
+      assertThat(v.getElementAtIndex(2).getLong()).isEqualTo(1234567890);
     });
   }
 
@@ -210,47 +212,35 @@ public class TestVariantArrayBuilder {
   public void testMissingEndArray() {
     VariantBuilder b = new VariantBuilder();
     b.startArray();
-    try {
-      b.build();
-      Assert.fail("Expected Exception when calling build() without endArray()");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::build)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call build() while an array is being built. Must call endArray() first.");
   }
 
   @Test
   public void testMissingStartArray() {
     VariantBuilder b = new VariantBuilder();
-    try {
-      b.endArray();
-      Assert.fail("Expected Exception when calling endArray() without startArray()");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endArray)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endArray() without calling startArray() first.");
   }
 
   @Test
   public void testInvalidAppendDuringArray() {
     VariantBuilder b = new VariantBuilder();
     b.startArray();
-    try {
-      b.appendInt(1);
-      Assert.fail("Expected Exception when calling append() before endArray()");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> b.appendInt(1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call append() methods while an array is being built. Must call endArray() first.");
   }
 
   @Test
   public void testStartArrayEndObject() {
     VariantBuilder b = new VariantBuilder();
     VariantArrayBuilder obj = b.startArray();
-    try {
-      obj.endObject();
-      Assert.fail("Expected Exception when calling endObject() while building array");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(obj::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endObject() without calling startObject() first.");
   }
 
   @Test
@@ -258,12 +248,9 @@ public class TestVariantArrayBuilder {
     VariantBuilder b = new VariantBuilder();
     VariantArrayBuilder arr = b.startArray();
     arr.startObject();
-    try {
-      b.endArray();
-      Assert.fail("Expected Exception when calling endArray() with an open nested object");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endArray)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endArray() while a nested object/array is still open.");
   }
 
   @Test
@@ -272,12 +259,9 @@ public class TestVariantArrayBuilder {
     VariantArrayBuilder arr = b.startArray();
     VariantObjectBuilder nested = arr.startObject();
     nested.appendKey("nested");
-    try {
-      b.endArray();
-      Assert.fail("Expected Exception when calling endArray() with an open nested object");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endArray)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endArray() while a nested object/array is still open.");
   }
 
   @Test
@@ -287,12 +271,9 @@ public class TestVariantArrayBuilder {
     VariantObjectBuilder nested = arr.startObject();
     nested.appendKey("nested");
     nested.appendInt(1);
-    try {
-      b.endArray();
-      Assert.fail("Expected Exception when calling endArray() with an open nested object");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endArray)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endArray() while a nested object/array is still open.");
   }
 
   @Test
@@ -300,12 +281,9 @@ public class TestVariantArrayBuilder {
     VariantBuilder b = new VariantBuilder();
     VariantArrayBuilder arr = b.startArray();
     arr.startArray();
-    try {
-      b.endArray();
-      Assert.fail("Expected Exception when calling endArray() with an open nested array");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endArray)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endArray() while a nested object/array is still open.");
   }
 
   @Test
@@ -314,11 +292,8 @@ public class TestVariantArrayBuilder {
     VariantArrayBuilder arr = b.startArray();
     VariantArrayBuilder nested = arr.startArray();
     nested.appendInt(1);
-    try {
-      b.endArray();
-      Assert.fail("Expected Exception when calling endArray() with an open nested array");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endArray)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endArray() while a nested object/array is still open.");
   }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
@@ -18,6 +18,9 @@
  */
 package org.apache.parquet.variant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.nio.ByteBuffer;
@@ -30,7 +33,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,7 +141,7 @@ public class TestVariantObject {
     Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10, 0x00}), VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(0);
     });
   }
 
@@ -149,7 +151,7 @@ public class TestVariantObject {
         ByteBuffer.wrap(new byte[] {0b1000010, 0x00, 0x00, 0x00, 0x00}), VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(0);
     });
   }
 
@@ -163,13 +165,13 @@ public class TestVariantObject {
         constructMetadata(false, ImmutableList.of("c", "b", "a")));
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(3);
       VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
+      assertThat(v.getFieldByKey("a").getInt()).isEqualTo(1234567890);
       VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getFieldByKey("b").getBoolean());
+      assertThat(v.getFieldByKey("b").getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals("variant", v.getFieldByKey("c").getString());
+      assertThat(v.getFieldByKey("c").getString()).isEqualTo("variant");
     });
   }
 
@@ -184,19 +186,18 @@ public class TestVariantObject {
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(3);
       VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
+      assertThat(v.getFieldByKey("a").getInt()).isEqualTo(1234567890);
       VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getFieldByKey("b").getBoolean());
+      assertThat(v.getFieldByKey("b").getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getFieldByKey("c"), VariantUtil.OBJECT, Variant.Type.OBJECT);
 
       Variant nestedV = v.getFieldByKey("c");
-      Assert.assertEquals(2, nestedV.numObjectElements());
+      assertThat(nestedV.numObjectElements()).isEqualTo(2);
       VariantTestUtil.checkType(nestedV.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.DATE);
-      Assert.assertEquals(
-          LocalDate.parse("2025-04-17"),
-          LocalDate.ofEpochDay(nestedV.getFieldByKey("a").getInt()));
+      assertThat(LocalDate.ofEpochDay(nestedV.getFieldByKey("a").getInt()))
+          .isEqualTo(LocalDate.parse("2025-04-17"));
       VariantTestUtil.checkType(nestedV.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.NULL);
     });
   }
@@ -211,13 +212,13 @@ public class TestVariantObject {
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(3);
       VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getFieldByKey("a").getInt());
+      assertThat(v.getFieldByKey("a").getInt()).isEqualTo(1234567890);
       VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getFieldByKey("b").getBoolean());
+      assertThat(v.getFieldByKey("b").getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals("variant", v.getFieldByKey("c").getString());
+      assertThat(v.getFieldByKey("c").getString()).isEqualTo("variant");
     });
   }
 
@@ -231,13 +232,13 @@ public class TestVariantObject {
         constructMetadata(true, ImmutableList.of("a", "b", "c")));
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(3);
       VariantTestUtil.checkType(v.getFieldByKey("a"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals(randomString, v.getFieldByKey("a").getString());
+      assertThat(v.getFieldByKey("a").getString()).isEqualTo(randomString);
       VariantTestUtil.checkType(v.getFieldByKey("b"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getFieldByKey("b").getBoolean());
+      assertThat(v.getFieldByKey("b").getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getFieldByKey("c"), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getFieldByKey("c").getInt());
+      assertThat(v.getFieldByKey("c").getInt()).isEqualTo(1234567890);
     });
   }
 
@@ -275,11 +276,11 @@ public class TestVariantObject {
         constructMetadata(true, fieldNames));
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(2, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(2);
       VariantTestUtil.checkType(v.getFieldByKey("z1"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getFieldByKey("z1").getBoolean());
+      assertThat(v.getFieldByKey("z1").getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getFieldByKey("z2"), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getFieldByKey("z2").getInt());
+      assertThat(v.getFieldByKey("z2").getInt()).isEqualTo(1234567890);
     });
   }
 
@@ -318,28 +319,23 @@ public class TestVariantObject {
         new Variant(ByteBuffer.wrap(constructObject(keys, fields, false)), constructMetadata(true, sortedKeys));
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1000, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(1000);
 
       for (int i = 0; i < 1000; i++) {
         String name = String.format("a%04d", i);
         VariantTestUtil.checkType(v.getFieldByKey(name), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-        Assert.assertEquals(
-            new String(fields.get(name), 5, fields.get(name).length - 5),
-            v.getFieldByKey(name).getString());
+        assertThat(v.getFieldByKey(name).getString())
+            .isEqualTo(new String(fields.get(name), 5, fields.get(name).length - 5));
       }
     });
   }
 
   @Test
   public void testInvalidObject() {
-    try {
-      // An array header
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10011}), VariantTestUtil.EMPTY_METADATA);
-      value.numObjectElements();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read ARRAY value as OBJECT", e.getMessage());
-    }
+    Variant value = new Variant(ByteBuffer.wrap(new byte[] {0b10011}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::numObjectElements)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read ARRAY value as OBJECT");
   }
 
   @Test
@@ -348,8 +344,9 @@ public class TestVariantObject {
     // buffer is only 3 bytes, so the offset table cannot fit.
     byte[] metadata = new byte[] {0x01, (byte) 200, 0x00};
     byte[] value = new byte[] {0x00};
-    Assert.assertThrows(
-        IllegalArgumentException.class, () -> new Variant(ByteBuffer.wrap(value), ByteBuffer.wrap(metadata)));
+    assertThatThrownBy(() -> new Variant(ByteBuffer.wrap(value), ByteBuffer.wrap(metadata)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variant metadata dictionary extends past buffer: dictSize=200");
   }
 
   @Test
@@ -358,8 +355,9 @@ public class TestVariantObject {
     // to guard against int overflow in the bound check arithmetic.
     byte[] metadata = new byte[] {(byte) 0xC1, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0x7F};
     byte[] value = new byte[] {0x00};
-    Assert.assertThrows(
-        IllegalArgumentException.class, () -> new Variant(ByteBuffer.wrap(value), ByteBuffer.wrap(metadata)));
+    assertThatThrownBy(() -> new Variant(ByteBuffer.wrap(value), ByteBuffer.wrap(metadata)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variant metadata dictionary extends past buffer: dictSize=2147483647");
   }
 
   @Test
@@ -368,8 +366,9 @@ public class TestVariantObject {
     // dictSize field itself can't be read.
     byte[] metadata = new byte[] {(byte) 0xC1, 0x00, 0x00};
     byte[] value = new byte[] {0x00};
-    Assert.assertThrows(
-        IllegalArgumentException.class, () -> new Variant(ByteBuffer.wrap(value), ByteBuffer.wrap(metadata)));
+    assertThatThrownBy(() -> new Variant(ByteBuffer.wrap(value), ByteBuffer.wrap(metadata)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("variant metadata truncated: offsetSize=4");
   }
 
   @Test
@@ -403,8 +402,8 @@ public class TestVariantObject {
     // With a non-zero position and read-only buffer, the else-branch is taken,
     // which previously used the wrong offset.
     ImmutableMetadata immutableMetadata = new ImmutableMetadata(offsetMetadata);
-    Assert.assertEquals(0, immutableMetadata.getOrInsert("name"));
-    Assert.assertEquals(1, immutableMetadata.getOrInsert("age"));
+    assertThat(immutableMetadata.getOrInsert("name")).isEqualTo(0);
+    assertThat(immutableMetadata.getOrInsert("age")).isEqualTo(1);
   }
 
   @Test
@@ -423,12 +422,12 @@ public class TestVariantObject {
 
     // hasArray branch
     ImmutableMetadata writable = new ImmutableMetadata(metaBuf);
-    Assert.assertEquals(0, writable.getOrInsert("élève"));
-    Assert.assertEquals(1, writable.getOrInsert("中文"));
+    assertThat(writable.getOrInsert("élève")).isEqualTo(0);
+    assertThat(writable.getOrInsert("中文")).isEqualTo(1);
 
     // read-only branch (else path in getMetadataMap): asReadOnlyBuffer() makes isReadOnly() true
     ImmutableMetadata readOnly = new ImmutableMetadata(metaBuf.asReadOnlyBuffer());
-    Assert.assertEquals(0, readOnly.getOrInsert("élève"));
-    Assert.assertEquals(1, readOnly.getOrInsert("中文"));
+    assertThat(readOnly.getOrInsert("élève")).isEqualTo(0);
+    assertThat(readOnly.getOrInsert("中文")).isEqualTo(1);
   }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
@@ -18,10 +18,12 @@
  */
 package org.apache.parquet.variant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.UUID;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -47,9 +49,9 @@ public class TestVariantObjectBuilder {
 
     VariantTestUtil.testVariant(builder.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(1);
       VariantTestUtil.checkType(v.getFieldByKey("id"), VariantUtil.PRIMITIVE, Variant.Type.UUID);
-      Assert.assertEquals(expected, v.getFieldByKey("id").getUUID());
+      assertThat(v.getFieldByKey("id").getUUID()).isEqualTo(expected);
     });
   }
 
@@ -60,7 +62,7 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(0);
     });
   }
 
@@ -75,10 +77,10 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1234, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(1234);
       for (int i = 0; i < 1234; i++) {
         VariantTestUtil.checkType(v.getFieldByKey("a" + i), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-        Assert.assertEquals(i, v.getFieldByKey("a" + i).getLong());
+        assertThat(v.getFieldByKey("a" + i).getLong()).isEqualTo(i);
       }
     });
   }
@@ -116,28 +118,28 @@ public class TestVariantObjectBuilder {
 
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(4, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(4);
       VariantTestUtil.checkType(v.getFieldByKey("outer 1"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getFieldByKey("outer 1").getBoolean());
+      assertThat(v.getFieldByKey("outer 1").getBoolean()).isTrue();
       VariantTestUtil.checkType(v.getFieldByKey("outer 2"), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-      Assert.assertEquals(1234567890, v.getFieldByKey("outer 2").getLong());
+      assertThat(v.getFieldByKey("outer 2").getLong()).isEqualTo(1234567890);
       VariantTestUtil.checkType(v.getFieldByKey("outer 3"), VariantUtil.OBJECT, Variant.Type.OBJECT);
 
       Variant nested = v.getFieldByKey("outer 3");
-      Assert.assertEquals(3, nested.numObjectElements());
+      assertThat(nested.numObjectElements()).isEqualTo(3);
       VariantTestUtil.checkType(nested.getFieldByKey("nested 1"), VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(0, nested.getFieldByKey("nested 1").numObjectElements());
+      assertThat(nested.getFieldByKey("nested 1").numObjectElements()).isEqualTo(0);
       VariantTestUtil.checkType(nested.getFieldByKey("nested 2"), VariantUtil.SHORT_STR, Variant.Type.STRING);
-      Assert.assertEquals("variant", nested.getFieldByKey("nested 2").getString());
+      assertThat(nested.getFieldByKey("nested 2").getString()).isEqualTo("variant");
       VariantTestUtil.checkType(nested.getFieldByKey("nested 3"), VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(1, nested.getFieldByKey("nested 3").numArrayElements());
+      assertThat(nested.getFieldByKey("nested 3").numArrayElements()).isEqualTo(1);
       VariantTestUtil.checkType(
           nested.getFieldByKey("nested 3").getElementAtIndex(0), VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(
-          321, nested.getFieldByKey("nested 3").getElementAtIndex(0).getInt());
+      assertThat(nested.getFieldByKey("nested 3").getElementAtIndex(0).getInt())
+          .isEqualTo(321);
 
       VariantTestUtil.checkType(v.getFieldByKey("outer 4"), VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(0, v.getFieldByKey("outer 4").numArrayElements());
+      assertThat(v.getFieldByKey("outer 4").numArrayElements()).isEqualTo(0);
     });
   }
 
@@ -157,22 +159,16 @@ public class TestVariantObjectBuilder {
 
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(2, v.numObjectElements());
-      Assert.assertEquals(
-          ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
-          v.getFieldByKey("as_binary").getBinary());
+      assertThat(v.numObjectElements()).isEqualTo(2);
+      assertThat(v.getFieldByKey("as_binary").getBinary())
+          .isEqualTo(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
       Variant nestedArray = v.getFieldByKey("in_array");
       VariantTestUtil.checkType(nestedArray, VariantUtil.ARRAY, Variant.Type.ARRAY);
-      Assert.assertEquals(3, nestedArray.numArrayElements());
-      Assert.assertEquals(
-          ByteBuffer.wrap(new byte[] {}),
-          nestedArray.getElementAtIndex(0).getBinary());
-      Assert.assertEquals(
-          ByteBuffer.wrap(new byte[] {10, 11, 12, 13, 14, 15, 16}),
-          nestedArray.getElementAtIndex(1).getBinary());
-      Assert.assertEquals(
-          ByteBuffer.wrap(new byte[] {17, 18}),
-          nestedArray.getElementAtIndex(2).getBinary());
+      assertThat(nestedArray.numArrayElements()).isEqualTo(3);
+      assertThat(nestedArray.getElementAtIndex(0).getBinary()).isEqualTo(ByteBuffer.wrap(new byte[] {}));
+      assertThat(nestedArray.getElementAtIndex(1).getBinary())
+          .isEqualTo(ByteBuffer.wrap(new byte[] {10, 11, 12, 13, 14, 15, 16}));
+      assertThat(nestedArray.getElementAtIndex(2).getBinary()).isEqualTo(ByteBuffer.wrap(new byte[] {17, 18}));
     });
   }
 
@@ -197,12 +193,12 @@ public class TestVariantObjectBuilder {
       for (int i = 1000; i >= 0; i--) {
         VariantTestUtil.checkType(curr, VariantUtil.OBJECT, Variant.Type.OBJECT);
         if (i == 0) {
-          Assert.assertEquals(0, curr.numObjectElements());
+          assertThat(curr.numObjectElements()).isEqualTo(0);
         } else {
-          Assert.assertEquals(2, curr.numObjectElements());
+          assertThat(curr.numObjectElements()).isEqualTo(2);
           VariantTestUtil.checkType(
               curr.getFieldByKey("key" + i), VariantUtil.SHORT_STR, Variant.Type.STRING);
-          Assert.assertEquals("str" + i, curr.getFieldByKey("key" + i).getString());
+          assertThat(curr.getFieldByKey("key" + i).getString()).isEqualTo("str" + i);
           curr = curr.getFieldByKey("duplicate");
         }
       }
@@ -222,13 +218,13 @@ public class TestVariantObjectBuilder {
 
     Variant v = b.build();
     VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-    Assert.assertEquals(3, v.numObjectElements());
+    assertThat(v.numObjectElements()).isEqualTo(3);
     VariantTestUtil.checkType(v.getFieldByKey("key1"), VariantUtil.PRIMITIVE, Variant.Type.STRING);
-    Assert.assertEquals(randomString, v.getFieldByKey("key1").getString());
+    assertThat(v.getFieldByKey("key1").getString()).isEqualTo(randomString);
     VariantTestUtil.checkType(v.getFieldByKey("key2"), VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-    Assert.assertTrue(v.getFieldByKey("key2").getBoolean());
+    assertThat(v.getFieldByKey("key2").getBoolean()).isTrue();
     VariantTestUtil.checkType(v.getFieldByKey("key3"), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-    Assert.assertEquals(1234567890, v.getFieldByKey("key3").getLong());
+    assertThat(v.getFieldByKey("key3").getLong()).isEqualTo(1234567890);
   }
 
   @Test
@@ -260,12 +256,12 @@ public class TestVariantObjectBuilder {
 
     Variant v = b.build();
     VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-    Assert.assertEquals(numKeys, v.numObjectElements());
+    assertThat(v.numObjectElements()).isEqualTo(numKeys);
     // Only check a few keys, to avoid slowing down the test
     VariantTestUtil.checkType(v.getFieldByKey("k" + 0), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-    Assert.assertEquals(0, v.getFieldByKey("k" + 0).getLong());
+    assertThat(v.getFieldByKey("k" + 0).getLong()).isEqualTo(0);
     VariantTestUtil.checkType(v.getFieldByKey("k" + (numKeys - 1)), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-    Assert.assertEquals(numKeys - 1, v.getFieldByKey("k" + (numKeys - 1)).getLong());
+    assertThat(v.getFieldByKey("k" + (numKeys - 1)).getLong()).isEqualTo(numKeys - 1);
   }
 
   @Test
@@ -297,9 +293,9 @@ public class TestVariantObjectBuilder {
     objBuilder.appendLong(1);
     b.endObject();
     Variant v = b.build();
-    Assert.assertEquals(1, v.numObjectElements());
+    assertThat(v.numObjectElements()).isEqualTo(1);
     VariantTestUtil.checkType(v.getFieldByKey("duplicate"), VariantUtil.PRIMITIVE, Variant.Type.LONG);
-    Assert.assertEquals(1, v.getFieldByKey("duplicate").getLong());
+    assertThat(v.getFieldByKey("duplicate").getLong()).isEqualTo(1);
   }
 
   @Test
@@ -315,10 +311,10 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(1);
       Variant variant = v.getFieldByKey("duplicate");
       VariantTestUtil.checkType(variant, VariantUtil.SHORT_STR, Variant.Type.STRING);
-      Assert.assertEquals("hello", variant.getString());
+      assertThat(variant.getString()).isEqualTo("hello");
     });
   }
 
@@ -335,10 +331,10 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(1, v.numObjectElements());
+      assertThat(v.numObjectElements()).isEqualTo(1);
       Variant variant = v.getFieldByKey("duplicate");
       VariantTestUtil.checkType(variant, VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1, variant.getInt());
+      assertThat(variant.getInt()).isEqualTo(1);
     });
   }
 
@@ -361,10 +357,10 @@ public class TestVariantObjectBuilder {
     b.endObject();
     VariantTestUtil.testVariant(b.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
-      Assert.assertEquals(3, v.numObjectElements());
-      Assert.assertEquals("a-final", v.getFieldByKey("a").getString());
-      Assert.assertEquals(123456789L, v.getFieldByKey("b").getLong());
-      Assert.assertEquals("c-only", v.getFieldByKey("c").getString());
+      assertThat(v.numObjectElements()).isEqualTo(3);
+      assertThat(v.getFieldByKey("a").getString()).isEqualTo("a-final");
+      assertThat(v.getFieldByKey("b").getLong()).isEqualTo(123456789L);
+      assertThat(v.getFieldByKey("c").getString()).isEqualTo("c-only");
     });
   }
 
@@ -382,38 +378,32 @@ public class TestVariantObjectBuilder {
     objBuilder.appendString("22");
     b.endObject();
     Variant v = b.build();
-    Assert.assertEquals(4, v.numObjectElements());
+    assertThat(v.numObjectElements()).isEqualTo(4);
     VariantTestUtil.checkType(v.getFieldByKey("0"), VariantUtil.SHORT_STR, Variant.Type.STRING);
-    Assert.assertEquals("", v.getFieldByKey("0").getString());
+    assertThat(v.getFieldByKey("0").getString()).isEqualTo("");
     VariantTestUtil.checkType(v.getFieldByKey("1"), VariantUtil.SHORT_STR, Variant.Type.STRING);
-    Assert.assertEquals("1", v.getFieldByKey("1").getString());
+    assertThat(v.getFieldByKey("1").getString()).isEqualTo("1");
     VariantTestUtil.checkType(v.getFieldByKey("2"), VariantUtil.SHORT_STR, Variant.Type.STRING);
-    Assert.assertEquals("22", v.getFieldByKey("2").getString());
+    assertThat(v.getFieldByKey("2").getString()).isEqualTo("22");
     VariantTestUtil.checkType(v.getFieldByKey("3"), VariantUtil.SHORT_STR, Variant.Type.STRING);
-    Assert.assertEquals("333", v.getFieldByKey("3").getString());
+    assertThat(v.getFieldByKey("3").getString()).isEqualTo("333");
   }
 
   @Test
   public void testMissingEndObject() {
     VariantBuilder b = new VariantBuilder();
     b.startObject();
-    try {
-      b.build();
-      Assert.fail("Expected Exception when calling build() without endObject()");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::build)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call build() while an object is being built. Must call endObject() first.");
   }
 
   @Test
   public void testMissingStartObject() {
     VariantBuilder b = new VariantBuilder();
-    try {
-      b.endObject();
-      Assert.fail("Expected Exception when calling endObject() without startObject()");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endObject() without calling startObject() first.");
   }
 
   @Test
@@ -421,33 +411,25 @@ public class TestVariantObjectBuilder {
     VariantBuilder b = new VariantBuilder();
     VariantObjectBuilder obj = b.startObject();
     obj.appendKey("a");
-    try {
-      b.endObject();
-      Assert.fail("Expected Exception when calling endObject() with mismatched keys and values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Number of object keys (1) do not match the number of values (0).");
 
     obj.appendInt(1);
     obj.appendKey("b");
-    try {
-      b.endObject();
-      Assert.fail("Expected Exception when calling endObject() with mismatched keys and values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Number of object keys (2) do not match the number of values (1).");
   }
 
   @Test
   public void testInvalidAppendDuringObjectAppend() {
     VariantBuilder b = new VariantBuilder();
     b.startObject();
-    try {
-      b.appendInt(1);
-      Assert.fail("Expected Exception when calling append() before endObject()");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> b.appendInt(1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Cannot call append() methods while an object is being built. Must call endObject() first.");
   }
 
   @Test
@@ -455,24 +437,18 @@ public class TestVariantObjectBuilder {
     VariantBuilder b = new VariantBuilder();
     VariantObjectBuilder obj = b.startObject();
     obj.appendKey("a");
-    try {
-      obj.appendKey("a");
-      Assert.fail("Expected Exception when calling appendKey() multiple times without appending a value");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> obj.appendKey("a"))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call appendKey() before appending a value for the previous key.");
   }
 
   @Test
   public void testNoAppendKey() {
     VariantBuilder b = new VariantBuilder();
     VariantObjectBuilder obj = b.startObject();
-    try {
-      obj.appendInt(1);
-      Assert.fail("Expected Exception when appending a value, before appending a key");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> obj.appendInt(1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot append an object value before calling appendKey()");
   }
 
   @Test
@@ -481,24 +457,18 @@ public class TestVariantObjectBuilder {
     VariantObjectBuilder obj = b.startObject();
     obj.appendKey("a");
     obj.appendInt(1);
-    try {
-      obj.appendInt(1);
-      Assert.fail("Expected Exception when appending a value, before appending a key");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> obj.appendInt(1))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot append an object value before calling appendKey()");
   }
 
   @Test
   public void testStartObjectEndArray() {
     VariantBuilder b = new VariantBuilder();
     VariantObjectBuilder obj = b.startObject();
-    try {
-      obj.endArray();
-      Assert.fail("Expected Exception when calling endArray() while building object");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(obj::endArray)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endArray() without calling startArray() first.");
   }
 
   @Test
@@ -507,12 +477,9 @@ public class TestVariantObjectBuilder {
     VariantObjectBuilder obj = b.startObject();
     obj.appendKey("outer");
     obj.startObject();
-    try {
-      b.endObject();
-      Assert.fail("Expected Exception when calling endObject() with an open nested object");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endObject() while a nested object/array is still open.");
   }
 
   @Test
@@ -522,12 +489,9 @@ public class TestVariantObjectBuilder {
     obj.appendKey("outer");
     VariantObjectBuilder nested = obj.startObject();
     nested.appendKey("nested");
-    try {
-      b.endObject();
-      Assert.fail("Expected Exception when calling endObject() with an open nested object");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endObject() while a nested object/array is still open.");
   }
 
   @Test
@@ -538,12 +502,9 @@ public class TestVariantObjectBuilder {
     VariantObjectBuilder nested = obj.startObject();
     nested.appendKey("nested");
     nested.appendInt(1);
-    try {
-      b.endObject();
-      Assert.fail("Expected Exception when calling endObject() with an open nested object");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endObject() while a nested object/array is still open.");
   }
 
   @Test
@@ -552,12 +513,9 @@ public class TestVariantObjectBuilder {
     VariantObjectBuilder obj = b.startObject();
     obj.appendKey("outer");
     obj.startArray();
-    try {
-      b.endObject();
-      Assert.fail("Expected Exception when calling endObject() with an open nested array");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endObject() while a nested object/array is still open.");
   }
 
   @Test
@@ -567,11 +525,8 @@ public class TestVariantObjectBuilder {
     obj.appendKey("outer");
     VariantArrayBuilder nested = obj.startArray();
     nested.appendInt(1);
-    try {
-      b.endObject();
-      Assert.fail("Expected Exception when calling endObject() with an open nested array");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(b::endObject)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call endObject() while a nested object/array is still open.");
   }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantParseJson.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantParseJson.java
@@ -18,11 +18,14 @@
  */
 package org.apache.parquet.variant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 import java.math.BigDecimal;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestVariantParseJson {
@@ -30,73 +33,71 @@ public class TestVariantParseJson {
   @Test
   public void testParseNull() throws IOException {
     Variant v = VariantJsonParser.parseJson("null");
-    Assert.assertEquals(Variant.Type.NULL, v.getType());
+    assertThat(v.getType()).isEqualTo(Variant.Type.NULL);
   }
 
   @Test
   public void testParseTrue() throws IOException {
     Variant v = VariantJsonParser.parseJson("true");
-    Assert.assertEquals(Variant.Type.BOOLEAN, v.getType());
-    Assert.assertTrue(v.getBoolean());
+    assertThat(v.getType()).isEqualTo(Variant.Type.BOOLEAN);
+    assertThat(v.getBoolean()).isTrue();
   }
 
   @Test
   public void testParseFalse() throws IOException {
     Variant v = VariantJsonParser.parseJson("false");
-    Assert.assertEquals(Variant.Type.BOOLEAN, v.getType());
-    Assert.assertFalse(v.getBoolean());
+    assertThat(v.getType()).isEqualTo(Variant.Type.BOOLEAN);
+    assertThat(v.getBoolean()).isFalse();
   }
 
   @Test
   public void testParseString() throws IOException {
     Variant v = VariantJsonParser.parseJson("\"hello world\"");
-    Assert.assertEquals(Variant.Type.STRING, v.getType());
-    Assert.assertEquals("hello world", v.getString());
+    assertThat(v.getType()).isEqualTo(Variant.Type.STRING);
+    assertThat(v.getString()).isEqualTo("hello world");
   }
 
   @Test
   public void testParseSmallInteger() throws IOException {
     Variant v = VariantJsonParser.parseJson("42");
-    Assert.assertEquals(Variant.Type.BYTE, v.getType());
-    Assert.assertEquals(42, v.getLong());
+    assertThat(v.getType()).isEqualTo(Variant.Type.BYTE);
+    assertThat(v.getLong()).isEqualTo(42);
   }
 
   @Test
   public void testParseShortInteger() throws IOException {
     Variant v = VariantJsonParser.parseJson("1000");
-    Assert.assertEquals(Variant.Type.SHORT, v.getType());
-    Assert.assertEquals(1000, v.getLong());
+    assertThat(v.getType()).isEqualTo(Variant.Type.SHORT);
+    assertThat(v.getLong()).isEqualTo(1000);
   }
 
   @Test
   public void testParseIntInteger() throws IOException {
     Variant v = VariantJsonParser.parseJson("100000");
-    Assert.assertEquals(Variant.Type.INT, v.getType());
-    Assert.assertEquals(100000, v.getLong());
+    assertThat(v.getType()).isEqualTo(Variant.Type.INT);
+    assertThat(v.getLong()).isEqualTo(100000);
   }
 
   @Test
   public void testParseLongInteger() throws IOException {
     Variant v = VariantJsonParser.parseJson("9999999999");
-    Assert.assertEquals(Variant.Type.LONG, v.getType());
-    Assert.assertEquals(9999999999L, v.getLong());
+    assertThat(v.getType()).isEqualTo(Variant.Type.LONG);
+    assertThat(v.getLong()).isEqualTo(9999999999L);
   }
 
   @Test
   public void testParseDecimalFloat() throws IOException {
     Variant v = VariantJsonParser.parseJson("3.14");
     Variant.Type type = v.getType();
-    Assert.assertTrue(
-        "Expected decimal type, got " + type,
-        type == Variant.Type.DECIMAL4 || type == Variant.Type.DECIMAL8 || type == Variant.Type.DECIMAL16);
-    Assert.assertEquals(0, new BigDecimal("3.14").compareTo(v.getDecimal()));
+    assertThat(type).isIn(Variant.Type.DECIMAL4, Variant.Type.DECIMAL8, Variant.Type.DECIMAL16);
+    assertThat(v.getDecimal()).isEqualByComparingTo(new BigDecimal("3.14"));
   }
 
   @Test
   public void testParseScientificNotationDouble() throws IOException {
     Variant v = VariantJsonParser.parseJson("1.5e10");
-    Assert.assertEquals(Variant.Type.DOUBLE, v.getType());
-    Assert.assertEquals(1.5e10, v.getDouble(), 0.001);
+    assertThat(v.getType()).isEqualTo(Variant.Type.DOUBLE);
+    assertThat(v.getDouble()).isCloseTo(1.5e10, within(0.001));
   }
 
   @Test
@@ -104,105 +105,102 @@ public class TestVariantParseJson {
     String bigNum = "99999999999999999999";
     Variant v = VariantJsonParser.parseJson(bigNum);
     Variant.Type type = v.getType();
-    Assert.assertTrue(
-        "Expected decimal type for big integer, got " + type,
-        type == Variant.Type.DECIMAL4 || type == Variant.Type.DECIMAL8 || type == Variant.Type.DECIMAL16);
-    Assert.assertEquals(0, new BigDecimal(bigNum).compareTo(v.getDecimal()));
+    assertThat(type).isIn(Variant.Type.DECIMAL4, Variant.Type.DECIMAL8, Variant.Type.DECIMAL16);
+    assertThat(v.getDecimal()).isEqualByComparingTo(new BigDecimal(bigNum));
   }
 
   @Test
   public void testParseNegativeInteger() throws IOException {
     Variant v = VariantJsonParser.parseJson("-100");
-    Assert.assertEquals(-100, v.getLong());
+    assertThat(v.getLong()).isEqualTo(-100);
   }
 
   @Test
   public void testParseNegativeDecimal() throws IOException {
     Variant v = VariantJsonParser.parseJson("-99.99");
-    Assert.assertEquals(0, new BigDecimal("-99.99").compareTo(v.getDecimal()));
+    assertThat(v.getDecimal()).isEqualByComparingTo(new BigDecimal("-99.99"));
   }
 
   @Test
   public void testParseZero() throws IOException {
     Variant v = VariantJsonParser.parseJson("0");
-    Assert.assertEquals(Variant.Type.BYTE, v.getType());
-    Assert.assertEquals(0, v.getLong());
+    assertThat(v.getType()).isEqualTo(Variant.Type.BYTE);
+    assertThat(v.getLong()).isEqualTo(0);
   }
 
   @Test
   public void testParseEmptyObject() throws IOException {
     Variant v = VariantJsonParser.parseJson("{}");
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
-    Assert.assertEquals(0, v.numObjectElements());
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
+    assertThat(v.numObjectElements()).isEqualTo(0);
   }
 
   @Test
   public void testParseSimpleObject() throws IOException {
     Variant v = VariantJsonParser.parseJson("{\"name\":\"John\",\"age\":30}");
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
-    Assert.assertEquals(2, v.numObjectElements());
-    Assert.assertEquals("John", v.getFieldByKey("name").getString());
-    Assert.assertEquals(30, v.getFieldByKey("age").getLong());
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
+    assertThat(v.numObjectElements()).isEqualTo(2);
+    assertThat(v.getFieldByKey("name").getString()).isEqualTo("John");
+    assertThat(v.getFieldByKey("age").getLong()).isEqualTo(30);
   }
 
   @Test
   public void testParseNestedObject() throws IOException {
     Variant v = VariantJsonParser.parseJson("{\"user\":{\"id\":100,\"country\":\"US\"},\"active\":true}");
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
     Variant user = v.getFieldByKey("user");
-    Assert.assertEquals(Variant.Type.OBJECT, user.getType());
-    Assert.assertEquals(100, user.getFieldByKey("id").getLong());
-    Assert.assertEquals("US", user.getFieldByKey("country").getString());
-    Assert.assertTrue(v.getFieldByKey("active").getBoolean());
+    assertThat(user.getType()).isEqualTo(Variant.Type.OBJECT);
+    assertThat(user.getFieldByKey("id").getLong()).isEqualTo(100);
+    assertThat(user.getFieldByKey("country").getString()).isEqualTo("US");
+    assertThat(v.getFieldByKey("active").getBoolean()).isTrue();
   }
 
   @Test
   public void testParseEmptyArray() throws IOException {
     Variant v = VariantJsonParser.parseJson("[]");
-    Assert.assertEquals(Variant.Type.ARRAY, v.getType());
-    Assert.assertEquals(0, v.numArrayElements());
+    assertThat(v.getType()).isEqualTo(Variant.Type.ARRAY);
+    assertThat(v.numArrayElements()).isEqualTo(0);
   }
 
   @Test
   public void testParseSimpleArray() throws IOException {
     Variant v = VariantJsonParser.parseJson("[1,2,3,\"four\"]");
-    Assert.assertEquals(Variant.Type.ARRAY, v.getType());
-    Assert.assertEquals(4, v.numArrayElements());
-    Assert.assertEquals(1, v.getElementAtIndex(0).getLong());
-    Assert.assertEquals(2, v.getElementAtIndex(1).getLong());
-    Assert.assertEquals(3, v.getElementAtIndex(2).getLong());
-    Assert.assertEquals("four", v.getElementAtIndex(3).getString());
+    assertThat(v.getType()).isEqualTo(Variant.Type.ARRAY);
+    assertThat(v.numArrayElements()).isEqualTo(4);
+    assertThat(v.getElementAtIndex(0).getLong()).isEqualTo(1);
+    assertThat(v.getElementAtIndex(1).getLong()).isEqualTo(2);
+    assertThat(v.getElementAtIndex(2).getLong()).isEqualTo(3);
+    assertThat(v.getElementAtIndex(3).getString()).isEqualTo("four");
   }
 
   @Test
   public void testParseNestedArray() throws IOException {
     Variant v = VariantJsonParser.parseJson("[[1,2],[3,4]]");
-    Assert.assertEquals(Variant.Type.ARRAY, v.getType());
-    Assert.assertEquals(2, v.numArrayElements());
+    assertThat(v.getType()).isEqualTo(Variant.Type.ARRAY);
+    assertThat(v.numArrayElements()).isEqualTo(2);
     Variant inner = v.getElementAtIndex(0);
-    Assert.assertEquals(Variant.Type.ARRAY, inner.getType());
-    Assert.assertEquals(1, inner.getElementAtIndex(0).getLong());
-    Assert.assertEquals(2, inner.getElementAtIndex(1).getLong());
+    assertThat(inner.getType()).isEqualTo(Variant.Type.ARRAY);
+    assertThat(inner.getElementAtIndex(0).getLong()).isEqualTo(1);
+    assertThat(inner.getElementAtIndex(1).getLong()).isEqualTo(2);
   }
 
   @Test
   public void testParseMixedArray() throws IOException {
     Variant v = VariantJsonParser.parseJson("[1,\"two\",true,null,3.14]");
-    Assert.assertEquals(Variant.Type.ARRAY, v.getType());
-    Assert.assertEquals(5, v.numArrayElements());
-    Assert.assertEquals(1, v.getElementAtIndex(0).getLong());
-    Assert.assertEquals("two", v.getElementAtIndex(1).getString());
-    Assert.assertTrue(v.getElementAtIndex(2).getBoolean());
-    Assert.assertEquals(Variant.Type.NULL, v.getElementAtIndex(3).getType());
-    Assert.assertEquals(
-        0, new BigDecimal("3.14").compareTo(v.getElementAtIndex(4).getDecimal()));
+    assertThat(v.getType()).isEqualTo(Variant.Type.ARRAY);
+    assertThat(v.numArrayElements()).isEqualTo(5);
+    assertThat(v.getElementAtIndex(0).getLong()).isEqualTo(1);
+    assertThat(v.getElementAtIndex(1).getString()).isEqualTo("two");
+    assertThat(v.getElementAtIndex(2).getBoolean()).isTrue();
+    assertThat(v.getElementAtIndex(3).getType()).isEqualTo(Variant.Type.NULL);
+    assertThat(v.getElementAtIndex(4).getDecimal()).isEqualByComparingTo(new BigDecimal("3.14"));
   }
 
   @Test
   public void testParseObjectWithNullValue() throws IOException {
     Variant v = VariantJsonParser.parseJson("{\"key\":null}");
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
-    Assert.assertEquals(Variant.Type.NULL, v.getFieldByKey("key").getType());
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
+    assertThat(v.getFieldByKey("key").getType()).isEqualTo(Variant.Type.NULL);
   }
 
   @Test
@@ -212,59 +210,59 @@ public class TestVariantParseJson {
         + "{\"eType\":\"purchase\",\"amount\":99.99}"
         + "]}";
     Variant v = VariantJsonParser.parseJson(json);
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
-    Assert.assertEquals(12345, v.getFieldByKey("userId").getLong());
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
+    assertThat(v.getFieldByKey("userId").getLong()).isEqualTo(12345);
     Variant events = v.getFieldByKey("events");
-    Assert.assertEquals(Variant.Type.ARRAY, events.getType());
-    Assert.assertEquals(2, events.numArrayElements());
-    Assert.assertEquals(
-        "login", events.getElementAtIndex(0).getFieldByKey("eType").getString());
-    Assert.assertEquals(
-        0,
-        new BigDecimal("99.99")
-            .compareTo(events.getElementAtIndex(1)
-                .getFieldByKey("amount")
-                .getDecimal()));
+    assertThat(events.getType()).isEqualTo(Variant.Type.ARRAY);
+    assertThat(events.numArrayElements()).isEqualTo(2);
+    assertThat(events.getElementAtIndex(0).getFieldByKey("eType").getString())
+        .isEqualTo("login");
+    assertThat(events.getElementAtIndex(1).getFieldByKey("amount").getDecimal())
+        .isEqualByComparingTo(new BigDecimal("99.99"));
   }
 
   @Test
   public void testParseEmptyString() throws IOException {
     Variant v = VariantJsonParser.parseJson("\"\"");
-    Assert.assertEquals(Variant.Type.STRING, v.getType());
-    Assert.assertEquals("", v.getString());
+    assertThat(v.getType()).isEqualTo(Variant.Type.STRING);
+    assertThat(v.getString()).isEqualTo("");
   }
 
   @Test
   public void testParseUnicodeString() throws IOException {
     Variant v = VariantJsonParser.parseJson("\"\\u00e9l\\u00e8ve\"");
-    Assert.assertEquals(Variant.Type.STRING, v.getType());
-    Assert.assertEquals("\u00e9l\u00e8ve", v.getString());
+    assertThat(v.getType()).isEqualTo(Variant.Type.STRING);
+    assertThat(v.getString()).isEqualTo("\u00e9l\u00e8ve");
   }
 
   @Test
   public void testParseUnicodeKey() throws IOException {
     Variant v = VariantJsonParser.parseJson("{\"\\u00e9l\\u00e8ve\": 42}");
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
     Variant value = v.getFieldByKey("élève");
-    Assert.assertNotNull(value);
-    Assert.assertEquals(42, value.getInt());
+    assertThat(value).isNotNull();
+    assertThat(value.getInt()).isEqualTo(42);
   }
 
   @Test
   public void testParseEscapedString() throws IOException {
     Variant v = VariantJsonParser.parseJson("\"hello\\nworld\"");
-    Assert.assertEquals(Variant.Type.STRING, v.getType());
-    Assert.assertEquals("hello\nworld", v.getString());
+    assertThat(v.getType()).isEqualTo(Variant.Type.STRING);
+    assertThat(v.getString()).isEqualTo("hello\nworld");
   }
 
-  @Test(expected = IOException.class)
-  public void testParseMalformedJson() throws IOException {
-    VariantJsonParser.parseJson("{invalid");
+  @Test
+  public void testParseMalformedJson() {
+    assertThatThrownBy(() -> VariantJsonParser.parseJson("{invalid"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("was expecting double-quote to start field name");
   }
 
-  @Test(expected = IOException.class)
-  public void testParseIncompleteObject() throws IOException {
-    VariantJsonParser.parseJson("{\"key\":");
+  @Test
+  public void testParseIncompleteObject() {
+    assertThatThrownBy(() -> VariantJsonParser.parseJson("{\"key\":"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unexpected end-of-input within/between Object entries");
   }
 
   @Test
@@ -273,17 +271,17 @@ public class TestVariantParseJson {
     try (JsonParser parser = factory.createParser("{\"a\":1}")) {
       parser.nextToken();
       Variant v = VariantJsonParser.parseJson(parser);
-      Assert.assertEquals(Variant.Type.OBJECT, v.getType());
-      Assert.assertEquals(1, v.getFieldByKey("a").getLong());
+      assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
+      assertThat(v.getFieldByKey("a").getLong()).isEqualTo(1);
     }
   }
 
   @Test
   public void testParseDuplicateKeysLastWins() throws IOException {
     Variant v = VariantJsonParser.parseJson("{\"k\":1,\"k\":2}");
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
-    Assert.assertEquals(1, v.numObjectElements());
-    Assert.assertEquals(2, v.getFieldByKey("k").getLong());
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
+    assertThat(v.numObjectElements()).isEqualTo(1);
+    assertThat(v.getFieldByKey("k").getLong()).isEqualTo(2);
   }
 
   @Test
@@ -298,35 +296,41 @@ public class TestVariantParseJson {
     }
     Variant v = VariantJsonParser.parseJson(sb.toString());
     for (int i = 0; i < 20; i++) {
-      Assert.assertEquals(Variant.Type.OBJECT, v.getType());
+      assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
       v = v.getFieldByKey("n");
     }
-    Assert.assertEquals(42, v.getLong());
+    assertThat(v.getLong()).isEqualTo(42);
   }
 
   @Test
   public void testObjectKeysSorted() throws IOException {
     Variant v = VariantJsonParser.parseJson("{\"c\":3,\"a\":1,\"b\":2}");
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
-    Assert.assertEquals(3, v.numObjectElements());
-    Assert.assertEquals("a", v.getFieldAtIndex(0).key);
-    Assert.assertEquals("b", v.getFieldAtIndex(1).key);
-    Assert.assertEquals("c", v.getFieldAtIndex(2).key);
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
+    assertThat(v.numObjectElements()).isEqualTo(3);
+    assertThat(v.getFieldAtIndex(0).key).isEqualTo("a");
+    assertThat(v.getFieldAtIndex(1).key).isEqualTo("b");
+    assertThat(v.getFieldAtIndex(2).key).isEqualTo("c");
   }
 
-  @Test(expected = IOException.class)
-  public void testParseEmptyInput() throws IOException {
-    VariantJsonParser.parseJson("");
+  @Test
+  public void testParseEmptyInput() {
+    assertThatThrownBy(() -> VariantJsonParser.parseJson(""))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unexpected null token");
   }
 
-  @Test(expected = IOException.class)
-  public void testParseNotJson() throws IOException {
-    VariantJsonParser.parseJson("not json at all");
+  @Test
+  public void testParseNotJson() {
+    assertThatThrownBy(() -> VariantJsonParser.parseJson("not json at all"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unrecognized token 'not'");
   }
 
-  @Test(expected = IOException.class)
-  public void testParseIncompleteArray() throws IOException {
-    VariantJsonParser.parseJson("[1, 2,");
+  @Test
+  public void testParseIncompleteArray() {
+    assertThatThrownBy(() -> VariantJsonParser.parseJson("[1, 2,"))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("Unexpected end-of-input within/between Array entries");
   }
 
   @Test
@@ -342,11 +346,11 @@ public class TestVariantParseJson {
     sb.append("}");
 
     Variant v = VariantJsonParser.parseJson(sb.toString());
-    Assert.assertEquals(Variant.Type.OBJECT, v.getType());
-    Assert.assertEquals(numKeys, v.numObjectElements());
+    assertThat(v.getType()).isEqualTo(Variant.Type.OBJECT);
+    assertThat(v.numObjectElements()).isEqualTo(numKeys);
     // Spot-check a few values
-    Assert.assertEquals(0, v.getFieldByKey("key0").getLong());
-    Assert.assertEquals(500, v.getFieldByKey("key500").getLong());
-    Assert.assertEquals(999, v.getFieldByKey("key999").getLong());
+    assertThat(v.getFieldByKey("key0").getLong()).isEqualTo(0);
+    assertThat(v.getFieldByKey("key500").getLong()).isEqualTo(500);
+    assertThat(v.getFieldByKey("key999").getLong()).isEqualTo(999);
   }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
@@ -18,6 +18,9 @@
  */
 package org.apache.parquet.variant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -25,7 +28,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +48,7 @@ public class TestVariantScalar {
         ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(1)}), VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertTrue(v.getBoolean());
+      assertThat(v.getBoolean()).isTrue();
     });
   }
 
@@ -56,7 +58,7 @@ public class TestVariantScalar {
         ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(2)}), VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-      Assert.assertFalse(v.getBoolean());
+      assertThat(v.getBoolean()).isFalse();
     });
   }
 
@@ -77,7 +79,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
-      Assert.assertEquals(1234567890987654321L, v.getLong());
+      assertThat(v.getLong()).isEqualTo(1234567890987654321L);
     });
   }
 
@@ -98,7 +100,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
-      Assert.assertEquals(-1L, v.getLong());
+      assertThat(v.getLong()).isEqualTo(-1L);
     });
   }
 
@@ -109,7 +111,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(1234567890, v.getInt());
+      assertThat(v.getInt()).isEqualTo(1234567890);
     });
   }
 
@@ -122,7 +124,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
-      Assert.assertEquals(-1, v.getInt());
+      assertThat(v.getInt()).isEqualTo(-1);
     });
   }
 
@@ -133,7 +135,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
-      Assert.assertEquals((short) 1234, v.getShort());
+      assertThat(v.getShort()).isEqualTo((short) 1234);
     });
   }
 
@@ -144,7 +146,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
-      Assert.assertEquals((short) -1, v.getShort());
+      assertThat(v.getShort()).isEqualTo((short) -1);
     });
   }
 
@@ -154,7 +156,7 @@ public class TestVariantScalar {
         ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(3), 34}), VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
-      Assert.assertEquals((byte) 34, v.getByte());
+      assertThat(v.getByte()).isEqualTo((byte) 34);
     });
   }
 
@@ -165,7 +167,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
-      Assert.assertEquals((byte) -1, v.getByte());
+      assertThat(v.getByte()).isEqualTo((byte) -1);
     });
   }
 
@@ -176,7 +178,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
-      Assert.assertEquals(Float.intBitsToFloat(1234567890), v.getFloat(), 0);
+      assertThat(v.getFloat()).isEqualTo(Float.intBitsToFloat(1234567890));
     });
   }
 
@@ -187,7 +189,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
-      Assert.assertEquals(-0.0F, v.getFloat(), 0);
+      assertThat(v.getFloat()).isEqualTo(-0.0F);
     });
   }
 
@@ -208,7 +210,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
-      Assert.assertEquals(Double.longBitsToDouble(1234567890987654321L), v.getDouble(), 0);
+      assertThat(v.getDouble()).isEqualTo(Double.longBitsToDouble(1234567890987654321L));
     });
   }
 
@@ -221,7 +223,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
-      Assert.assertEquals(-0.0D, v.getDouble(), 0);
+      assertThat(v.getDouble()).isEqualTo(-0.0D);
     });
   }
 
@@ -233,7 +235,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
-      Assert.assertEquals(new BigDecimal("123456.7890"), v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(new BigDecimal("123456.7890"));
     });
   }
 
@@ -246,7 +248,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
-      Assert.assertEquals(new BigDecimal("-0.0001"), v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(new BigDecimal("-0.0001"));
     });
   }
 
@@ -268,7 +270,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
-      Assert.assertEquals(new BigDecimal("1234567890.987654321"), v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(new BigDecimal("1234567890.987654321"));
     });
   }
 
@@ -290,7 +292,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
-      Assert.assertEquals(new BigDecimal("-0.000000001"), v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(new BigDecimal("-0.000000001"));
     });
   }
 
@@ -320,7 +322,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
-      Assert.assertEquals(new BigDecimal("9876543210.123456789"), v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(new BigDecimal("9876543210.123456789"));
     });
   }
 
@@ -350,7 +352,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
-      Assert.assertEquals(new BigDecimal("-9876543210.123456789"), v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(new BigDecimal("-9876543210.123456789"));
     });
   }
 
@@ -361,7 +363,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
-      Assert.assertEquals(LocalDate.parse("2025-04-17"), LocalDate.ofEpochDay(v.getInt()));
+      assertThat(LocalDate.ofEpochDay(v.getInt())).isEqualTo(LocalDate.parse("2025-04-17"));
     });
   }
 
@@ -374,7 +376,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
-      Assert.assertEquals(LocalDate.parse("1969-12-31"), LocalDate.ofEpochDay(v.getInt()));
+      assertThat(LocalDate.ofEpochDay(v.getInt())).isEqualTo(LocalDate.parse("1969-12-31"));
     });
   }
 
@@ -395,8 +397,8 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
-      Assert.assertEquals(
-          Instant.parse("2025-04-17T08:09:10.123456Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS));
+      assertThat(Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS))
+          .isEqualTo(Instant.parse("2025-04-17T08:09:10.123456Z"));
     });
   }
 
@@ -417,8 +419,8 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
-      Assert.assertEquals(
-          Instant.parse("1969-12-31T23:59:59.999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS));
+      assertThat(Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS))
+          .isEqualTo(Instant.parse("1969-12-31T23:59:59.999999Z"));
     });
   }
 
@@ -439,8 +441,8 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
-      Assert.assertEquals(
-          Instant.parse("2025-04-17T08:09:10.123456Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS));
+      assertThat(Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS))
+          .isEqualTo(Instant.parse("2025-04-17T08:09:10.123456Z"));
     });
   }
 
@@ -461,8 +463,8 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
-      Assert.assertEquals(
-          Instant.parse("1969-12-31T23:59:59.999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS));
+      assertThat(Instant.EPOCH.plus(v.getLong(), ChronoUnit.MICROS))
+          .isEqualTo(Instant.parse("1969-12-31T23:59:59.999999Z"));
     });
   }
 
@@ -475,7 +477,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BINARY);
-      Assert.assertEquals(ByteBuffer.wrap(new byte[] {'a', 'b', 'c', 'd', 'e'}), v.getBinary());
+      assertThat(v.getBinary()).isEqualTo(ByteBuffer.wrap(new byte[] {'a', 'b', 'c', 'd', 'e'}));
     });
   }
 
@@ -488,7 +490,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.STRING);
-      Assert.assertEquals("variant", v.getString());
+      assertThat(v.getString()).isEqualTo("variant");
     });
   }
 
@@ -499,7 +501,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.SHORT_STR, Variant.Type.STRING);
-      Assert.assertEquals("variant", v.getString());
+      assertThat(v.getString()).isEqualTo("variant");
     });
   }
 
@@ -520,7 +522,7 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIME);
-      Assert.assertEquals(LocalTime.parse("23:59:59.123456"), LocalTime.ofNanoOfDay(v.getLong() * 1_000));
+      assertThat(LocalTime.ofNanoOfDay(v.getLong() * 1_000)).isEqualTo(LocalTime.parse("23:59:59.123456"));
     });
   }
 
@@ -541,8 +543,8 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
-      Assert.assertEquals(
-          Instant.parse("2025-04-17T08:09:10.123456789Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
+      assertThat(Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS))
+          .isEqualTo(Instant.parse("2025-04-17T08:09:10.123456789Z"));
     });
   }
 
@@ -563,8 +565,8 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
-      Assert.assertEquals(
-          Instant.parse("1969-12-31T23:59:59.999999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
+      assertThat(Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS))
+          .isEqualTo(Instant.parse("1969-12-31T23:59:59.999999999Z"));
     });
   }
 
@@ -585,8 +587,8 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
-      Assert.assertEquals(
-          Instant.parse("2025-04-17T08:09:10.123456789Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
+      assertThat(Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS))
+          .isEqualTo(Instant.parse("2025-04-17T08:09:10.123456789Z"));
     });
   }
 
@@ -607,8 +609,8 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
-      Assert.assertEquals(
-          Instant.parse("1969-12-31T23:59:59.999999999Z"), Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS));
+      assertThat(Instant.EPOCH.plus(v.getLong(), ChronoUnit.NANOS))
+          .isEqualTo(Instant.parse("1969-12-31T23:59:59.999999999Z"));
     });
   }
 
@@ -637,154 +639,115 @@ public class TestVariantScalar {
         VariantTestUtil.EMPTY_METADATA);
     VariantTestUtil.testVariant(value, v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
-      Assert.assertEquals(UUID.fromString("00112233-4455-6677-8899-aabbccddeeff"), v.getUUID());
+      assertThat(v.getUUID()).isEqualTo(UUID.fromString("00112233-4455-6677-8899-aabbccddeeff"));
     });
   }
 
   @Test
   public void testInvalidType() {
-    try {
-      Variant value = new Variant(ByteBuffer.wrap(new byte[] {(byte) 0xFC}), VariantTestUtil.EMPTY_METADATA);
-      value.getBoolean();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals(
-          "Cannot read unknownType(basicType: 0, valueHeader: 63) value as BOOLEAN", e.getMessage());
-    }
+    Variant value = new Variant(ByteBuffer.wrap(new byte[] {(byte) 0xFC}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getBoolean)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read unknownType(basicType: 0, valueHeader: 63) value as BOOLEAN");
   }
 
   @Test
   public void testInvalidBoolean() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getBoolean();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as BOOLEAN", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getBoolean)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as BOOLEAN");
   }
 
   @Test
   public void testInvalidLong() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(16)}), VariantTestUtil.EMPTY_METADATA);
-      value.getLong();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals(
-          "Cannot read STRING value as one of [BYTE, SHORT, INT, DATE, LONG, TIMESTAMP_TZ, TIMESTAMP_NTZ, TIME, TIMESTAMP_NANOS_TZ, TIMESTAMP_NANOS_NTZ]",
-          e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(16)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getLong)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot read STRING value as one of [BYTE, SHORT, INT, DATE, LONG, TIMESTAMP_TZ, TIMESTAMP_NTZ, TIME, TIMESTAMP_NANOS_TZ, TIMESTAMP_NANOS_NTZ]");
   }
 
   @Test
   public void testInvalidInt() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getInt();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as one of [BYTE, SHORT, INT, DATE]", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getInt)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as one of [BYTE, SHORT, INT, DATE]");
   }
 
   @Test
   public void testInvalidShort() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getShort();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as one of [BYTE, SHORT]", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getShort)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as one of [BYTE, SHORT]");
   }
 
   @Test
   public void testInvalidByte() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getByte();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as BYTE", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getByte)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as BYTE");
   }
 
   @Test
   public void testInvalidFloat() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getFloat();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as FLOAT", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getFloat)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as FLOAT");
   }
 
   @Test
   public void testInvalidDouble() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getDouble();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as DOUBLE", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getDouble)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as DOUBLE");
   }
 
   @Test
   public void testInvalidDecimal() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6), 0}),
-          VariantTestUtil.EMPTY_METADATA);
-      value.getDecimal();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as one of [DECIMAL4, DECIMAL8, DECIMAL16]", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6), 0}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getDecimal)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as one of [DECIMAL4, DECIMAL8, DECIMAL16]");
   }
 
   @Test
   public void testInvalidUUID() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getUUID();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as UUID", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getUUID)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as UUID");
   }
 
   @Test
   public void testInvalidString() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getString();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as STRING", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getString)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as STRING");
   }
 
   @Test
   public void testInvalidBinary() {
-    try {
-      Variant value = new Variant(
-          ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
-      value.getBinary();
-      Assert.fail("Expected exception not thrown");
-    } catch (Exception e) {
-      Assert.assertEquals("Cannot read LONG value as BINARY", e.getMessage());
-    }
+    Variant value = new Variant(
+        ByteBuffer.wrap(new byte[] {VariantTestUtil.primitiveHeader(6)}), VariantTestUtil.EMPTY_METADATA);
+    assertThatThrownBy(value::getBinary)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot read LONG value as BINARY");
   }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalarBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalarBuilder.java
@@ -18,6 +18,9 @@
  */
 package org.apache.parquet.variant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -27,7 +30,6 @@ import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.IntStream;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,12 +43,9 @@ public class TestVariantScalarBuilder {
     vb.appendNull();
     VariantTestUtil.testVariant(vb.build(), v -> VariantTestUtil.checkType(v, VariantUtil.NULL, Variant.Type.NULL));
 
-    try {
-      vb.appendNull();
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(vb::appendNull)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -56,15 +55,12 @@ public class TestVariantScalarBuilder {
       vb.appendBoolean(b);
       VariantTestUtil.testVariant(vb.build(), v -> {
         VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BOOLEAN);
-        Assert.assertEquals(b, v.getBoolean());
+        assertThat(v.getBoolean()).isEqualTo(b);
       });
 
-      try {
-        vb.appendBoolean(true);
-        Assert.fail("Expected Exception when appending multiple values");
-      } catch (Exception e) {
-        // expected
-      }
+      assertThatThrownBy(() -> vb.appendBoolean(true))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Cannot call multiple append() methods.");
     });
   }
 
@@ -85,15 +81,12 @@ public class TestVariantScalarBuilder {
           vb.appendLong(l);
           VariantTestUtil.testVariant(vb.build(), v -> {
             VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.LONG);
-            Assert.assertEquals((long) l, v.getLong());
+            assertThat(v.getLong()).isEqualTo((long) l);
           });
 
-          try {
-            vb.appendLong(1L);
-            Assert.fail("Expected Exception when appending multiple values");
-          } catch (Exception e) {
-            // expected
-          }
+          assertThatThrownBy(() -> vb.appendLong(1L))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessage("Cannot call multiple append() methods.");
         });
   }
 
@@ -112,15 +105,12 @@ public class TestVariantScalarBuilder {
           vb.appendInt(i);
           VariantTestUtil.testVariant(vb.build(), v -> {
             VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.INT);
-            Assert.assertEquals((int) i, v.getInt());
+            assertThat(v.getInt()).isEqualTo((int) i);
           });
 
-          try {
-            vb.appendInt(1);
-            Assert.fail("Expected Exception when appending multiple values");
-          } catch (Exception e) {
-            // expected
-          }
+          assertThatThrownBy(() -> vb.appendInt(1))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessage("Cannot call multiple append() methods.");
         });
   }
 
@@ -132,15 +122,12 @@ public class TestVariantScalarBuilder {
           vb.appendShort(s);
           VariantTestUtil.testVariant(vb.build(), v -> {
             VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.SHORT);
-            Assert.assertEquals((short) s, v.getShort());
+            assertThat(v.getShort()).isEqualTo((short) s);
           });
 
-          try {
-            vb.appendShort((short) 1);
-            Assert.fail("Expected Exception when appending multiple values");
-          } catch (Exception e) {
-            // expected
-          }
+          assertThatThrownBy(() -> vb.appendShort((short) 1))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessage("Cannot call multiple append() methods.");
         });
   }
 
@@ -151,15 +138,12 @@ public class TestVariantScalarBuilder {
       vb.appendByte(b);
       VariantTestUtil.testVariant(vb.build(), v -> {
         VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BYTE);
-        Assert.assertEquals((byte) b, v.getByte());
+        assertThat(v.getByte()).isEqualTo((byte) b);
       });
 
-      try {
-        vb.appendByte((byte) 1);
-        Assert.fail("Expected Exception when appending multiple values");
-      } catch (Exception e) {
-        // expected
-      }
+      assertThatThrownBy(() -> vb.appendByte((byte) 1))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Cannot call multiple append() methods.");
     });
   }
 
@@ -170,15 +154,12 @@ public class TestVariantScalarBuilder {
       vb.appendFloat(f);
       VariantTestUtil.testVariant(vb.build(), v -> {
         VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.FLOAT);
-        Assert.assertEquals(f, v.getFloat(), 0);
+        assertThat(v.getFloat()).isEqualTo(f);
       });
 
-      try {
-        vb.appendFloat(1.2f);
-        Assert.fail("Expected Exception when appending multiple values");
-      } catch (Exception e) {
-        // expected
-      }
+      assertThatThrownBy(() -> vb.appendFloat(1.2f))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Cannot call multiple append() methods.");
     });
   }
 
@@ -200,7 +181,9 @@ public class TestVariantScalarBuilder {
     vb.appendFloat(testFloat);
 
     int writePos = (Integer) writePosField.get(vb);
-    Assert.assertEquals("writePos should be exactly 5 after appendFloat", 5, writePos);
+    assertThat(writePos)
+        .as("writePos should be exactly 5 after appendFloat")
+        .isEqualTo(5);
 
     int modifiedBytes = 0;
     for (int i = 0; i < 10; i++) {
@@ -208,15 +191,20 @@ public class TestVariantScalarBuilder {
         modifiedBytes++;
       }
     }
-    Assert.assertEquals("appendFloat should write exactly 5 bytes (1 header + 4 data)", 5, modifiedBytes);
+    assertThat(modifiedBytes)
+        .as("appendFloat should write exactly 5 bytes (1 header + 4 data)")
+        .isEqualTo(5);
 
     for (int i = 5; i < 10; i++) {
-      Assert.assertEquals(
-          "Byte at position " + i + " should not be modified by appendFloat", (byte) 0xFF, buffer[i]);
+      assertThat(buffer[i])
+          .as("Byte at position " + i + " should not be modified by appendFloat")
+          .isEqualTo((byte) 0xFF);
     }
 
     Variant variant = vb.build();
-    Assert.assertEquals("Float value should be preserved correctly", testFloat, variant.getFloat(), 0.0f);
+    assertThat(variant.getFloat())
+        .as("Float value should be preserved correctly")
+        .isEqualTo(testFloat);
   }
 
   @Test
@@ -226,15 +214,12 @@ public class TestVariantScalarBuilder {
       vb.appendDouble(d);
       VariantTestUtil.testVariant(vb.build(), v -> {
         VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DOUBLE);
-        Assert.assertEquals(d, v.getDouble(), 0);
+        assertThat(v.getDouble()).isEqualTo(d);
       });
 
-      try {
-        vb.appendDouble(1.2);
-        Assert.fail("Expected Exception when appending multiple values");
-      } catch (Exception e) {
-        // expected
-      }
+      assertThatThrownBy(() -> vb.appendDouble(1.2))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessage("Cannot call multiple append() methods.");
     });
   }
 
@@ -246,7 +231,7 @@ public class TestVariantScalarBuilder {
       vb.appendDecimal(d);
       VariantTestUtil.testVariant(vb.build(), v -> {
         VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
-        Assert.assertEquals(d, v.getDecimal());
+        assertThat(v.getDecimal()).isEqualTo(d);
       });
     });
 
@@ -257,7 +242,7 @@ public class TestVariantScalarBuilder {
           vb.appendDecimal(d);
           VariantTestUtil.testVariant(vb.build(), v -> {
             VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
-            Assert.assertEquals(d, v.getDecimal());
+            assertThat(v.getDecimal()).isEqualTo(d);
           });
         });
 
@@ -268,18 +253,15 @@ public class TestVariantScalarBuilder {
           vb.appendDecimal(d);
           VariantTestUtil.testVariant(vb.build(), v -> {
             VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL16);
-            Assert.assertEquals(d, v.getDecimal());
+            assertThat(v.getDecimal()).isEqualTo(d);
           });
         });
 
     VariantBuilder vb = new VariantBuilder();
     vb.appendDecimal(new BigDecimal("10.2147483647"));
-    try {
-      vb.appendDecimal(new BigDecimal("10.2147483647"));
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendDecimal(new BigDecimal("10.2147483647")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -290,7 +272,7 @@ public class TestVariantScalarBuilder {
     vb1.appendDecimal(smallPrecisionLargeScale);
     VariantTestUtil.testVariant(vb1.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
-      Assert.assertEquals(smallPrecisionLargeScale, v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(smallPrecisionLargeScale);
     });
 
     BigDecimal mediumPrecisionLargeScale = new BigDecimal("1234567890").scaleByPowerOfTen(-25);
@@ -298,7 +280,7 @@ public class TestVariantScalarBuilder {
     vb2.appendDecimal(mediumPrecisionLargeScale);
     VariantTestUtil.testVariant(vb2.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
-      Assert.assertEquals(mediumPrecisionLargeScale, v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(mediumPrecisionLargeScale);
     });
 
     BigDecimal maxDecimal4Precision = new BigDecimal("123456789").scaleByPowerOfTen(-18);
@@ -306,7 +288,7 @@ public class TestVariantScalarBuilder {
     vb3.appendDecimal(maxDecimal4Precision);
     VariantTestUtil.testVariant(vb3.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL4);
-      Assert.assertEquals(maxDecimal4Precision, v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(maxDecimal4Precision);
     });
 
     BigDecimal maxDecimal8Precision = new BigDecimal("123456789012345678").scaleByPowerOfTen(-19);
@@ -314,7 +296,7 @@ public class TestVariantScalarBuilder {
     vb4.appendDecimal(maxDecimal8Precision);
     VariantTestUtil.testVariant(vb4.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DECIMAL8);
-      Assert.assertEquals(maxDecimal8Precision, v.getDecimal());
+      assertThat(v.getDecimal()).isEqualTo(maxDecimal8Precision);
     });
   }
 
@@ -325,15 +307,12 @@ public class TestVariantScalarBuilder {
     vb.appendDate(days);
     VariantTestUtil.testVariant(vb.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.DATE);
-      Assert.assertEquals(days, v.getInt());
+      assertThat(v.getInt()).isEqualTo(days);
     });
 
-    try {
-      vb.appendDate(123);
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendDate(123))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -342,15 +321,12 @@ public class TestVariantScalarBuilder {
     vb.appendTimestampTz(1734373425321456L);
     VariantTestUtil.testVariant(vb.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_TZ);
-      Assert.assertEquals(1734373425321456L, v.getLong());
+      assertThat(v.getLong()).isEqualTo(1734373425321456L);
     });
 
-    try {
-      vb.appendTimestampTz(1734373425321456L);
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendTimestampTz(1734373425321456L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -359,15 +335,12 @@ public class TestVariantScalarBuilder {
     vb.appendTimestampNtz(1734373425321456L);
     VariantTestUtil.testVariant(vb.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NTZ);
-      Assert.assertEquals(1734373425321456L, v.getLong());
+      assertThat(v.getLong()).isEqualTo(1734373425321456L);
     });
 
-    try {
-      vb.appendTimestampNtz(1734373425321456L);
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendTimestampNtz(1734373425321456L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -376,15 +349,12 @@ public class TestVariantScalarBuilder {
     vb.appendBinary(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
     VariantTestUtil.testVariant(vb.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.BINARY);
-      Assert.assertEquals(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}), v.getBinary());
+      assertThat(v.getBinary()).isEqualTo(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
     });
 
-    try {
-      vb.appendBinary(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendBinary(ByteBuffer.wrap(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -394,8 +364,8 @@ public class TestVariantScalarBuilder {
     int remainingBefore = buf.remaining();
     VariantBuilder vb = new VariantBuilder();
     vb.appendBinary(buf);
-    Assert.assertEquals(positionBefore, buf.position());
-    Assert.assertEquals(remainingBefore, buf.remaining());
+    assertThat(buf.position()).isEqualTo(positionBefore);
+    assertThat(buf.remaining()).isEqualTo(remainingBefore);
   }
 
   @Test
@@ -411,18 +381,15 @@ public class TestVariantScalarBuilder {
             } else {
               VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.STRING);
             }
-            Assert.assertEquals(s, v.getString());
+            assertThat(v.getString()).isEqualTo(s);
           });
         });
 
     VariantBuilder vb = new VariantBuilder();
     vb.appendString(VariantTestUtil.randomString(10));
-    try {
-      vb.appendString(VariantTestUtil.randomString(10));
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendString(VariantTestUtil.randomString(10)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -434,27 +401,20 @@ public class TestVariantScalarBuilder {
       vb.appendTime(micros);
       VariantTestUtil.testVariant(vb.build(), v -> {
         VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIME);
-        Assert.assertEquals(micros, v.getLong());
+        assertThat(v.getLong()).isEqualTo(micros);
       });
     }
 
     // test negative time
-    try {
-      VariantBuilder vb = new VariantBuilder();
-      vb.appendTime(-1);
-      Assert.fail("Expected Exception when adding a negative time value");
-    } catch (IllegalArgumentException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> new VariantBuilder().appendTime(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Time value (-1) cannot be negative.");
 
     VariantBuilder vb = new VariantBuilder();
     vb.appendTime(123456);
-    try {
-      vb.appendTime(123456);
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendTime(123456))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -463,15 +423,12 @@ public class TestVariantScalarBuilder {
     vb.appendTimestampNanosTz(1734373425321456987L);
     VariantTestUtil.testVariant(vb.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_TZ);
-      Assert.assertEquals(1734373425321456987L, v.getLong());
+      assertThat(v.getLong()).isEqualTo(1734373425321456987L);
     });
 
-    try {
-      vb.appendTimestampNanosTz(1734373425321456987L);
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendTimestampNanosTz(1734373425321456987L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -480,15 +437,12 @@ public class TestVariantScalarBuilder {
     vb.appendTimestampNanosNtz(1734373425321456987L);
     VariantTestUtil.testVariant(vb.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.TIMESTAMP_NANOS_NTZ);
-      Assert.assertEquals(1734373425321456987L, v.getLong());
+      assertThat(v.getLong()).isEqualTo(1734373425321456987L);
     });
 
-    try {
-      vb.appendTimestampNanosNtz(1734373425321456987L);
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendTimestampNanosNtz(1734373425321456987L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -502,15 +456,12 @@ public class TestVariantScalarBuilder {
     vb.appendUUID(expected);
     VariantTestUtil.testVariant(vb.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
-      Assert.assertEquals(expected, v.getUUID());
+      assertThat(v.getUUID()).isEqualTo(expected);
     });
 
-    try {
-      vb.appendUUID(expected);
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendUUID(expected))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 
   @Test
@@ -524,16 +475,13 @@ public class TestVariantScalarBuilder {
     vb.appendUUIDBytes(ByteBuffer.wrap(uuid));
     VariantTestUtil.testVariant(vb.build(), v -> {
       VariantTestUtil.checkType(v, VariantUtil.PRIMITIVE, Variant.Type.UUID);
-      Assert.assertEquals(expected, v.getUUID());
+      assertThat(v.getUUID()).isEqualTo(expected);
     });
 
     // appendUUIDBytes must go through onAppend(), so a second append on the root builder
     // (which already holds a value) must be rejected instead of producing a multi-value buffer.
-    try {
-      vb.appendUUIDBytes(ByteBuffer.wrap(uuid));
-      Assert.fail("Expected Exception when appending multiple values");
-    } catch (Exception e) {
-      // expected
-    }
+    assertThatThrownBy(() -> vb.appendUUIDBytes(ByteBuffer.wrap(uuid)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot call multiple append() methods.");
   }
 }

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/VariantTestUtil.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/VariantTestUtil.java
@@ -18,13 +18,14 @@
  */
 package org.apache.parquet.variant;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.function.Consumer;
-import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,8 +39,9 @@ public class VariantTestUtil {
   static final ByteBuffer EMPTY_METADATA = ByteBuffer.wrap(new byte[] {0b1});
 
   static void checkType(Variant v, int expectedBasicType, Variant.Type expectedType) {
-    Assert.assertEquals(expectedBasicType, v.value.get(v.value.position()) & VariantUtil.BASIC_TYPE_MASK);
-    Assert.assertEquals(expectedType, v.getType());
+    assertThat(v.value.get(v.value.position()) & VariantUtil.BASIC_TYPE_MASK)
+        .isEqualTo(expectedBasicType);
+    assertThat(v.getType()).isEqualTo(expectedType);
   }
 
   static String randomString(int len) {

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
     <brotli-codec.version>0.1.1</brotli-codec.version>
     <assertj.version>3.27.7</assertj.version>
     <junit.version>5.14.4</junit.version>
+    <assertj.version>3.27.7</assertj.version>
     <mockito.version>5.23.0</mockito.version>
     <net.openhft.version>0.27ea1</net.openhft.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

This introduces AssertJ for testing, which enables more fluent assertion checks, easier debugging and overall easier testing. Additional details about the motivation can be found in https://github.com/apache/parquet-java/issues/3615

### What changes are included in this PR?
added the assertj library to the test scope. Also updated parquet-variant to use the new `assertThat` checks to make test code more readable

### Are these changes tested?
yes, existing tests

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
