### PR TITLE
GH-3618: Upgrade JUnit4 to JUnit 5.14.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
     <avro.version>1.11.5</avro.version>
     <guava.version>33.6.0-jre</guava.version>
     <brotli-codec.version>0.1.1</brotli-codec.version>
+    <junit.version>5.14.4</junit.version>
     <mockito.version>5.23.0</mockito.version>
     <net.openhft.version>0.27ea1</net.openhft.version>
     <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
@@ -158,9 +159,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -629,6 +636,7 @@
               <ignoreNonCompile>true</ignoreNonCompile>
               <ignoredDependencies>
                 <dependency>javax.annotation:javax.annotation-api:jar:1.3.2</dependency>
+                <dependency>junit:junit</dependency>
               </ignoredDependencies>
             </configuration>
           </execution>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
JUnit4 is outdated and the last release was in 2021. This switches to JUnit5 in order to make it possible to migrate the existing tests from JUnit4 to JUnit5 in the scope of https://github.com/apache/parquet-java/issues/3618

### What changes are included in this PR?


### Are these changes tested?
existing tests

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->


/cc @Fokko @wgtmac 