### PR TITLE
GH-3558: Bump hadoop to 3.4.3 and properly close buffers for vectored IO

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileReader.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.HadoopReadOptions;
 import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.Preconditions;
+import org.apache.parquet.bytes.ByteBufferAllocator;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.ByteBufferReleaser;
 import org.apache.parquet.bytes.BytesInput;
@@ -1361,8 +1362,32 @@ public class ParquetFileReader implements Closeable {
       totalSize += len;
     }
     LOG.debug("Reading {} bytes of data with vectored IO in {} ranges", totalSize, ranges.size());
-    // Request a vectored read;
-    f.readVectored(ranges, options.getAllocator());
+    // Wrap the allocator to track buffers allocated during the vectored read.
+    // Hadoop's vectored IO may merge ranges and return slices of merged buffers,
+    // so the buffers returned via CompletableFuture may differ from those originally
+    // allocated. We track the originals here to ensure they are properly released.
+    ByteBufferAllocator baseAllocator = options.getAllocator();
+    List<ByteBuffer> allocatedBuffers = new ArrayList<>();
+    ByteBufferAllocator trackingAllocator = new ByteBufferAllocator() {
+      @Override
+      public ByteBuffer allocate(int size) {
+        ByteBuffer buf = baseAllocator.allocate(size);
+        allocatedBuffers.add(buf);
+        return buf;
+      }
+
+      @Override
+      public void release(ByteBuffer b) {
+        baseAllocator.release(b);
+      }
+
+      @Override
+      public boolean isDirect() {
+        return baseAllocator.isDirect();
+      }
+    };
+    f.readVectored(ranges, trackingAllocator);
+    builder.addBuffersToRelease(allocatedBuffers);
     int k = 0;
     for (ConsecutivePartList consecutivePart : allParts) {
       ParquetFileRange currRange = ranges.get(k++);

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <spotless.version>2.46.1</spotless.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.5.0</hadoop.version>
     <parquet.format.version>2.13.0</parquet.format.version>
     <previous.version>1.17.0</previous.version>
     <thrift.executable>thrift</thrift.executable>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <spotless.version>2.46.1</spotless.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
-    <hadoop.version>3.5.0</hadoop.version>
+    <hadoop.version>3.4.3</hadoop.version>
     <parquet.format.version>2.13.0</parquet.format.version>
     <previous.version>1.17.0</previous.version>
     <thrift.executable>thrift</thrift.executable>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change

This closes allocated buffers for vectored IO, because after updating to Hadoop > 3.4.x we see a bunch of failing tests where buffers are not properly closed.

Closes https://github.com/apache/parquet-java/issues/3558
Closes https://github.com/apache/parquet-java/issues/3356

### What changes are included in this PR?


### Are these changes tested?
existing tests

### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
