### PR TITLE
GH-3625: Compute dataSize correctly when dealing with duplicate keys

### DIFF
--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantBuilder.java
@@ -497,7 +497,6 @@ public class VariantBuilder {
     int numFields = fields.size();
     Collections.sort(fields);
     int maxId = numFields == 0 ? 0 : fields.get(0).id;
-    int dataSize = numFields == 0 ? 0 : fields.get(0).valueSize;
 
     int distinctPos = 0;
     // Maintain a list of distinct keys in-place.
@@ -512,7 +511,6 @@ public class VariantBuilder {
         // Found a distinct key. Add the field to the list.
         distinctPos++;
         fields.set(distinctPos, fields.get(i));
-        dataSize += fields.get(i).valueSize;
       }
     }
 
@@ -520,6 +518,13 @@ public class VariantBuilder {
       numFields = distinctPos + 1;
       // Resize `fields` to `size`.
       fields.subList(numFields, fields.size()).clear();
+    }
+
+    // Compute the data size from the retained fields. This must happen after deduplication, since a
+    // duplicate key keeps the last-written value, whose size may differ from the first occurrence.
+    int dataSize = 0;
+    for (int i = 0; i < numFields; ++i) {
+      dataSize += fields.get(i).valueSize;
     }
 
     boolean largeSize = numFields > VariantUtil.U8_MAX;

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
@@ -278,6 +278,72 @@ public class TestVariantObjectBuilder {
   }
 
   @Test
+  public void testDuplicateKeysKeptValueLarger() {
+    // The retained (last-written) value is larger than the first occurrence. The data size must be
+    // computed from the retained value, otherwise the encoded object is truncated/corrupt.
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    objBuilder.appendKey("duplicate");
+    objBuilder.appendInt(1); // 5 bytes
+    objBuilder.appendKey("duplicate");
+    objBuilder.appendString("hello"); // 6 bytes
+    b.endObject();
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(1, v.numObjectElements());
+      Variant variant = v.getFieldByKey("duplicate");
+      VariantTestUtil.checkType(variant, VariantUtil.SHORT_STR, Variant.Type.STRING);
+      Assert.assertEquals("hello", variant.getString());
+    });
+  }
+
+  @Test
+  public void testDuplicateKeysKeptValueSmaller() {
+    // The retained (last-written) value is smaller than the first occurrence. The data size must be
+    // computed from the retained value, otherwise the encoded object reserves stale trailing bytes.
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    objBuilder.appendKey("duplicate");
+    objBuilder.appendString("hello"); // 6 bytes
+    objBuilder.appendKey("duplicate");
+    objBuilder.appendInt(1); // 5 bytes
+    b.endObject();
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(1, v.numObjectElements());
+      Variant variant = v.getFieldByKey("duplicate");
+      VariantTestUtil.checkType(variant, VariantUtil.PRIMITIVE, Variant.Type.INT);
+      Assert.assertEquals(1, variant.getInt());
+    });
+  }
+
+  @Test
+  public void testDuplicateKeysDifferentSizesAcrossMultipleKeys() {
+    // Exercises deduplication across several keys where the retained values differ in size from the
+    // first occurrence, ensuring offsets remain consistent for every field.
+    VariantBuilder b = new VariantBuilder();
+    VariantObjectBuilder objBuilder = b.startObject();
+    objBuilder.appendKey("a");
+    objBuilder.appendInt(1); // 5 bytes
+    objBuilder.appendKey("b");
+    objBuilder.appendBoolean(true); // 1 byte
+    objBuilder.appendKey("a");
+    objBuilder.appendString("a-final"); // larger, retained for "a"
+    objBuilder.appendKey("b");
+    objBuilder.appendLong(123456789L); // 9 bytes, retained for "b"
+    objBuilder.appendKey("c");
+    objBuilder.appendString("c-only");
+    b.endObject();
+    VariantTestUtil.testVariant(b.build(), v -> {
+      VariantTestUtil.checkType(v, VariantUtil.OBJECT, Variant.Type.OBJECT);
+      Assert.assertEquals(3, v.numObjectElements());
+      Assert.assertEquals("a-final", v.getFieldByKey("a").getString());
+      Assert.assertEquals(123456789L, v.getFieldByKey("b").getLong());
+      Assert.assertEquals("c-only", v.getFieldByKey("c").getString());
+    });
+  }
+
+  @Test
   public void testSortingKeys() {
     VariantBuilder b = new VariantBuilder();
     VariantObjectBuilder objBuilder = b.startObject();


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
When a Variant object is built with the same key appended more than once, `VariantBuilder.endObject()` deduplicates the entries and keeps the last-written value. However, the total `dataSize` of the object's value region was computed from each key's **first** occurrence rather than the value that was actually retained.

When duplicate keys had values of different encoded sizes, this size mismatch corrupted the output:

* If the retained value was larger (e.g. `{"a": 1, "a": "hello"}`), the buffer was under-reserved, the offset width could be undersized, and the final offset entry understated the real data length. Reading the field then threw `IllegalArgumentException: Invalid byte-array offset` or returned truncated data.
* If the retained value was smaller, the object reserved stale trailing bytes and overstated its size.

Closes https://github.com/apache/parquet-java/issues/3625

### What changes are included in this PR?


### Are these changes tested?
yes, added tests that reproduce the underlying issue

### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
