### PR TITLE
Bump com.squareup.okhttp3:okhttp from 4.12.0 to 5.4.0

### DIFF
--- a/parquet-hadoop/pom.xml
+++ b/parquet-hadoop/pom.xml
@@ -62,6 +62,19 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <scope>provided</scope>
+      <exclusions>
+        <!-- hadoop-hdfs-client pulls in the legacy okhttp 2.x / okio 1.x, which
+             clash with okhttp 5.x / okio 3.x used by the interop tests and break
+             okhttp3.internal._UtilCommonKt initialization. -->
+        <exclusion>
+          <groupId>com.squareup.okhttp</groupId>
+          <artifactId>okhttp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.squareup.okio</groupId>
+          <artifactId>okio</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -182,8 +195,8 @@
     </dependency>
     <dependency>
       <groupId>com.squareup.okhttp3</groupId>
-      <artifactId>okhttp</artifactId>
-      <version>4.12.0</version>
+      <artifactId>okhttp-jvm</artifactId>
+      <version>5.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/keytools/samples/VaultClient.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/keytools/samples/VaultClient.java
@@ -133,7 +133,7 @@ public class VaultClient implements KmsClient {
   private String getContentFromTransitEngine(String endPoint, String jPayload, String masterKeyIdentifier) {
     LOG.info("masterKeyIdentifier: " + masterKeyIdentifier);
 
-    final RequestBody requestBody = RequestBody.create(JSON_MEDIA_TYPE, jPayload);
+    final RequestBody requestBody = RequestBody.create(jPayload, JSON_MEDIA_TYPE);
     Request request = new Request.Builder()
         .url(endPoint + masterKeyIdentifier)
         .header(tokenHeader, kmsToken)


### PR DESCRIPTION
This supersedes https://github.com/apache/parquet-java/pull/3614 and bumps [com.squareup.okhttp3:okhttp](https://github.com/square/okhttp) from 4.12.0 to 5.4.0.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/square/okhttp/blob/master/CHANGELOG.md">com.squareup.okhttp3:okhttp's changelog</a>.</em></p>
<blockquote>
<h2>Version 5.4.0</h2>
<p><em>2026-06-08</em></p>
<ul>
<li>New: Add superpowers to interceptors. Interceptors can now override anything settable on
<code>OkHttpClient.Builder</code>, such as the cache, connection pool, socket factory, and DNS. We expect
this will allow most users to use interceptors everywhere, insted of mixing and matching
interceptors with custom <code>Call.Factory</code> wrappers.</li>
<li>Fix: Limit each HTTP/2 response to 256 KiB of total headers.</li>
<li>Upgrade: [kotlinx.coroutines 1.11.0][coroutines_1_11_0]. This is used by the optional
<code>okhttp-coroutines</code> artifact.</li>
<li>Upgrade: [GraalVM 25.0.3][graalvm_25].</li>
<li>Upgrade: [Okio 3.17.0][okio_3_17_0].</li>
</ul>
<h2>Version 5.3.2</h2>
<p><em>2025-11-18</em></p>
<ul>
<li>
<p>Fix: Don't delay triggering timeouts. In Okio 3.16.0 we introduced a regression that caused
timeouts to fire later than they were supposed to.</p>
</li>
<li>
<p>Upgrade: [Okio 3.16.4][okio_3_16_4].</p>
</li>
</ul>
<h2>Version 5.3.1</h2>
<p><em>2025-11-16</em></p>
<p>This release is the same as 5.3.0. Okio 3.16.3 didn't have a necessary fix!</p>
<ul>
<li>Upgrade: [Okio 3.16.3][okio_3_16_3].</li>
</ul>
<h2>Version 5.3.0</h2>
<p><em>2025-10-30</em></p>
<ul>
<li>
<p>New: Add tags to <code>Call</code>, including computable tags. Use this to attach application-specific
metadata to a <code>Call</code> in an <code>EventListener</code> or <code>Interceptor</code>. The tag can be read in any other
<code>EventListener</code> or <code>Interceptor</code>.</p>
<pre lang="kotlin"><code>  override fun intercept(chain: Interceptor.Chain): Response {
    chain.call().tag(MyAnalyticsTag::class) {
      MyAnalyticsTag(...)
    }
<pre><code>return chain.proceed(chain.request())
</code></pre>
<p>}
</code></pre></p>
</li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/square/okhttp/commit/61423f472da24e0ccc42b6a2c0863fb27932fea5"><code>61423f4</code></a> Prepare for release 5.4.0.</li>
<li><a href="https://github.com/square/okhttp/commit/d7e6effcb6852ca848b5f497032546b98b0a6370"><code>d7e6eff</code></a> Update eclipse.osgi to v3.24.200 (<a href="https://redirect.github.com/square/okhttp/issues/9480">#9480</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/7a350986e3231a7b81cbfcc6e3c185327033422b"><code>7a35098</code></a> Update bnd to v7.3.0 (<a href="https://redirect.github.com/square/okhttp/issues/9475">#9475</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/0c5a45b1174b8f735cc251eb19faaed87b65d868"><code>0c5a45b</code></a> Update dependency com.puppycrawl.tools:checkstyle to v13.5.0 (<a href="https://redirect.github.com/square/okhttp/issues/9468">#9468</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/113ad17f70af6984a1a8b4d46024118e5409c44b"><code>113ad17</code></a> Update dependency macos to v26 (<a href="https://redirect.github.com/square/okhttp/issues/9457">#9457</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/84f601af03d047eef3f4b2f0ca6b6f72303dcea1"><code>84f601a</code></a> Update shadow.plugin to v9.4.2 (<a href="https://redirect.github.com/square/okhttp/issues/9466">#9466</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/7d463f4bcfca91e4466037f2c65c7c700545d64c"><code>7d463f4</code></a> Update spotless.plugin to v8.6.0 (<a href="https://redirect.github.com/square/okhttp/issues/9464">#9464</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/3bf00f52921a0727bd18997cd92112dd2e582ed7"><code>3bf00f5</code></a> Update plugin com.diffplug.spotless to v8.6.0 (<a href="https://redirect.github.com/square/okhttp/issues/9463">#9463</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/cfc45a3f146d2389797a3d51d405e9118bed56c9"><code>cfc45a3</code></a> Update spotless.plugin to v8.5.1 (<a href="https://redirect.github.com/square/okhttp/issues/9456">#9456</a>)</li>
<li><a href="https://github.com/square/okhttp/commit/81c5006e336c1cb67870694e38707e2c1c44fb34"><code>81c5006</code></a> Apply gradle lint correctly (<a href="https://redirect.github.com/square/okhttp/issues/9459">#9459</a>)</li>
<li>Additional commits viewable in <a href="https://github.com/square/okhttp/compare/parent-4.12.0...parent-5.4.0">compare view</a></li>
</ul>
</details>
<br />
