### PR TITLE
GH-3615: Replace @Test(expected=...) with assertThatThrownBy() checks

### DIFF
--- a/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
+++ b/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
@@ -30,6 +30,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.List;
@@ -469,11 +470,13 @@ public class TestSchemaConverter {
     Assert.assertEquals("p, s<r<p>, r<p>>, r<s<r<s<p, p>>, p>>", toSummaryString(map));
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testArrowTimeSecondToParquet() {
-    converter
-        .fromArrow(new Schema(asList(field("a", new ArrowType.Time(TimeUnit.SECOND, 32)))))
-        .getParquetSchema();
+    assertThatThrownBy(() -> converter
+            .fromArrow(new Schema(asList(field("a", new ArrowType.Time(TimeUnit.SECOND, 32)))))
+            .getParquetSchema())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Unsupported type Time(SECOND, 32)");
   }
 
   @Test
@@ -580,29 +583,35 @@ public class TestSchemaConverter {
         expected, converterInt96ToTimestamp.fromParquet(parquet).getArrowSchema());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testParquetInt64TimeMillisToArrow() {
-    converter.fromParquet(Types.buildMessage()
-        .addField(Types.optional(INT64)
-            .as(LogicalTypeAnnotation.timeType(false, MILLIS))
-            .named("a"))
-        .named("root"));
+    assertThatThrownBy(() -> converter.fromParquet(Types.buildMessage()
+            .addField(Types.optional(INT64)
+                .as(LogicalTypeAnnotation.timeType(false, MILLIS))
+                .named("a"))
+            .named("root")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("TIME(MILLIS,false) can only annotate INT32");
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testParquetInt32TimeMicrosToArrow() {
-    converter.fromParquet(Types.buildMessage()
-        .addField(Types.optional(INT32)
-            .as(LogicalTypeAnnotation.timeType(false, MICROS))
-            .named("a"))
-        .named("root"));
+    assertThatThrownBy(() -> converter.fromParquet(Types.buildMessage()
+            .addField(Types.optional(INT32)
+                .as(LogicalTypeAnnotation.timeType(false, MICROS))
+                .named("a"))
+            .named("root")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("TIME(MICROS,false) can only annotate INT64");
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testArrowTimestampSecondToParquet() {
-    converter
-        .fromArrow(new Schema(asList(field("a", new ArrowType.Timestamp(TimeUnit.SECOND, "UTC")))))
-        .getParquetSchema();
+    assertThatThrownBy(() -> converter
+            .fromArrow(new Schema(asList(field("a", new ArrowType.Timestamp(TimeUnit.SECOND, "UTC")))))
+            .getParquetSchema())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Unsupported type Timestamp(SECOND, UTC)");
   }
 
   @Test
@@ -655,21 +664,25 @@ public class TestSchemaConverter {
     Assert.assertEquals(expected, converter.fromParquet(parquet).getArrowSchema());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testParquetInt32TimestampMillisToArrow() {
-    converter.fromParquet(Types.buildMessage()
-        .addField(Types.optional(INT32)
-            .as(LogicalTypeAnnotation.timestampType(false, MILLIS))
-            .named("a"))
-        .named("root"));
+    assertThatThrownBy(() -> converter.fromParquet(Types.buildMessage()
+            .addField(Types.optional(INT32)
+                .as(LogicalTypeAnnotation.timestampType(false, MILLIS))
+                .named("a"))
+            .named("root")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("TIMESTAMP(MILLIS,false) can only annotate INT64");
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testParquetInt32TimestampMicrosToArrow() {
-    converter.fromParquet(Types.buildMessage()
-        .addField(Types.optional(INT32)
-            .as(LogicalTypeAnnotation.timestampType(false, MICROS))
-            .named("a"))
-        .named("root"));
+    assertThatThrownBy(() -> converter.fromParquet(Types.buildMessage()
+            .addField(Types.optional(INT32)
+                .as(LogicalTypeAnnotation.timestampType(false, MICROS))
+                .named("a"))
+            .named("root")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("TIMESTAMP(MICROS,false) can only annotate INT64");
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -43,6 +43,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 
@@ -168,9 +169,11 @@ public class TestAvroSchemaConverter {
         convertedAvroSchema.toString());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testTopLevelMustBeARecord() {
-    new AvroSchemaConverter().convert(Schema.create(INT));
+    assertThatThrownBy(() -> new AvroSchemaConverter().convert(Schema.create(INT)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Avro schema must be a record.");
   }
 
   @Test
@@ -292,7 +295,7 @@ public class TestAvroSchemaConverter {
     testParquetToAvroConversion(schema, ALL_PARQUET_SCHEMA);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testParquetMapWithNonStringKeyFails() throws Exception {
     MessageType parquetSchema =
         MessageTypeParser.parseMessageType("message myrecord {\n" + "  required group mymap (MAP) {\n"
@@ -302,7 +305,9 @@ public class TestAvroSchemaConverter {
             + "    }\n"
             + "  }\n"
             + "}\n");
-    new AvroSchemaConverter().convert(parquetSchema);
+    assertThatThrownBy(() -> new AvroSchemaConverter().convert(parquetSchema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Map key type must be binary (UTF8): required int32 key");
   }
 
   @Test

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
@@ -22,6 +22,7 @@ import static org.apache.parquet.avro.AvroTestUtil.optional;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -256,7 +257,7 @@ public class TestReadWrite {
     }
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testMapRequiredValueWithNull() throws Exception {
     Schema schema = Schema.createRecord("record1", null, null, false);
     schema.setFields(Lists.newArrayList(
@@ -277,7 +278,9 @@ public class TestReadWrite {
 
       GenericData.Record record =
           new GenericRecordBuilder(schema).set("mymap", map).build();
-      writer.write(record);
+      assertThatThrownBy(() -> writer.write(record))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessage("Null map value for map");
     }
   }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
@@ -23,6 +23,7 @@ import static org.apache.parquet.avro.AvroTestUtil.optional;
 import static org.apache.parquet.avro.AvroTestUtil.optionalField;
 import static org.apache.parquet.avro.AvroTestUtil.primitive;
 import static org.apache.parquet.avro.AvroTestUtil.record;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -161,7 +162,7 @@ public class TestReadWriteOldListBehavior {
     }
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testMapRequiredValueWithNull() throws Exception {
     Schema schema = Schema.createRecord("record1", null, null, false);
     schema.setFields(Lists.newArrayList(
@@ -181,7 +182,9 @@ public class TestReadWriteOldListBehavior {
 
       GenericData.Record record =
           new GenericRecordBuilder(schema).set("mymap", map).build();
-      writer.write(record);
+      assertThatThrownBy(() -> writer.write(record))
+          .isInstanceOf(RuntimeException.class)
+          .hasMessage("Null map value for map");
     }
   }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestStringBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestStringBehavior.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.avro;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.io.Resources;
@@ -349,7 +351,7 @@ public class TestStringBehavior {
     Assert.assertEquals("Should have the correct BigDecimal value", BIG_DECIMAL, parquetRecord.stringable_class);
   }
 
-  @Test(expected = SecurityException.class)
+  @Test
   public void testSpecificValidationFail() throws IOException {
     Configuration conf = new Configuration();
     conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false);
@@ -359,11 +361,16 @@ public class TestStringBehavior {
         AvroParquetReader.<org.apache.parquet.avro.StringBehaviorTest>builder(parquetFile)
             .withConf(conf)
             .build()) {
-      parquet.read();
+      assertThatThrownBy(parquet::read)
+          .isInstanceOf(SecurityException.class)
+          .hasMessage(
+              "Forbidden java.math.BigDecimal! This class is not trusted to be included in Avro schema "
+                  + "using java-class or java-key-class. Please set the Parquet/Hadoop configuration "
+                  + "parquet.avro.serializable.classes with the classes you trust.");
     }
   }
 
-  @Test(expected = SecurityException.class)
+  @Test
   public void testReflectValidationFail() throws IOException {
     Schema reflectSchema = ReflectData.get().getSchema(ReflectRecord.class);
 
@@ -374,11 +381,16 @@ public class TestStringBehavior {
     try (ParquetReader<ReflectRecord> parquet = AvroParquetReader.<ReflectRecord>builder(parquetFile)
         .withConf(conf)
         .build()) {
-      parquet.read();
+      assertThatThrownBy(parquet::read)
+          .isInstanceOf(SecurityException.class)
+          .hasMessage(
+              "Forbidden java.math.BigDecimal! This class is not trusted to be included in Avro schema "
+                  + "using java-class or java-key-class. Please set the Parquet/Hadoop configuration "
+                  + "parquet.avro.serializable.classes with the classes you trust.");
     }
   }
 
-  @Test(expected = SecurityException.class)
+  @Test
   public void testReflectJavaClassValidationFail() throws IOException {
     Schema reflectSchema = ReflectData.get().getSchema(ReflectRecordJavaClass.class);
 
@@ -391,7 +403,12 @@ public class TestStringBehavior {
             parquetFile)
         .withConf(conf)
         .build()) {
-      parquet.read();
+      assertThatThrownBy(parquet::read)
+          .isInstanceOf(SecurityException.class)
+          .hasMessage(
+              "Forbidden java.math.BigDecimal! This class is not trusted to be included in Avro schema "
+                  + "using java-class or java-key-class. Please set the Parquet/Hadoop configuration "
+                  + "parquet.avro.serializable.classes with the classes you trust.");
     }
   }
 

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.google.protobuf.Message;
 import java.io.File;
 import java.io.IOException;
@@ -65,14 +67,16 @@ public class CatCommandTest extends ParquetFileTest {
     Assert.assertEquals(0, command.run());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testCatCommandWithInvalidColumn() throws IOException {
+  @Test
+  public void testCatCommandWithInvalidColumn() {
     File file = parquetFile();
     CatCommand command = new CatCommand(createLogger(), 0);
     command.sourceFiles = Arrays.asList(file.getAbsolutePath());
     command.columns = Arrays.asList("invalid_field");
     command.setConf(new Configuration());
-    command.run();
+    assertThatThrownBy(command::run)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find field 'invalid_field' in schema");
   }
 
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -50,8 +52,8 @@ public class ConvertCSVCommandTest extends CSVFileTest {
     Assert.assertTrue(output.exists());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testConvertCSVCommandWithDifferentSchemas() throws IOException {
+  @Test
+  public void testConvertCSVCommandWithDifferentSchemas() {
     File file = csvFile();
     File fileWithDifferentSchema = csvFileWithDifferentSchema();
     ConvertCSVCommand command = new ConvertCSVCommand(createLogger());
@@ -59,7 +61,9 @@ public class ConvertCSVCommandTest extends CSVFileTest {
     File output = new File(getTempFolder(), getClass().getSimpleName() + ".parquet");
     command.outputPath = output.getAbsolutePath();
     command.setConf(new Configuration());
-    command.run();
+    assertThatThrownBy(command::run)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("seems to have a different schema from others");
   }
 
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -40,7 +42,7 @@ public class RewriteCommandTest extends ParquetFileTest {
     Assert.assertTrue(output.exists());
   }
 
-  @Test(expected = FileAlreadyExistsException.class)
+  @Test
   public void testRewriteCommandWithoutOverwrite() throws IOException {
     File file = parquetFile();
     RewriteCommand command = new RewriteCommand(createLogger());
@@ -50,7 +52,9 @@ public class RewriteCommandTest extends ParquetFileTest {
     command.setConf(new Configuration());
 
     Files.createFile(output.toPath());
-    command.run();
+    assertThatThrownBy(command::run)
+        .isInstanceOf(FileAlreadyExistsException.class)
+        .hasMessageContaining("File already exists");
   }
 
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -44,13 +46,15 @@ public class ScanCommandTest extends ParquetFileTest {
     Assert.assertEquals(0, command.run());
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testScanCommandWithInvalidColumnName() throws IOException {
+  @Test
+  public void testScanCommandWithInvalidColumnName() {
     File file = parquetFile();
     ScanCommand command = new ScanCommand(createLogger());
     command.sourceFiles = Arrays.asList(file.getAbsolutePath());
     command.columns = Arrays.asList("invalid_field");
     command.setConf(new Configuration());
-    command.run();
+    assertThatThrownBy(command::run)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot find field 'invalid_field' in schema");
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/SchemaCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/SchemaCommandTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -52,7 +54,7 @@ public class SchemaCommandTest extends ParquetFileTest {
     Assert.assertTrue(0 < outputFile.length());
   }
 
-  @Test(expected = FileAlreadyExistsException.class)
+  @Test
   public void testSchemaCommandOverwriteExistentFileWithoutOverwriteOption() throws IOException {
     File inputFile = parquetFile();
     File outputFile = new File(getTempFolder(), getClass().getSimpleName() + ".avsc");
@@ -61,6 +63,8 @@ public class SchemaCommandTest extends ParquetFileTest {
     command.targets = Arrays.asList(inputFile.getAbsolutePath());
     command.outputPath = outputFile.getAbsolutePath();
     command.setConf(new Configuration());
-    command.run();
+    assertThatThrownBy(command::run)
+        .isInstanceOf(FileAlreadyExistsException.class)
+        .hasMessageContaining("File already exists");
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
@@ -19,6 +19,8 @@
 
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.beust.jcommander.JCommander;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -95,9 +97,12 @@ public class ToAvroCommandTest extends AvroFileTest {
     Assert.assertTrue(avroFile.exists());
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testToAvroCommandWithInvalidCompression() throws IOException {
-    toAvro(parquetFile(), "FOO");
+    File parquetFile = parquetFile();
+    assertThatThrownBy(() -> toAvro(parquetFile, "FOO"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Codec incompatible with Avro: FOO");
   }
 
   @Test
@@ -109,10 +114,13 @@ public class ToAvroCommandTest extends AvroFileTest {
     Assert.assertTrue(0 < avroFile.length());
   }
 
-  @Test(expected = FileAlreadyExistsException.class)
+  @Test
   public void testToAvroCommandOverwriteExistentFileWithoutOverwriteOption() throws IOException {
     File outputFile = new File(getTempFolder(), getClass().getSimpleName() + ".avro");
     FileUtils.touch(outputFile);
-    toAvro(parquetFile(), outputFile, false);
+    File parquetFile = parquetFile();
+    assertThatThrownBy(() -> toAvro(parquetFile, outputFile, false))
+        .isInstanceOf(FileAlreadyExistsException.class)
+        .hasMessageContaining("File already exists");
   }
 }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForIntegerTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForIntegerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.column.values.delta;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -48,9 +49,12 @@ public class DeltaBinaryPackingValuesWriterForIntegerTest {
     random = new Random(0);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void miniBlockSizeShouldBeMultipleOf8() {
-    new DeltaBinaryPackingValuesWriterForInteger(1281, 4, 100, 100, new DirectByteBufferAllocator());
+    assertThatThrownBy(() -> new DeltaBinaryPackingValuesWriterForInteger(
+            1281, 4, 100, 100, new DirectByteBufferAllocator()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("miniBlockSize must be multiple of 8, but it's 320.25");
   }
 
   /* When data size is multiple of Block*/

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForLongTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForLongTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.column.values.delta;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -48,9 +49,12 @@ public class DeltaBinaryPackingValuesWriterForLongTest {
     random = new Random(0);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void miniBlockSizeShouldBeMultipleOf8() {
-    new DeltaBinaryPackingValuesWriterForLong(1281, 4, 100, 100, new DirectByteBufferAllocator());
+    assertThatThrownBy(() ->
+            new DeltaBinaryPackingValuesWriterForLong(1281, 4, 100, 100, new DirectByteBufferAllocator()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("miniBlockSize must be multiple of 8, but it's 320.25");
   }
 
   /* When data size is multiple of Block */

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -50,6 +50,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -226,9 +227,11 @@ public class TestTypeBuilders {
         new MessageType("m"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFixedWithoutLength() {
-    Types.required(FIXED_LEN_BYTE_ARRAY).named("fixed");
+    assertThatThrownBy(() -> Types.required(FIXED_LEN_BYTE_ARRAY).named("fixed"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid FIXED_LEN_BYTE_ARRAY length: 0");
   }
 
   @Test
@@ -1462,20 +1465,25 @@ public class TestTypeBuilders {
     assertEquals(variantExpected, variantActual);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDecimalLogicalTypeWithDeprecatedScaleMismatch() {
-    Types.required(BINARY)
-        .as(LogicalTypeAnnotation.decimalType(3, 4))
-        .scale(4)
-        .named("aDecimal");
+    assertThatThrownBy(() -> Types.required(BINARY)
+            .as(LogicalTypeAnnotation.decimalType(3, 4))
+            .scale(4)
+            .named("aDecimal"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Decimal scale should match with the scale of the logical type. Expected: 3, but was: 4");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDecimalLogicalTypeWithDeprecatedPrecisionMismatch() {
-    Types.required(BINARY)
-        .as(LogicalTypeAnnotation.decimalType(3, 4))
-        .precision(5)
-        .named("aDecimal");
+    assertThatThrownBy(() -> Types.required(BINARY)
+            .as(LogicalTypeAnnotation.decimalType(3, 4))
+            .precision(5)
+            .named("aDecimal"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Decimal precision should match with the precision of the logical type. Expected: 4, but was: 5");
   }
 
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuildersWithLogicalTypes.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuildersWithLogicalTypes.java
@@ -40,6 +40,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -415,20 +416,25 @@ public class TestTypeBuildersWithLogicalTypes {
     Assert.assertEquals(nonUtcMicrosExpected, nonUtcMicrosActual);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDecimalLogicalTypeWithDeprecatedScaleMismatch() {
-    Types.required(BINARY)
-        .as(LogicalTypeAnnotation.decimalType(3, 4))
-        .scale(4)
-        .named("aDecimal");
+    assertThatThrownBy(() -> Types.required(BINARY)
+            .as(LogicalTypeAnnotation.decimalType(3, 4))
+            .scale(4)
+            .named("aDecimal"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Decimal scale should match with the scale of the logical type. Expected: 3, but was: 4");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testDecimalLogicalTypeWithDeprecatedPrecisionMismatch() {
-    Types.required(BINARY)
-        .as(LogicalTypeAnnotation.decimalType(3, 4))
-        .precision(5)
-        .named("aDecimal");
+    assertThatThrownBy(() -> Types.required(BINARY)
+            .as(LogicalTypeAnnotation.decimalType(3, 4))
+            .precision(5)
+            .named("aDecimal"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Decimal precision should match with the precision of the logical type. Expected: 4, but was: 5");
   }
 
   @Test

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -26,6 +26,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -650,31 +651,42 @@ public class ParquetRewriterTest {
     }
   }
 
-  @Test(expected = InvalidSchemaException.class)
+  @Test
   public void testMergeTwoFilesWithDifferentSchema() throws Exception {
-    testMergeTwoFilesWithDifferentSchemaSetup(true, null, null);
+    assertThatThrownBy(() -> testMergeTwoFilesWithDifferentSchemaSetup(true, null, null))
+        .isInstanceOf(InvalidSchemaException.class)
+        .hasMessageContaining("Input files have different schemas, current file:");
   }
 
-  @Test(expected = InvalidSchemaException.class)
+  @Test
   public void testMergeTwoFilesToJoinWithDifferentSchema() throws Exception {
-    testMergeTwoFilesWithDifferentSchemaSetup(false, null, null);
+    assertThatThrownBy(() -> testMergeTwoFilesWithDifferentSchemaSetup(false, null, null))
+        .isInstanceOf(InvalidSchemaException.class)
+        .hasMessageContaining("Input files have different schemas, current file:");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMergeTwoFilesWithWrongDestinationRenamedColumn() throws Exception {
-    testMergeTwoFilesWithDifferentSchemaSetup(
-        null, ImmutableMap.of("WrongColumnName", "WrongColumnNameRenamed"), null);
+    assertThatThrownBy(() -> testMergeTwoFilesWithDifferentSchemaSetup(
+            null, ImmutableMap.of("WrongColumnName", "WrongColumnNameRenamed"), null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Column to rename 'WrongColumnName' is not found in input files schema");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMergeTwoFilesWithWrongSourceRenamedColumn() throws Exception {
-    testMergeTwoFilesWithDifferentSchemaSetup(null, ImmutableMap.of("Name", "DocId"), null);
+    assertThatThrownBy(
+            () -> testMergeTwoFilesWithDifferentSchemaSetup(null, ImmutableMap.of("Name", "DocId"), null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Renamed column target name 'DocId' is already present in a schema");
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMergeTwoFilesNullifyAndRenamedSameColumn() throws Exception {
-    testMergeTwoFilesWithDifferentSchemaSetup(
-        null, ImmutableMap.of("Name", "NameRenamed"), ImmutableMap.of("Name", MaskMode.NULLIFY));
+    assertThatThrownBy(() -> testMergeTwoFilesWithDifferentSchemaSetup(
+            null, ImmutableMap.of("Name", "NameRenamed"), ImmutableMap.of("Name", MaskMode.NULLIFY)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot nullify and rename the same column");
   }
 
   public void testMergeTwoFilesWithDifferentSchemaSetup(
@@ -842,12 +854,10 @@ public class ParquetRewriterTest {
         inputFilesToJoin.stream().map(x -> new Path(x.getFileName())).collect(Collectors.toList()),
         true);
     RewriteOptions options = builder.build();
-    try {
-      rewriter =
-          new ParquetRewriter(options); // This should throw an exception because the row count is different
-    } catch (RuntimeException e) {
-      assertTrue(e.getMessage().contains("The number of rows in each block must match"));
-    }
+    // This should throw an exception because the row count is different
+    assertThatThrownBy(() -> new ParquetRewriter(options))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("The number of rows in each block must match");
   }
 
   @Test

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/ColumnMaskerTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/ColumnMaskerTest.java
@@ -24,6 +24,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
 
 import com.google.common.collect.ImmutableMap;
@@ -83,24 +84,28 @@ public class ColumnMaskerTest {
     nullifyColumns(conf, inputFile, outputFile);
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testNullColumns() throws IOException {
     ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(), new Path(outputFile))
         .withConf(conf)
         .build();
     Group group = reader.read();
-    group.getLong("DocId", 0);
+    assertThatThrownBy(() -> group.getLong("DocId", 0))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("not found 0(DocId) element number 0 in group:\n%s", group);
     reader.close();
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testNullNestedColumns() throws IOException {
     ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(), new Path(outputFile))
         .withConf(conf)
         .build();
     Group group = reader.read();
     Group subGroup = group.getGroup("Links", 0);
-    subGroup.getBinary("Backward", 0).getBytes();
+    assertThatThrownBy(() -> subGroup.getBinary("Backward", 0).getBytes())
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("not found 0(Backward) element number 0 in group:\n%s", subGroup);
     reader.close();
   }
 

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.proto;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -975,8 +976,8 @@ public class ProtoWriteSupportTest {
     Mockito.verifyNoMoreInteractions(readConsumerMock);
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void testMessageWithExtensions() throws Exception {
+  @Test
+  public void testMessageWithExtensions() {
     RecordConsumer readConsumerMock = Mockito.mock(RecordConsumer.class);
     ProtoWriteSupport<TestProtobuf.Vehicle> instance =
         createReadConsumerInstance(TestProtobuf.Vehicle.class, readConsumerMock);
@@ -987,7 +988,9 @@ public class ProtoWriteSupportTest {
     // will cause an exception.
     msg.setExtension(TestProtobuf.Airplane.wingSpan, 50);
 
-    instance.write(msg.build());
+    assertThatThrownBy(() -> instance.write(msg.build()))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot convert Protobuf message with extension field(s)");
   }
 
   @Test


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Replaced the old `@Test(expected = SomeException.class)` patterns in the tests with `assertThatThrownBy(...)`, asserting on both the exception type and the message

The reason for the change is because `@Test(expected = SomeException.class)` can't assert on the exception message at all. Also, it's not clear which statement in the entire test method threw the exception, so a test could pass for the wrong reason

### What changes are included in this PR?


### Are these changes tested?
yes, existing tests

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
