### PR TITLE
Restrict trigger push branch for GitHub Workflow

### DIFF
--- a/.github/workflows/ci-hadoop3.yml
+++ b/.github/workflows/ci-hadoop3.yml
@@ -17,7 +17,12 @@
 
 name: CI Hadoop 3
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - parquet-*
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/vector-plugins.yml
+++ b/.github/workflows/vector-plugins.yml
@@ -17,7 +17,12 @@
 
 name: Vector-plugins
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - parquet-*
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Feature branches rarely need their own CI runs: the code is already tested when a pull request is opened against a release branch. If the push trigger has no branch restriction and pull_request is also configured, every push to a branch with an open PR runs the workflow twice: once for the push and once for the PR synchronisation.

Always give the push trigger an explicit list of branches: this stops branches created from a release branch from inheriting its workflow runs.

see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=430408443#GitHubActionsRecommendedPractices-Restrictthepushtriggertospecificbranches

<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change


### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
