### PR TITLE
GH-3659: Throw IAE when dealing with odd-length/invalid hex string in Parquet CLI

### DIFF
--- a/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
+++ b/parquet-cli/src/main/java/org/apache/parquet/cli/BaseCommand.java
@@ -20,6 +20,7 @@
 package org.apache.parquet.cli;
 
 import com.beust.jcommander.internal.Lists;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
@@ -428,16 +429,22 @@ public abstract class BaseCommand implements Command, Configurable {
     }
   }
 
-  private byte[] hexToBytes(String hex) {
-
+  @VisibleForTesting
+  byte[] hexToBytes(String hex) {
+    String originalHex = hex;
     if (hex.startsWith("0x") || hex.startsWith("0X")) {
       hex = hex.substring(2);
     }
 
     int len = hex.length();
+    Preconditions.checkArgument(len % 2 == 0, "Invalid hex string: %s", originalHex);
+
     byte[] data = new byte[len / 2];
     for (int i = 0; i < len; i += 2) {
-      data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4) + Character.digit(hex.charAt(i + 1), 16));
+      int high = Character.digit(hex.charAt(i), 16);
+      int low = Character.digit(hex.charAt(i + 1), 16);
+      Preconditions.checkArgument(high >= 0 && low >= 0, "Invalid hex string: %s", originalHex);
+      data[i / 2] = (byte) ((high << 4) + low);
     }
     return data;
   }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
@@ -18,6 +18,9 @@
  */
 package org.apache.parquet.cli;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -60,6 +63,29 @@ public class BaseCommandTest {
   public void qualifiedURIResourceURITest() throws IOException {
     URI uri = this.command.qualifiedURI("resource:/a");
     Assert.assertEquals("/a", uri.getPath());
+  }
+
+  @Test
+  public void hexToBytes() {
+    assertThat(this.command.hexToBytes("0x10")).containsExactly(0x10);
+    assertThat(this.command.hexToBytes("0x0506")).containsExactly(0x05, 0x06);
+    assertThat(this.command.hexToBytes("0506")).containsExactly(0x05, 0x06);
+    assertThat(this.command.hexToBytes("0x010203")).containsExactly(0x01, 0x02, 0x03);
+  }
+
+  @Test
+  public void hexToBytesRejectsInvalidHexString() {
+    assertThatThrownBy(() -> this.command.hexToBytes("0x011"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid hex string: 0x011");
+
+    assertThatThrownBy(() -> this.command.hexToBytes("0xABZZ"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid hex string: 0xABZZ");
+
+    assertThatThrownBy(() -> this.command.hexToBytes("0xabgg"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid hex string: 0xabgg");
   }
 
   // For Windows


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
This avoids odd-length hex strings being passed, which cause IndexOutOfBoundsExceptions and instead throws IAE to make it clearer that hex string length must be even

Closes #3659 

### What changes are included in this PR?


### Are these changes tested?
added tests that reproduce the issue

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
