### PR TITLE
MINOR: Fix withLogicalTypeAnnotation Javadoc @return description

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java
@@ -678,7 +678,7 @@ public final class PrimitiveType extends Type {
 
   /**
    * @param logicalType LogicalTypeAnnotation
-   * @return a new PrimitiveType with the same fields and a new id null
+   * @return a new PrimitiveType with the same fields and the given logical type annotation
    */
   public PrimitiveType withLogicalTypeAnnotation(LogicalTypeAnnotation logicalType) {
     return new PrimitiveType(getRepetition(), primitive, length, getName(), logicalType, getId());


### PR DESCRIPTION

### Rationale for this change

The `@return` tag on the public method
`PrimitiveType.withLogicalTypeAnnotation(LogicalTypeAnnotation)` reads:

> `@return a new PrimitiveType with the same fields and a new id null`

That description is self-contradicting ("a new id null") and factually wrong. The
method body is:

```java
public PrimitiveType withLogicalTypeAnnotation(LogicalTypeAnnotation logicalType) {
  return new PrimitiveType(getRepetition(), primitive, length, getName(), logicalType, getId());
}
```

It passes `getId()` straight through to the constructor, so the existing field id
is preserved unchanged; only the logical type annotation is replaced. The method
never assigns a new id and never nulls it.

The wording is a mangled copy-paste from the sibling `withId(int)` method just
above it, whose `@return a new PrimitiveType with the same fields and a new id` is
correct there because `withId` passes `new ID(id)`.

### What changes are included in this PR?

A single-line Javadoc correction on that `@return` tag (in
`parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveType.java`):

```diff
   /**
    * @param logicalType LogicalTypeAnnotation
-   * @return a new PrimitiveType with the same fields and a new id null
+   * @return a new PrimitiveType with the same fields and the given logical type annotation
    */
   public PrimitiveType withLogicalTypeAnnotation(LogicalTypeAnnotation logicalType) {
```

No code behavior changes.

### Are these changes tested?

No new test. This is a Javadoc `@return` correction with no runtime behavior
change, so a unit test would not assert anything meaningful. I confirmed the
module still builds and produces valid Javadoc:

- `mvn -pl parquet-column spotless:check` -> BUILD SUCCESS (palantir-java-format
  gate passes)
- `mvn -pl parquet-column -am -DskipTests package` -> BUILD SUCCESS
- `mvn -pl parquet-column javadoc:javadoc` -> BUILD SUCCESS (no new warnings; the
  corrected `@return` tag is well-formed)

### Are there any user-facing changes?

No. Documentation (Javadoc) only; no API or behavior change.
