### PR TITLE
MINOR: Fix VariantUtil.getByte() Javadoc copied from getShort()

### DIFF
--- a/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
+++ b/parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java
@@ -546,9 +546,9 @@ class VariantUtil {
   }
 
   /**
-   * Similar to getLong(), but for the types: Type.BYTE, SHORT.
+   * Similar to getLong(), but for the type: Type.BYTE.
    * @param value The Variant value
-   * @return The short value
+   * @return The byte value
    */
   static byte getByte(ByteBuffer value) {
     checkIndex(value.position(), value.limit());


### PR DESCRIPTION

### Rationale for this change

The Javadoc on the package-private helper `VariantUtil.getByte(ByteBuffer)` is a
verbatim copy of the `getShort(ByteBuffer)` block directly above it, and was never
adjusted for `getByte`. It currently reads:

```java
/**
 * Similar to getLong(), but for the types: Type.BYTE, SHORT.
 * @param value The Variant value
 * @return The short value
 */
static byte getByte(ByteBuffer value) {
```

Both lines contradict the method:

- `getByte` does not handle `Type.SHORT`. Its switch has only `case INT8:` (the
  BYTE type); every other type, `SHORT` included, falls through to
  `throw unexpectedType(Variant.Type.BYTE, value)`.
- `@return The short value` contradicts the declared `static byte getByte(...)`
  return type; the method returns `(byte) readLong(value, value.position() + 1, 1)`.

`getShort` above it genuinely handles both `INT8` and `INT16` and returns `short`,
so the doc block was clearly copy-pasted onto `getByte` and left stale.

### What changes are included in this PR?

A two-line Javadoc correction on `getByte` (in
`parquet-variant/src/main/java/org/apache/parquet/variant/VariantUtil.java`):

```diff
   /**
-   * Similar to getLong(), but for the types: Type.BYTE, SHORT.
+   * Similar to getLong(), but for the type: Type.BYTE.
    * @param value The Variant value
-   * @return The short value
+   * @return The byte value
    */
   static byte getByte(ByteBuffer value) {
```

The (correct) `getShort` Javadoc directly above is left untouched. No code behavior
changes.

### Are these changes tested?

No new test. This is a Javadoc correction with no runtime behavior change, so a
unit test would not assert anything meaningful. The corrected wording simply makes
the internal contract match the already-tested behavior (`TestVariantScalar`
exercises `getByte` on BYTE values and the invalid-read paths). I confirmed the
module still passes its gates locally:

- `mvn -pl parquet-variant spotless:check` -> BUILD SUCCESS (palantir-java-format
  gate passes)
- `mvn -pl parquet-variant -am -Dspotless.check.skip=true test` -> BUILD SUCCESS
  (parquet-variant: 180 run, 0 failures, 0 errors, 1 skipped)

### Are there any user-facing changes?

No. Documentation (Javadoc) only, on a package-private helper. No API or behavior
change.

<!-- No linked issue: trivial doc fix, MINOR: per the PR template. -->
