### PR TITLE
GH-3652: Use assertThat checks in parquet-format-structures/parquet-encoding/parquet-thrift tests

### DIFF
--- a/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.bytes;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import org.junit.Test;
@@ -32,7 +32,7 @@ public class TestBytesInput {
       BytesInput varInt = BytesInput.fromUnsignedVarInt(testVal);
       byte[] rno = varInt.toByteArray();
       int i = BytesUtils.readUnsignedVarInt(new ByteArrayInputStream(rno));
-      assertEquals((int) testVal, i);
+      assertThat(i).isEqualTo(testVal);
     }
   }
 }

--- a/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestCapacityByteArrayOutputStream.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestCapacityByteArrayOutputStream.java
@@ -18,13 +18,10 @@
  */
 package org.apache.parquet.bytes;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -49,7 +46,7 @@ public class TestCapacityByteArrayOutputStream {
       final int expectedSize = 54;
       for (int i = 0; i < expectedSize; i++) {
         capacityByteArrayOutputStream.write(i);
-        assertEquals(i + 1, capacityByteArrayOutputStream.size());
+        assertThat(capacityByteArrayOutputStream.size()).isEqualTo(i + 1);
       }
       validate(capacityByteArrayOutputStream, expectedSize);
     }
@@ -67,31 +64,30 @@ public class TestCapacityByteArrayOutputStream {
   @Test
   public void testWriteArrayExpand() throws Throwable {
     try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(2)) {
-      assertEquals(0, capacityByteArrayOutputStream.getCapacity());
+      assertThat(capacityByteArrayOutputStream.getCapacity()).isZero();
 
-      byte[] toWrite = {(byte) (1), (byte) (2), (byte) (3), (byte) (4)};
+      byte[] toWrite = bytes(1, 2, 3, 4);
       int toWriteOffset = 0;
       int writeLength = 2;
       // write 2 bytes array
       capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
       toWriteOffset += writeLength;
-      assertEquals(2, capacityByteArrayOutputStream.size());
-      assertEquals(2, capacityByteArrayOutputStream.getCapacity());
+      assertThat(capacityByteArrayOutputStream.size()).isEqualTo(2);
+      assertThat(capacityByteArrayOutputStream.getCapacity()).isEqualTo(2);
 
       // write 1 byte array, expand capacity to 4
       writeLength = 1;
       capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
       toWriteOffset += writeLength;
-      assertEquals(3, capacityByteArrayOutputStream.size());
-      assertEquals(4, capacityByteArrayOutputStream.getCapacity());
+      assertThat(capacityByteArrayOutputStream.size()).isEqualTo(3);
+      assertThat(capacityByteArrayOutputStream.getCapacity()).isEqualTo(4);
 
       // write 1 byte array, not expand
       capacityByteArrayOutputStream.write(toWrite, toWriteOffset, writeLength);
-      assertEquals(4, capacityByteArrayOutputStream.size());
-      assertEquals(4, capacityByteArrayOutputStream.getCapacity());
-      final byte[] byteArray =
-          BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-      assertArrayEquals(toWrite, byteArray);
+      assertThat(capacityByteArrayOutputStream.size()).isEqualTo(4);
+      assertThat(capacityByteArrayOutputStream.getCapacity()).isEqualTo(4);
+      assertThat(BytesInput.from(capacityByteArrayOutputStream).toByteArray())
+          .containsExactly(toWrite);
     }
   }
 
@@ -99,10 +95,9 @@ public class TestCapacityByteArrayOutputStream {
   public void testWriteArrayAndInt() throws Throwable {
     try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10)) {
       for (int i = 0; i < 23; i++) {
-        byte[] toWrite = {(byte) (i * 3), (byte) (i * 3 + 1)};
-        capacityByteArrayOutputStream.write(toWrite);
-        capacityByteArrayOutputStream.write((byte) (i * 3 + 2));
-        assertEquals((i + 1) * 3, capacityByteArrayOutputStream.size());
+        capacityByteArrayOutputStream.write(bytes(i * 3, i * 3 + 1));
+        capacityByteArrayOutputStream.write(i * 3 + 2);
+        assertThat(capacityByteArrayOutputStream.size()).isEqualTo((i + 1) * 3);
       }
       validate(capacityByteArrayOutputStream, 23 * 3);
     }
@@ -117,19 +112,15 @@ public class TestCapacityByteArrayOutputStream {
     try (CapacityByteArrayOutputStream capacityByteArrayOutputStream = newCapacityBAOS(10)) {
       for (int i = 0; i < 54; i++) {
         capacityByteArrayOutputStream.write(i);
-        assertEquals(i + 1, capacityByteArrayOutputStream.size());
+        assertThat(capacityByteArrayOutputStream.size()).isEqualTo(i + 1);
       }
       capacityByteArrayOutputStream.reset();
       for (int i = 0; i < 54; i++) {
         capacityByteArrayOutputStream.write(54 + i);
-        assertEquals(i + 1, capacityByteArrayOutputStream.size());
+        assertThat(capacityByteArrayOutputStream.size()).isEqualTo(i + 1);
       }
-      final byte[] byteArray =
-          BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-      assertEquals(54, byteArray.length);
-      for (int i = 0; i < 54; i++) {
-        assertEquals(i + " in " + Arrays.toString(byteArray), 54 + i, byteArray[i]);
-      }
+      assertThat(BytesInput.from(capacityByteArrayOutputStream).toByteArray())
+          .isEqualTo(byteRange(54, 54));
     }
   }
 
@@ -139,42 +130,17 @@ public class TestCapacityByteArrayOutputStream {
       int v = 23;
       writeArraysOf3(capacityByteArrayOutputStream, v);
       int n = v * 3;
-      byte[] toWrite = { // bigger than 2 slabs of size of 10
-        (byte) n,
-        (byte) (n + 1),
-        (byte) (n + 2),
-        (byte) (n + 3),
-        (byte) (n + 4),
-        (byte) (n + 5),
-        (byte) (n + 6),
-        (byte) (n + 7),
-        (byte) (n + 8),
-        (byte) (n + 9),
-        (byte) (n + 10),
-        (byte) (n + 11),
-        (byte) (n + 12),
-        (byte) (n + 13),
-        (byte) (n + 14),
-        (byte) (n + 15),
-        (byte) (n + 16),
-        (byte) (n + 17),
-        (byte) (n + 18),
-        (byte) (n + 19),
-        (byte) (n + 20)
-      };
+      byte[] toWrite = byteRange(n, 21);
       capacityByteArrayOutputStream.write(toWrite);
       n = n + toWrite.length;
-      assertEquals(n, capacityByteArrayOutputStream.size());
+      assertThat(capacityByteArrayOutputStream.size()).isEqualTo(n);
       validate(capacityByteArrayOutputStream, n);
       capacityByteArrayOutputStream.reset();
       // check it works after reset too
       capacityByteArrayOutputStream.write(toWrite);
-      assertEquals(toWrite.length, capacityByteArrayOutputStream.size());
-      byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-      assertEquals(toWrite.length, byteArray.length);
-      for (int i = 0; i < toWrite.length; i++) {
-        assertEquals(toWrite[i], byteArray[i]);
-      }
+      assertThat(capacityByteArrayOutputStream.size()).isEqualTo(toWrite.length);
+      assertThat(BytesInput.from(capacityByteArrayOutputStream).toByteArray())
+          .isEqualTo(toWrite);
     }
   }
 
@@ -185,27 +151,24 @@ public class TestCapacityByteArrayOutputStream {
       int v = 23;
       for (int j = 0; j < it; j++) {
         for (int i = 0; i < v; i++) {
-          byte[] toWrite = {(byte) (i * 3), (byte) (i * 3 + 1), (byte) (i * 3 + 2)};
-          capacityByteArrayOutputStream.write(toWrite);
-          assertEquals((i + 1) * 3 + v * 3 * j, capacityByteArrayOutputStream.size());
+          capacityByteArrayOutputStream.write(bytes(i * 3, i * 3 + 1, i * 3 + 2));
+          assertThat(capacityByteArrayOutputStream.size()).isEqualTo((i + 1) * 3 + v * 3 * j);
         }
       }
       byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-      assertEquals(v * 3 * it, byteArray.length);
-      for (int i = 0; i < v * 3 * it; i++) {
-        assertEquals(i % (v * 3), byteArray[i]);
-      }
+      assertThat(byteArray).hasSize(v * 3 * it);
+      assertThat(byteArray).isEqualTo(repeatedByteRange(0, v * 3, v * 3 * it));
       // verifying we have not created 500 * 23 / 10 slabs
-      assertTrue(
-          "slab count: " + capacityByteArrayOutputStream.getSlabCount(),
-          capacityByteArrayOutputStream.getSlabCount() <= 20);
+      assertThat(capacityByteArrayOutputStream.getSlabCount())
+          .as("slab count: " + capacityByteArrayOutputStream.getSlabCount())
+          .isLessThanOrEqualTo(20);
       capacityByteArrayOutputStream.reset();
       writeArraysOf3(capacityByteArrayOutputStream, v);
       validate(capacityByteArrayOutputStream, v * 3);
       // verifying we use less slabs now
-      assertTrue(
-          "slab count: " + capacityByteArrayOutputStream.getSlabCount(),
-          capacityByteArrayOutputStream.getSlabCount() <= 2);
+      assertThat(capacityByteArrayOutputStream.getSlabCount())
+          .as("slab count: " + capacityByteArrayOutputStream.getSlabCount())
+          .isLessThanOrEqualTo(2);
     }
   }
 
@@ -214,11 +177,11 @@ public class TestCapacityByteArrayOutputStream {
     // test replace the first value
     try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
       cbaos.write(10);
-      assertEquals(0, cbaos.getCurrentIndex());
+      assertThat(cbaos.getCurrentIndex()).isZero();
       cbaos.setByte(0, (byte) 7);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       cbaos.writeTo(baos);
-      assertEquals(7, baos.toByteArray()[0]);
+      assertThat(baos.toByteArray()).isEqualTo(bytes(7));
     }
 
     // test replace value in the first slab
@@ -227,77 +190,63 @@ public class TestCapacityByteArrayOutputStream {
       cbaos.write(13);
       cbaos.write(15);
       cbaos.write(17);
-      assertEquals(3, cbaos.getCurrentIndex());
+      assertThat(cbaos.getCurrentIndex()).isEqualTo(3);
       cbaos.write(19);
       cbaos.setByte(3, (byte) 7);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       cbaos.writeTo(baos);
-      assertArrayEquals(new byte[] {10, 13, 15, 7, 19}, baos.toByteArray());
+      assertThat(baos.toByteArray()).isEqualTo(bytes(10, 13, 15, 7, 19));
     }
 
     // test replace in *not* the first slab
     try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
-
-      // advance part way through the 3rd slab
-      for (int i = 0; i < 12; i++) {
-        cbaos.write(100 + i);
-      }
-      assertEquals(11, cbaos.getCurrentIndex());
+      writeRange(cbaos, 100, 12);
+      assertThat(cbaos.getCurrentIndex()).isEqualTo(11);
 
       cbaos.setByte(6, (byte) 7);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       cbaos.writeTo(baos);
-      assertArrayEquals(
-          new byte[] {100, 101, 102, 103, 104, 105, 7, 107, 108, 109, 110, 111}, baos.toByteArray());
+      assertThat(baos.toByteArray()).isEqualTo(bytes(100, 101, 102, 103, 104, 105, 7, 107, 108, 109, 110, 111));
     }
 
     // test replace last value of a slab
     try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
-
-      // advance part way through the 3rd slab
-      for (int i = 0; i < 12; i++) {
-        cbaos.write(100 + i);
-      }
-      assertEquals(11, cbaos.getCurrentIndex());
+      writeRange(cbaos, 100, 12);
+      assertThat(cbaos.getCurrentIndex()).isEqualTo(11);
 
       cbaos.setByte(9, (byte) 7);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       cbaos.writeTo(baos);
-      assertArrayEquals(
-          new byte[] {100, 101, 102, 103, 104, 105, 106, 107, 108, 7, 110, 111}, baos.toByteArray());
+      assertThat(baos.toByteArray()).isEqualTo(bytes(100, 101, 102, 103, 104, 105, 106, 107, 108, 7, 110, 111));
     }
 
     // test replace last value
     try (CapacityByteArrayOutputStream cbaos = newCapacityBAOS(5)) {
-
-      // advance part way through the 3rd slab
-      for (int i = 0; i < 12; i++) {
-        cbaos.write(100 + i);
-      }
-      assertEquals(11, cbaos.getCurrentIndex());
+      writeRange(cbaos, 100, 12);
+      assertThat(cbaos.getCurrentIndex()).isEqualTo(11);
 
       cbaos.setByte(11, (byte) 7);
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
       cbaos.writeTo(baos);
-      assertArrayEquals(
-          new byte[] {100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 7}, baos.toByteArray());
+      assertThat(baos.toByteArray()).isEqualTo(bytes(100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 7));
     }
   }
 
   private void writeArraysOf3(CapacityByteArrayOutputStream capacityByteArrayOutputStream, int n) throws IOException {
     for (int i = 0; i < n; i++) {
-      byte[] toWrite = {(byte) (i * 3), (byte) (i * 3 + 1), (byte) (i * 3 + 2)};
-      capacityByteArrayOutputStream.write(toWrite);
-      assertEquals((i + 1) * 3, capacityByteArrayOutputStream.size());
+      capacityByteArrayOutputStream.write(bytes(i * 3, i * 3 + 1, i * 3 + 2));
+      assertThat(capacityByteArrayOutputStream.size()).isEqualTo((i + 1) * 3);
     }
   }
 
   private void validate(CapacityByteArrayOutputStream capacityByteArrayOutputStream, final int expectedSize)
       throws IOException {
-    final byte[] byteArray = BytesInput.from(capacityByteArrayOutputStream).toByteArray();
-    assertEquals(expectedSize, byteArray.length);
-    for (int i = 0; i < expectedSize; i++) {
-      assertEquals(i, byteArray[i]);
+    assertThat(BytesInput.from(capacityByteArrayOutputStream).toByteArray()).isEqualTo(byteRange(0, expectedSize));
+  }
+
+  private static void writeRange(CapacityByteArrayOutputStream stream, int start, int count) {
+    for (int i = 0; i < count; i++) {
+      stream.write(start + i);
     }
   }
 
@@ -331,11 +280,11 @@ public class TestCapacityByteArrayOutputStream {
       for (int v : values) {
         cbaos.writeInt(v);
       }
-      assertEquals(values.length * 4, cbaos.size());
+      assertThat(cbaos.size()).isEqualTo(values.length * 4);
 
       byte[] bytes = BytesInput.from(cbaos).toByteArray();
       for (int i = 0; i < values.length; i++) {
-        assertEquals("value at index " + i, values[i], readIntLE(bytes, i * 4));
+        assertThat(readIntLE(bytes, i * 4)).as("value at index " + i).isEqualTo(values[i]);
       }
     }
   }
@@ -347,12 +296,40 @@ public class TestCapacityByteArrayOutputStream {
       for (long v : values) {
         cbaos.writeLong(v);
       }
-      assertEquals(values.length * 8, cbaos.size());
+      assertThat(cbaos.size()).isEqualTo(values.length * 8);
 
       byte[] bytes = BytesInput.from(cbaos).toByteArray();
       for (int i = 0; i < values.length; i++) {
-        assertEquals("value at index " + i, values[i], readLongLE(bytes, i * 8));
+        assertThat(readLongLE(bytes, i * 8)).as("value at index " + i).isEqualTo(values[i]);
       }
     }
+  }
+
+  private static byte[] bytes(int... values) {
+    byte[] result = new byte[values.length];
+    for (int i = 0; i < values.length; i++) {
+      result[i] = (byte) values[i];
+    }
+    return result;
+  }
+
+  private static byte[] byteRange(int start, int length) {
+    return bytes(range(start, start + length));
+  }
+
+  private static byte[] repeatedByteRange(int start, int period, int totalLength) {
+    int[] values = new int[totalLength];
+    for (int i = 0; i < totalLength; i++) {
+      values[i] = start + (i % period);
+    }
+    return bytes(values);
+  }
+
+  private static int[] range(int startInclusive, int endExclusive) {
+    int[] values = new int[endExclusive - startInclusive];
+    for (int i = 0; i < values.length; i++) {
+      values[i] = startInclusive + i;
+    }
+    return values;
   }
 }

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestBitPacking.java
@@ -18,14 +18,13 @@
  */
 package org.apache.parquet.column.values.bitpacking;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingReader;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingWriter;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -165,7 +164,7 @@ public class TestBitPacking {
     byte[] bytes = baos.toByteArray();
     LOG.debug("vals (" + bitLength + "): " + toString(vals));
     LOG.debug("bytes: {}", toString(bytes));
-    Assert.assertEquals(expected, toString(bytes));
+    assertThat(toString(bytes)).isEqualTo(expected);
     ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
     BitPackingReader r = BitPacking.createBitPackingReader(bitLength, bais, vals.length);
     int[] result = new int[vals.length];
@@ -173,7 +172,7 @@ public class TestBitPacking {
       result[i] = r.read();
     }
     LOG.debug("result: {}", toString(result));
-    assertArrayEquals(vals, result);
+    assertThat(result).containsExactly(vals);
   }
 
   public static String toString(int[] vals) {

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBasedBitPackingEncoder.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBasedBitPackingEncoder.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.column.values.bitpacking;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.parquet.bytes.BytesUtils;
 import org.junit.Test;
@@ -38,8 +38,8 @@ public class TestByteBasedBitPackingEncoder {
           throw new RuntimeException(i + ": error writing " + j, e);
         }
       }
-      assertEquals(BytesUtils.paddedByteCountFromBits(totalValues * i), encoder.getBufferSize());
-      assertEquals(i == 0 ? 1 : 9, encoder.getNumSlabs());
+      assertThat(encoder.getBufferSize()).isEqualTo(BytesUtils.paddedByteCountFromBits(totalValues * i));
+      assertThat(encoder.getNumSlabs()).isEqualTo(i == 0 ? 1 : 9);
     }
   }
 }

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.column.values.bitpacking;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -25,7 +27,6 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingReader;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingWriter;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +44,7 @@ public class TestByteBitPacking {
       int[] values = generateValues(i);
       packUnpack(Packer.BIG_ENDIAN.newBytePacker(i), values, unpacked);
       LOG.debug("Output: {}", TestBitPacking.toString(unpacked));
-      Assert.assertArrayEquals("width " + i, values, unpacked);
+      assertThat(unpacked).as("width " + i).containsExactly(values);
     }
   }
 
@@ -58,10 +59,10 @@ public class TestByteBitPacking {
       long[] values = generateValuesLong(i);
       packUnpack32(Packer.BIG_ENDIAN.newBytePackerForLong(i), values, unpacked32);
       LOG.debug("Output 32: {}", TestBitPacking.toString(unpacked32));
-      Assert.assertArrayEquals("width " + i, values, unpacked32);
+      assertThat(unpacked32).as("width " + i).containsExactly(values);
       packUnpack8(Packer.BIG_ENDIAN.newBytePackerForLong(i), values, unpacked8);
       LOG.debug("Output 8: {}", TestBitPacking.toString(unpacked8));
-      Assert.assertArrayEquals("width " + i, values, unpacked8);
+      assertThat(unpacked8).as("width " + i).containsExactly(values);
     }
   }
 
@@ -141,7 +142,7 @@ public class TestByteBitPacking {
       }
 
       LOG.debug("Output: {}", TestBitPacking.toString(unpacked));
-      Assert.assertArrayEquals("width " + i, values, unpacked);
+      assertThat(unpacked).as("width " + i).containsExactly(values);
     }
   }
 
@@ -185,15 +186,14 @@ public class TestByteBitPacking {
         byte[] packedGenerated = new byte[i * 4];
         bytePacker.pack32Values(values, 0, packedGenerated, 0);
         LOG.debug("Gener. out: {}", TestBitPacking.toString(packedGenerated));
-        Assert.assertEquals(
-            pack.name() + " width " + i,
-            TestBitPacking.toString(packedByLemireAsBytes),
-            TestBitPacking.toString(packedGenerated));
+        assertThat(TestBitPacking.toString(packedGenerated))
+            .as(pack.name() + " width " + i)
+            .isEqualTo(TestBitPacking.toString(packedByLemireAsBytes));
 
         bytePacker.unpack32Values(ByteBuffer.wrap(packedByLemireAsBytes), 0, unpacked, 0);
         LOG.debug("Output: {}", TestBitPacking.toString(unpacked));
 
-        Assert.assertArrayEquals("width " + i, values, unpacked);
+        assertThat(unpacked).as("width " + i).containsExactly(values);
       }
     }
   }

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestLemireBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestLemireBitPacking.java
@@ -18,13 +18,14 @@
  */
 package org.apache.parquet.column.values.bitpacking;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingReader;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingWriter;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,12 +45,12 @@ public class TestLemireBitPacking {
         {
           packUnpack(packer.newIntPacker(i), values, unpacked);
           LOG.debug("int based Output " + packer.name() + ": " + TestBitPacking.toString(unpacked));
-          Assert.assertArrayEquals(packer.name() + " width " + i, values, unpacked);
+          assertThat(unpacked).as(packer.name() + " width " + i).containsExactly(values);
         }
         {
           packUnpack(packer.newBytePacker(i), values, unpacked);
           LOG.debug("byte based Output " + packer.name() + ": " + TestBitPacking.toString(unpacked));
-          Assert.assertArrayEquals(packer.name() + " width " + i, values, unpacked);
+          assertThat(unpacked).as(packer.name() + " width " + i).containsExactly(values);
         }
       }
     }
@@ -117,7 +118,7 @@ public class TestLemireBitPacking {
       }
 
       LOG.debug("Output: {}", TestBitPacking.toString(unpacked));
-      Assert.assertArrayEquals("width " + i, values, unpacked);
+      assertThat(unpacked).as("width " + i).containsExactly(values);
     }
   }
 }

--- a/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
+++ b/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
@@ -19,12 +19,10 @@
 package org.apache.parquet.format;
 
 import static java.util.Arrays.asList;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNull;
 import static org.apache.parquet.format.Util.readFileMetaData;
 import static org.apache.parquet.format.Util.writeFileMetaData;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -52,17 +50,13 @@ public class TestUtil {
     readFileMetaData(in(baos), new DefaultFileMetaDataConsumer(md4), true);
     FileMetaData md5 = readFileMetaData(in(baos), true);
     FileMetaData md6 = readFileMetaData(in(baos), false);
-    assertEquals(md, md2);
-    assertEquals(md, md3);
-    assertNull(md4.getRow_groups());
-    assertNull(md5.getRow_groups());
-    assertEquals(md4, md5);
+    assertThat(md2).isEqualTo(md3).isEqualTo(md);
+    assertThat(md4.getRow_groups()).isNull();
+    assertThat(md5.getRow_groups()).isNull();
+    assertThat(md4).isEqualTo(md5);
     md4.setRow_groups(md.getRow_groups());
     md5.setRow_groups(md.getRow_groups());
-    assertEquals(md, md4);
-    assertEquals(md, md5);
-    assertEquals(md4, md5);
-    assertEquals(md, md6);
+    assertThat(md4).isEqualTo(md5).isEqualTo(md6).isEqualTo(md);
   }
 
   @Test
@@ -71,14 +65,9 @@ public class TestUtil {
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     Util.writePageHeader(ph, out);
 
-    try {
-      Util.readPageHeader(in(out));
-      fail("Expected exception but did not thrown");
-    } catch (InvalidParquetMetadataException e) {
-      assertTrue(
-          "Exception message does not contain the expected parts",
-          e.getMessage().contains("Compressed page size"));
-    }
+    assertThatThrownBy(() -> Util.readPageHeader(in(out)))
+        .isInstanceOf(InvalidParquetMetadataException.class)
+        .hasMessageContaining("Compressed page size");
   }
 
   private ByteArrayInputStream in(ByteArrayOutputStream baos) {

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestArrayCompatibility.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestArrayCompatibility.java
@@ -18,8 +18,8 @@
  */
 package org.apache.parquet.hadoop.thrift;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -40,7 +40,6 @@ import org.apache.parquet.thrift.test.compat.ListOfSingleElementGroups;
 import org.apache.parquet.thrift.test.compat.Location;
 import org.apache.parquet.thrift.test.compat.SingleElementGroup;
 import org.apache.thrift.TBase;
-import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -135,7 +134,7 @@ public class TestArrayCompatibility extends DirectWriterTest {
 
     ListOfInts expected = new ListOfInts(Lists.newArrayList(34, 35, 36));
     ListOfInts actual = reader(test, ListOfInts.class).read();
-    Assert.assertEquals("Should read record correctly", expected, actual);
+    assertThat(actual).as("Should read record correctly").isEqualTo(expected);
   }
 
   @Test
@@ -320,13 +319,11 @@ public class TestArrayCompatibility extends DirectWriterTest {
     // expected.addToLocations(null);
     expected.addToLocations(new Location(0.0, 180.0));
 
-    try {
-      assertReaderContains(reader(test, ListOfLocations.class), expected);
-      fail("Should fail: locations are optional and not ignored");
-    } catch (RuntimeException e) {
-      // e is a RuntimeException wrapping the decoding exception
-      assertTrue(e.getCause().getCause().getMessage().contains("locations"));
-    }
+    assertThatThrownBy(() -> assertReaderContains(reader(test, ListOfLocations.class), expected))
+        .isInstanceOf(RuntimeException.class)
+        .cause()
+        .cause()
+        .hasMessageContaining("locations");
 
     assertReaderContains(readerIgnoreNulls(test, ListOfLocations.class), expected);
   }
@@ -722,13 +719,11 @@ public class TestArrayCompatibility extends DirectWriterTest {
     expected.addToLocations(new Location(0.0, 180.0));
     expected.addToLocations(new Location(0.0, 0.0));
 
-    try {
-      assertReaderContains(reader(test, ListOfLocations.class), expected);
-      fail("Should fail: locations are optional and not ignored");
-    } catch (RuntimeException e) {
-      // e is a RuntimeException wrapping the decoding exception
-      assertTrue(e.getCause().getCause().getMessage().contains("locations"));
-    }
+    assertThatThrownBy(() -> assertReaderContains(reader(test, ListOfLocations.class), expected))
+        .isInstanceOf(RuntimeException.class)
+        .cause()
+        .cause()
+        .hasMessageContaining("locations");
 
     assertReaderContains(readerIgnoreNulls(test, ListOfLocations.class), expected);
   }
@@ -753,6 +748,6 @@ public class TestArrayCompatibility extends DirectWriterTest {
     while ((record = reader.read()) != null) {
       actual.add(record);
     }
-    Assert.assertEquals("Should match exepected records", Lists.newArrayList(expected), actual);
+    assertThat(actual).as("Should match expected records").containsExactly(expected);
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestBinary.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestBinary.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.hadoop.thrift;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -68,19 +68,20 @@ public class TestBinary {
     reader.close();
 
     assertSchema(ParquetFileReader.readFooter(new Configuration(), path));
-    assertEquals("Should match after serialization round trip", expected, record);
+    assertThat(record).as("Should match after serialization round trip").isEqualTo(expected);
   }
 
   private void assertSchema(ParquetMetadata parquetMetadata) {
     List<Type> fields = parquetMetadata.getFileMetaData().getSchema().getFields();
-    assertEquals(2, fields.size());
-    assertEquals(
-        Types.required(PrimitiveType.PrimitiveTypeName.BINARY)
+    assertThat(fields).hasSize(2);
+    assertThat(fields.get(0))
+        .isEqualTo(Types.required(PrimitiveType.PrimitiveTypeName.BINARY)
             .as(OriginalType.UTF8)
             .id(1)
-            .named("s"),
-        fields.get(0));
-    assertEquals(
-        Types.required(PrimitiveType.PrimitiveTypeName.BINARY).id(2).named("b"), fields.get(1));
+            .named("s"));
+    assertThat(fields.get(1))
+        .isEqualTo(Types.required(PrimitiveType.PrimitiveTypeName.BINARY)
+            .id(2)
+            .named("b"));
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestCorruptThriftRecords.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestCorruptThriftRecords.java
@@ -19,8 +19,8 @@
 package org.apache.parquet.hadoop.thrift;
 
 import static org.apache.parquet.hadoop.thrift.TestInputOutputFormat.waitForJob;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,7 +55,7 @@ public class TestCorruptThriftRecords {
     public static List<Object> records;
 
     @Override
-    protected void setup(Context context) throws IOException, InterruptedException {
+    protected void setup(Context context) {
       records = new ArrayList<Object>();
     }
 
@@ -119,10 +119,6 @@ public class TestCorruptThriftRecords {
     job.setOutputFormatClass(NullOutputFormat.class);
   }
 
-  protected void assertEqualsExcepted(List<StructWithUnionV2> expected, List<Object> found) throws Exception {
-    assertEquals(expected, found);
-  }
-
   private Path writeFileWithCorruptRecords(int numCorrupt, List<StructWithUnionV2> collectExpectedRecords)
       throws Exception {
     // generate a file with records that are corrupt according to thrift
@@ -167,16 +163,14 @@ public class TestCorruptThriftRecords {
   }
 
   @Test
-  public void testDefaultsToNoTolerance() throws Exception {
+  public void testDefaultsToNoTolerance() {
     ArrayList<StructWithUnionV2> expected = new ArrayList<StructWithUnionV2>();
-    try {
-      readFile(writeFileWithCorruptRecords(1, expected), new Configuration(), "testDefaultsToNoTolerance");
-      fail("This should throw");
-    } catch (RuntimeException e) {
-      // still should have actually read all the valid records
-      assertEquals(100, ReadMapper.records.size());
-      assertEqualsExcepted(expected.subList(0, 100), ReadMapper.records);
-    }
+    assertThatThrownBy(() -> readFile(
+            writeFileWithCorruptRecords(1, expected), new Configuration(), "testDefaultsToNoTolerance"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("job failed testDefaultsToNoTolerance");
+    // still should have actually read all the valid records
+    assertThat(ReadMapper.records).hasSize(100).isEqualTo(expected.subList(0, 100));
   }
 
   @Test
@@ -187,24 +181,21 @@ public class TestCorruptThriftRecords {
     List<StructWithUnionV2> expected = new ArrayList<StructWithUnionV2>();
 
     readFile(writeFileWithCorruptRecords(4, expected), conf, "testCanTolerateBadRecords");
-    assertEquals(200, ReadMapper.records.size());
-    assertEqualsExcepted(expected, ReadMapper.records);
+    assertThat(ReadMapper.records).hasSize(200).isEqualTo(expected);
   }
 
   @Test
-  public void testThrowsWhenTooManyBadRecords() throws Exception {
+  public void testThrowsWhenTooManyBadRecords() {
     Configuration conf = new Configuration();
     conf.setFloat(UnmaterializableRecordCounter.BAD_RECORD_THRESHOLD_CONF_KEY, 0.1f);
 
     ArrayList<StructWithUnionV2> expected = new ArrayList<StructWithUnionV2>();
 
-    try {
-      readFile(writeFileWithCorruptRecords(300, expected), conf, "testThrowsWhenTooManyBadRecords");
-      fail("This should throw");
-    } catch (RuntimeException e) {
-      // still should have actually read all the valid records
-      assertEquals(100, ReadMapper.records.size());
-      assertEqualsExcepted(expected.subList(0, 100), ReadMapper.records);
-    }
+    assertThatThrownBy(() ->
+            readFile(writeFileWithCorruptRecords(300, expected), conf, "testThrowsWhenTooManyBadRecords"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("job failed testThrowsWhenTooManyBadRecords");
+    // still should have actually read all the valid records
+    assertThat(ReadMapper.records).hasSize(100).isEqualTo(expected.subList(0, 100));
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestInputOutputFormat.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestInputOutputFormat.java
@@ -19,8 +19,7 @@
 package org.apache.parquet.hadoop.thrift;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.twitter.data.proto.tutorial.thrift.AddressBook;
 import com.twitter.data.proto.tutorial.thrift.Name;
@@ -48,7 +47,6 @@ import org.apache.parquet.thrift.test.compat.StructV1;
 import org.apache.parquet.thrift.test.compat.StructV2;
 import org.apache.parquet.thrift.test.compat.StructV3;
 import org.apache.thrift.TBase;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -135,10 +133,10 @@ public class TestInputOutputFormat {
     while ((lineOut = out.readLine()) != null) {
       lineOut = lineOut.substring(lineOut.indexOf("\t") + 1);
       AddressBook a = nextAddressbook(lineNumber);
-      assertEquals("line " + lineNumber, a.toString(), lineOut);
+      assertThat(lineOut).as("line " + lineNumber).isEqualTo(a.toString());
       ++lineNumber;
     }
-    assertNull("line " + lineNumber, out.readLine());
+    assertThat(out.readLine()).as("line " + lineNumber).isNull();
     out.close();
   }
 
@@ -253,7 +251,7 @@ public class TestInputOutputFormat {
       ++lineNumber;
     }
     out.close();
-    Assert.assertEquals(expected, lineNumber);
+    assertThat(lineNumber).isEqualTo(expected);
   }
 
   private void write(

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestParquetToThriftReadWriteAndProjection.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestParquetToThriftReadWriteAndProjection.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.hadoop.thrift;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.twitter.data.proto.tutorial.thrift.AddressBook;
 import com.twitter.data.proto.tutorial.thrift.Name;
@@ -378,6 +378,6 @@ public class TestParquetToThriftReadWriteAndProjection {
         }
       }
     }
-    assertEquals(exptectedReadResult, readValue);
+    assertThat(readValue).isEqualTo(exptectedReadResult);
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestThriftToParquetFileWriter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestThriftToParquetFileWriter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.hadoop.thrift;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.twitter.data.proto.tutorial.thrift.AddressBook;
 import com.twitter.data.proto.tutorial.thrift.Name;
@@ -85,14 +85,13 @@ public class TestThriftToParquetFileWriter {
     Group g = null;
     int i = 0;
     while ((g = reader.read()) != null) {
-      assertEquals(a.persons.size(), g.getFieldRepetitionCount("persons"));
-      assertEquals(
-          a.persons.get(0).email,
-          g.getGroup("persons", 0).getGroup(0, 0).getString("email", 0));
+      assertThat(g.getFieldRepetitionCount("persons")).isEqualTo(a.persons.size());
+      assertThat(g.getGroup("persons", 0).getGroup(0, 0).getString("email", 0))
+          .isEqualTo(a.persons.get(0).email);
       // just some sanity check, we're testing the various layers somewhere else
       ++i;
     }
-    assertEquals("read 1 record", 1, i);
+    assertThat(i).as("read 1 record").isEqualTo(1);
   }
 
   @Test
@@ -223,13 +222,12 @@ public class TestThriftToParquetFileWriter {
 
     Group g = null;
     while ((g = reader.read()) != null) {
-      assertEquals(listMap.names.size(), g.getGroup("names", 0).getFieldRepetitionCount("names_tuple"));
-      assertEquals(
-          listMap.names.get(0).size(),
-          g.getGroup("names", 0).getGroup("names_tuple", 0).getFieldRepetitionCount("key_value"));
-      assertEquals(
-          listMap.names.get(1).size(),
-          g.getGroup("names", 0).getGroup("names_tuple", 1).getFieldRepetitionCount("key_value"));
+      assertThat(g.getGroup("names", 0).getFieldRepetitionCount("names_tuple"))
+          .isEqualTo(listMap.names.size());
+      assertThat(g.getGroup("names", 0).getGroup("names_tuple", 0).getFieldRepetitionCount("key_value"))
+          .isEqualTo(listMap.names.get(0).size());
+      assertThat(g.getGroup("names", 0).getGroup("names_tuple", 1).getFieldRepetitionCount("key_value"))
+          .isEqualTo(listMap.names.get(1).size());
     }
   }
 
@@ -244,18 +242,16 @@ public class TestThriftToParquetFileWriter {
 
     Group g = null;
     while ((g = reader.read()) != null) {
-      assertEquals(
-          "key",
-          g.getGroup("names", 0)
+      assertThat(g.getGroup("names", 0)
               .getGroup("key_value", 0)
               .getBinary("key", 0)
-              .toStringUsingUTF8());
-      assertEquals(
-          map.get("key").size(),
-          g.getGroup("names", 0)
+              .toStringUsingUTF8())
+          .isEqualTo("key");
+      assertThat(g.getGroup("names", 0)
               .getGroup("key_value", 0)
               .getGroup("value", 0)
-              .getFieldRepetitionCount(0));
+              .getFieldRepetitionCount(0))
+          .isEqualTo(map.get("key").size());
     }
   }
 
@@ -270,34 +266,30 @@ public class TestThriftToParquetFileWriter {
 
     Group g = null;
     while ((g = reader.read()) != null) {
-      assertEquals(
-          "key1",
-          g.getGroup("names", 0)
+      assertThat(g.getGroup("names", 0)
               .getGroup("key_value", 0)
               .getGroup("key", 0)
               .getBinary("key_tuple", 0)
-              .toStringUsingUTF8());
-      assertEquals(
-          "key2",
-          g.getGroup("names", 0)
+              .toStringUsingUTF8())
+          .isEqualTo("key1");
+      assertThat(g.getGroup("names", 0)
               .getGroup("key_value", 0)
               .getGroup("key", 0)
               .getBinary("key_tuple", 1)
-              .toStringUsingUTF8());
-      assertEquals(
-          "val1",
-          g.getGroup("names", 0)
+              .toStringUsingUTF8())
+          .isEqualTo("key2");
+      assertThat(g.getGroup("names", 0)
               .getGroup("key_value", 0)
               .getGroup("value", 0)
               .getBinary("value_tuple", 0)
-              .toStringUsingUTF8());
-      assertEquals(
-          "val2",
-          g.getGroup("names", 0)
+              .toStringUsingUTF8())
+          .isEqualTo("val1");
+      assertThat(g.getGroup("names", 0)
               .getGroup("key_value", 0)
               .getGroup("value", 0)
               .getBinary("value_tuple", 1)
-              .toStringUsingUTF8());
+              .toStringUsingUTF8())
+          .isEqualTo("val2");
     }
   }
 
@@ -319,14 +311,13 @@ public class TestThriftToParquetFileWriter {
     Group g = null;
     int i = 0;
     while ((g = reader.read()) != null) {
-      assertEquals(a.persons.size(), g.getFieldRepetitionCount("persons"));
-      assertEquals(
-          a.persons.get(0).email,
-          g.getGroup("persons", 0).getGroup(0, 0).getGroup(0, 0).getString("email", 0));
+      assertThat(g.getFieldRepetitionCount("persons")).isEqualTo(a.persons.size());
+      assertThat(g.getGroup("persons", 0).getGroup(0, 0).getGroup(0, 0).getString("email", 0))
+          .isEqualTo(a.persons.get(0).email);
       // just some sanity check, we're testing the various layers somewhere else
       ++i;
     }
-    assertEquals("read 1 record", 1, i);
+    assertThat(i).as("read 1 record").isEqualTo(1);
   }
 
   @Test
@@ -347,19 +338,17 @@ public class TestThriftToParquetFileWriter {
 
     Group g = null;
     while ((g = reader.read()) != null) {
-      assertEquals(listMap.names.size(), g.getGroup("names", 0).getFieldRepetitionCount("list"));
-      assertEquals(
-          listMap.names.get(0).size(),
-          g.getGroup("names", 0)
+      assertThat(g.getGroup("names", 0).getFieldRepetitionCount("list")).isEqualTo(listMap.names.size());
+      assertThat(g.getGroup("names", 0)
               .getGroup("list", 0)
               .getGroup("element", 0)
-              .getFieldRepetitionCount("key_value"));
-      assertEquals(
-          listMap.names.get(1).size(),
-          g.getGroup("names", 0)
+              .getFieldRepetitionCount("key_value"))
+          .isEqualTo(listMap.names.get(0).size());
+      assertThat(g.getGroup("names", 0)
               .getGroup("list", 1)
               .getGroup("element", 0)
-              .getFieldRepetitionCount("key_value"));
+              .getFieldRepetitionCount("key_value"))
+          .isEqualTo(listMap.names.get(1).size());
     }
   }
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetReadProtocol.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetReadProtocol.java
@@ -19,7 +19,7 @@
 package org.apache.parquet.thrift;
 
 import static com.twitter.data.proto.tutorial.thrift.PhoneType.MOBILE;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.twitter.data.proto.tutorial.thrift.AddressBook;
 import com.twitter.data.proto.tutorial.thrift.Name;
@@ -169,6 +169,6 @@ public class TestParquetReadProtocol {
 
     final T result = recordReader.read();
 
-    assertEquals(expected, result);
+    assertThat(result).isEqualTo(expected);
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestProtocolReadToWrite.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestProtocolReadToWrite.java
@@ -18,9 +18,8 @@
  */
 package org.apache.parquet.thrift;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.twitter.data.proto.tutorial.thrift.AddressBook;
 import com.twitter.data.proto.tutorial.thrift.Name;
@@ -138,7 +137,7 @@ public class TestProtocolReadToWrite {
       TBase<?, ?> b = a.getClass().newInstance();
       b.read(protocol(new ByteArrayInputStream(out.toByteArray())));
 
-      assertEquals(p.getClass().getSimpleName(), a, b);
+      assertThat(b).as(p.getClass().getSimpleName()).isEqualTo(a);
     }
   }
 
@@ -168,17 +167,15 @@ public class TestProtocolReadToWrite {
         new ArrayList<Short>(),
         new ArrayList<Long>());
     a.write(protocol(in));
-    try {
-      p.readOne(protocol(new ByteArrayInputStream(in.toByteArray())), protocol(out));
-      fail("this should throw");
-    } catch (SkippableException e) {
-      Throwable cause = e.getCause();
-      assertTrue(cause instanceof DecodingSchemaMismatchException);
-      assertTrue(cause.getMessage().contains("the data type does not match the expected thrift structure"));
-      assertTrue(cause.getMessage().contains("got BOOL"));
-    }
-    assertEquals(0, countingHandler.recordCountOfMissingFields);
-    assertEquals(0, countingHandler.fieldIgnoredCount);
+    assertThatThrownBy(() -> p.readOne(protocol(new ByteArrayInputStream(in.toByteArray())), protocol(out)))
+        .isInstanceOf(SkippableException.class)
+        .hasMessageContaining("Error while reading")
+        .cause()
+        .isInstanceOf(DecodingSchemaMismatchException.class)
+        .hasMessageContaining("the data type does not match the expected thrift structure")
+        .hasMessageContaining("got BOOL");
+    assertThat(countingHandler.recordCountOfMissingFields).isZero();
+    assertThat(countingHandler.fieldIgnoredCount).isZero();
   }
 
   @Test
@@ -200,16 +197,14 @@ public class TestProtocolReadToWrite {
     // first one should not throw
     p.readOne(protocol(baos), protocol(out));
 
-    try {
-      p.readOne(protocol(baos), protocol(out));
-      fail("this should throw");
-    } catch (SkippableException e) {
-      Throwable cause = e.getCause();
-      assertEquals(DecodingSchemaMismatchException.class, cause.getClass());
-      assertTrue(cause.getMessage().startsWith("Unrecognized union member with id: 3 for struct:"));
-    }
-    assertEquals(0, countingHandler.recordCountOfMissingFields);
-    assertEquals(0, countingHandler.fieldIgnoredCount);
+    assertThatThrownBy(() -> p.readOne(protocol(baos), protocol(out)))
+        .isInstanceOf(SkippableException.class)
+        .hasMessageContaining("Error while reading")
+        .cause()
+        .isInstanceOf(DecodingSchemaMismatchException.class)
+        .hasMessageStartingWith("Unrecognized union member with id: 3 for struct:");
+    assertThat(countingHandler.recordCountOfMissingFields).isZero();
+    assertThat(countingHandler.fieldIgnoredCount).isZero();
   }
 
   @Test
@@ -240,16 +235,15 @@ public class TestProtocolReadToWrite {
     // first one should not throw
     p.readOne(protocol(baos), protocol(out));
 
-    try {
-      p.readOne(protocol(baos), protocol(out));
-      fail("this should throw");
-    } catch (SkippableException e) {
-      Throwable cause = e.getCause();
-      assertEquals(DecodingSchemaMismatchException.class, cause.getClass());
-      assertTrue(cause.getMessage().startsWith("Cannot write a TUnion with no set value in"));
-    }
-    assertEquals(0, countingHandler.recordCountOfMissingFields);
-    assertEquals(0, countingHandler.fieldIgnoredCount);
+    final ByteArrayInputStream inputForMissingUnionRead = baos;
+    assertThatThrownBy(() -> p.readOne(protocol(inputForMissingUnionRead), protocol(out)))
+        .isInstanceOf(SkippableException.class)
+        .hasMessageContaining("Error while reading")
+        .cause()
+        .isInstanceOf(DecodingSchemaMismatchException.class)
+        .hasMessageStartingWith("Cannot write a TUnion with no set value in");
+    assertThat(countingHandler.recordCountOfMissingFields).isZero();
+    assertThat(countingHandler.fieldIgnoredCount).isZero();
 
     in = new ByteArrayOutputStream();
     validUnion.write(protocol(in));
@@ -260,16 +254,15 @@ public class TestProtocolReadToWrite {
     // first one should not throw
     p.readOne(protocol(baos), protocol(out));
 
-    try {
-      p.readOne(protocol(baos), protocol(out));
-      fail("this should throw");
-    } catch (SkippableException e) {
-      Throwable cause = e.getCause();
-      assertEquals(DecodingSchemaMismatchException.class, cause.getClass());
-      assertTrue(cause.getMessage().startsWith("Cannot write a TUnion with more than 1 set value in"));
-    }
-    assertEquals(0, countingHandler.recordCountOfMissingFields);
-    assertEquals(0, countingHandler.fieldIgnoredCount);
+    final ByteArrayInputStream inputForExtraUnionRead = baos;
+    assertThatThrownBy(() -> p.readOne(protocol(inputForExtraUnionRead), protocol(out)))
+        .isInstanceOf(SkippableException.class)
+        .hasMessageContaining("Error while reading")
+        .cause()
+        .isInstanceOf(DecodingSchemaMismatchException.class)
+        .hasMessageStartingWith("Cannot write a TUnion with more than 1 set value in");
+    assertThat(countingHandler.recordCountOfMissingFields).isZero();
+    assertThat(countingHandler.fieldIgnoredCount).isZero();
   }
 
   @Test
@@ -294,8 +287,8 @@ public class TestProtocolReadToWrite {
     p.readOne(protocol(baos), protocol(out));
     p.readOne(protocol(baos), protocol(out));
 
-    assertEquals(1, countingHandler.recordCountOfMissingFields);
-    assertEquals(1, countingHandler.fieldIgnoredCount);
+    assertThat(countingHandler.recordCountOfMissingFields).isEqualTo(1);
+    assertThat(countingHandler.fieldIgnoredCount).isEqualTo(1);
 
     in = new ByteArrayOutputStream();
     validUnion.write(protocol(in));
@@ -307,8 +300,8 @@ public class TestProtocolReadToWrite {
     p.readOne(protocol(baos), protocol(out));
     p.readOne(protocol(baos), protocol(out));
 
-    assertEquals(2, countingHandler.recordCountOfMissingFields);
-    assertEquals(2, countingHandler.fieldIgnoredCount);
+    assertThat(countingHandler.recordCountOfMissingFields).isEqualTo(2);
+    assertThat(countingHandler.fieldIgnoredCount).isEqualTo(2);
   }
 
   /**
@@ -333,16 +326,14 @@ public class TestProtocolReadToWrite {
     // first should not throw
     p.readOne(protocol(baos), protocol(out));
 
-    try {
-      p.readOne(protocol(baos), protocol(out));
-      fail("this should throw");
-    } catch (SkippableException e) {
-      Throwable cause = e.getCause();
-      assertEquals(DecodingSchemaMismatchException.class, cause.getClass());
-      assertTrue(cause.getMessage().contains("can not find index 4 in enum"));
-    }
-    assertEquals(0, countingHandler.recordCountOfMissingFields);
-    assertEquals(0, countingHandler.fieldIgnoredCount);
+    assertThatThrownBy(() -> p.readOne(protocol(baos), protocol(out)))
+        .isInstanceOf(SkippableException.class)
+        .hasMessageContaining("Error while reading")
+        .cause()
+        .isInstanceOf(DecodingSchemaMismatchException.class)
+        .hasMessageContaining("can not find index 4 in enum");
+    assertThat(countingHandler.recordCountOfMissingFields).isZero();
+    assertThat(countingHandler.fieldIgnoredCount).isZero();
   }
 
   /**
@@ -356,7 +347,7 @@ public class TestProtocolReadToWrite {
     CountingErrorHandler countingHandler = new CountingErrorHandler() {
       @Override
       public void handleFieldIgnored(TField field) {
-        assertEquals(field.id, 4);
+        assertThat(field.id).isEqualTo((short) 4);
         fieldIgnoredCount++;
       }
     };
@@ -378,15 +369,15 @@ public class TestProtocolReadToWrite {
     structForRead.readOne(protocol(new ByteArrayInputStream(in.toByteArray())), protocol(out));
 
     // record will be read without extra field
-    assertEquals(1, countingHandler.recordCountOfMissingFields);
-    assertEquals(1, countingHandler.fieldIgnoredCount);
+    assertThat(countingHandler.recordCountOfMissingFields).isEqualTo(1);
+    assertThat(countingHandler.fieldIgnoredCount).isEqualTo(1);
 
     StructV4WithExtracStructField b = StructV4WithExtracStructField.class.newInstance();
     b.read(protocol(new ByteArrayInputStream(out.toByteArray())));
-    assertEquals(dataWithNewSchema.getName(), b.getName());
-    assertEquals(dataWithNewSchema.getAge(), b.getAge());
-    assertEquals(dataWithNewSchema.getGender(), b.getGender());
-    assertEquals(null, b.getAddedStruct());
+    assertThat(b.getName()).isEqualTo(dataWithNewSchema.getName());
+    assertThat(b.getAge()).isEqualTo(dataWithNewSchema.getAge());
+    assertThat(b.getGender()).isEqualTo(dataWithNewSchema.getGender());
+    assertThat(b.getAddedStruct()).isNull();
   }
 
   @Test
@@ -394,7 +385,7 @@ public class TestProtocolReadToWrite {
     CountingErrorHandler countingHandler = new CountingErrorHandler() {
       @Override
       public void handleFieldIgnored(TField field) {
-        assertEquals(3, field.id);
+        assertThat(field.id).isEqualTo((short) 3);
         fieldIgnoredCount++;
       }
     };
@@ -412,8 +403,8 @@ public class TestProtocolReadToWrite {
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     structForRead.readOne(protocol(new ByteArrayInputStream(in.toByteArray())), protocol(out));
 
-    assertEquals(1, countingHandler.recordCountOfMissingFields);
-    assertEquals(1, countingHandler.fieldIgnoredCount);
+    assertThat(countingHandler.recordCountOfMissingFields).isEqualTo(1);
+    assertThat(countingHandler.fieldIgnoredCount).isEqualTo(1);
   }
 
   private TCompactProtocol protocol(OutputStream to) throws TTransportException {

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftMetaData.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftMetaData.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.thrift;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import org.apache.parquet.thrift.struct.ThriftField;
@@ -41,16 +41,19 @@ public class TestThriftMetaData {
 
     StructType descriptor = new StructType(new ArrayList<ThriftField>(), StructOrUnionType.STRUCT);
     ThriftMetaData tmd = new ThriftMetaData("non existent class!!!", descriptor);
-    assertEquals(
-        ("ThriftMetaData(thriftClassName: non existent class!!!, descriptor: {\n" + "  \"id\" : \"STRUCT\",\n"
+    assertThat(tmd)
+        .asString()
+        .isEqualTo(("ThriftMetaData(thriftClassName: non existent class!!!, descriptor: {\n"
+                + "  \"id\" : \"STRUCT\",\n"
                 + "  \"children\" : [ ],\n"
                 + "  \"structOrUnionType\" : \"STRUCT\",\n"
                 + "  \"logicalTypeAnnotation\" : null\n"
                 + "})")
-            .replace("\n", System.lineSeparator()),
-        tmd.toString());
+            .replace("\n", System.lineSeparator()));
 
     tmd = new ThriftMetaData("non existent class!!!", null);
-    assertEquals("ThriftMetaData(thriftClassName: non existent class!!!, descriptor: null)", tmd.toString());
+    assertThat(tmd)
+        .asString()
+        .isEqualTo("ThriftMetaData(thriftClassName: non existent class!!!, descriptor: null)");
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftParquetReaderWriter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftParquetReaderWriter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.thrift;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.twitter.data.proto.tutorial.thrift.AddressBook;
 import com.twitter.data.proto.tutorial.thrift.Name;
 import com.twitter.data.proto.tutorial.thrift.Person;
@@ -28,7 +30,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestThriftParquetReaderWriter {
@@ -66,14 +67,14 @@ public class TestThriftParquetReaderWriter {
       ThriftParquetReader<AddressBook> thriftParquetReader =
           new ThriftParquetReader<AddressBook>(f, AddressBook.class);
       AddressBook read = thriftParquetReader.read();
-      Assert.assertEquals(original, read);
+      assertThat(read).isEqualTo(original);
       thriftParquetReader.close();
     }
 
     { // read without providing a thrift class
       ThriftParquetReader<AddressBook> thriftParquetReader = new ThriftParquetReader<AddressBook>(f);
       AddressBook read = thriftParquetReader.read();
-      Assert.assertEquals(original, read);
+      assertThat(read).isEqualTo(original);
       thriftParquetReader.close();
     }
   }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftRecordConverter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftRecordConverter.java
@@ -18,8 +18,8 @@
  */
 package org.apache.parquet.thrift;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -52,30 +52,25 @@ public class TestThriftRecordConverter {
 
     conv.addBinary(Binary.fromString("hello"));
 
-    assertEquals(1, events.size());
-    assertEquals(77, events.get(0).readI32());
+    assertThat(events).hasSize(1);
+    assertThat(events.get(0).readI32()).isEqualTo(77);
 
-    try {
-      conv.addBinary(Binary.fromString("FAKE_ENUM_VALUE"));
-      fail("this should throw");
-    } catch (ParquetDecodingException e) {
-      assertEquals(
-          ("Unrecognized enum value: FAKE_ENUM_VALUE known values: {Binary{\"hello\"}=77} in {\n"
-                  + "  \"name\" : \"name\",\n"
-                  + "  \"fieldId\" : 1,\n"
-                  + "  \"requirement\" : \"REQUIRED\",\n"
-                  + "  \"type\" : {\n"
-                  + "    \"id\" : \"ENUM\",\n"
-                  + "    \"values\" : [ {\n"
-                  + "      \"id\" : 77,\n"
-                  + "      \"name\" : \"hello\"\n"
-                  + "    } ],\n"
-                  + "    \"logicalTypeAnnotation\" : null\n"
-                  + "  }\n"
-                  + "}")
-              .replace("\n", System.lineSeparator()),
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> conv.addBinary(Binary.fromString("FAKE_ENUM_VALUE")))
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasMessage(("Unrecognized enum value: FAKE_ENUM_VALUE known values: {Binary{\"hello\"}=77} in {\n"
+                + "  \"name\" : \"name\",\n"
+                + "  \"fieldId\" : 1,\n"
+                + "  \"requirement\" : \"REQUIRED\",\n"
+                + "  \"type\" : {\n"
+                + "    \"id\" : \"ENUM\",\n"
+                + "    \"values\" : [ {\n"
+                + "      \"id\" : 77,\n"
+                + "      \"name\" : \"hello\"\n"
+                + "    } ],\n"
+                + "    \"logicalTypeAnnotation\" : null\n"
+                + "  }\n"
+                + "}")
+            .replace("\n", System.lineSeparator()));
   }
 
   @Test

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConvertVisitor.java
@@ -20,7 +20,7 @@ package org.apache.parquet.thrift;
 
 import static org.apache.parquet.schema.Type.Repetition;
 import static org.apache.parquet.thrift.struct.ThriftField.Requirement;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,7 +65,7 @@ public class TestThriftSchemaConvertVisitor {
         .withId(fieldId);
     MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -86,7 +86,7 @@ public class TestThriftSchemaConvertVisitor {
         .withId(fieldId);
     MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -104,7 +104,7 @@ public class TestThriftSchemaConvertVisitor {
         .withId(fieldId);
     MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -125,7 +125,7 @@ public class TestThriftSchemaConvertVisitor {
         .withId(fieldId);
     MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -145,7 +145,7 @@ public class TestThriftSchemaConvertVisitor {
         .withId(fieldId);
     MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -167,6 +167,6 @@ public class TestThriftSchemaConvertVisitor {
         .withId(fieldId);
     MessageType expected = buildOneFieldParquetMessage(expectedParquetField);
 
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverter.java
@@ -20,8 +20,8 @@ package org.apache.parquet.thrift;
 
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
 import static org.apache.parquet.thrift.struct.ThriftField.Requirement.REQUIRED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.twitter.data.proto.tutorial.thrift.AddressBook;
 import com.twitter.data.proto.tutorial.thrift.Person;
@@ -64,7 +64,7 @@ public class TestThriftSchemaConverter {
         + "}";
     ThriftSchemaConverter schemaConverter = new ThriftSchemaConverter();
     final MessageType converted = schemaConverter.convert(AddressBook.class);
-    assertEquals(MessageTypeParser.parseMessageType(expected), converted);
+    assertThat(converted).isEqualTo(MessageTypeParser.parseMessageType(expected));
   }
 
   @Test
@@ -232,24 +232,16 @@ public class TestThriftSchemaConverter {
 
   private void shouldThrowWhenProjectionFilterMatchesNothing(
       String filters, String unmatchedFilter, Class<? extends TBase<?, ?>> thriftClass) {
-    try {
-      getDeprecatedFilteredSchema(filters, thriftClass);
-      fail("should throw projection exception when filter matches nothing");
-    } catch (ThriftProjectionException e) {
-      assertEquals(
-          "The following projection patterns did not match any columns in this schema:\n" + unmatchedFilter
-              + "\n",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> getDeprecatedFilteredSchema(filters, thriftClass))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("The following projection patterns did not match any columns in this schema:\n"
+            + unmatchedFilter + "\n");
   }
 
   private void shouldThrowWhenNoColumnsAreSelected(String filters, Class<? extends TBase<?, ?>> thriftClass) {
-    try {
-      getDeprecatedFilteredSchema(filters, thriftClass);
-      fail("should throw projection exception when no columns are selected");
-    } catch (ThriftProjectionException e) {
-      assertEquals("No columns have been selected", e.getMessage());
-    }
+    assertThatThrownBy(() -> getDeprecatedFilteredSchema(filters, thriftClass))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("No columns have been selected");
   }
 
   @Test
@@ -269,37 +261,23 @@ public class TestThriftSchemaConverter {
 
   @Test
   public void testProjectOnlyValueInMap() {
-    try {
-      getDeprecatedFilteredSchema("name;names/value/**", TestStructInMap.class);
-      fail("this should throw");
-    } catch (ThriftProjectionException e) {
-      assertEquals(
-          "Cannot select only the values of a map, you must keep the keys as well: names", e.getMessage());
-    }
+    assertThatThrownBy(() -> getDeprecatedFilteredSchema("name;names/value/**", TestStructInMap.class))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("Cannot select only the values of a map, you must keep the keys as well: names");
 
-    try {
-      getStrictFilteredSchema("name;names.value", TestStructInMap.class);
-      fail("this should throw");
-    } catch (ThriftProjectionException e) {
-      assertEquals(
-          "Cannot select only the values of a map, you must keep the keys as well: names", e.getMessage());
-    }
+    assertThatThrownBy(() -> getStrictFilteredSchema("name;names.value", TestStructInMap.class))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("Cannot select only the values of a map, you must keep the keys as well: names");
   }
 
   private void doTestPartialKeyProjection(String deprecated, String strict) {
-    try {
-      getDeprecatedFilteredSchema(deprecated, MapStructV2.class);
-      fail("this should throw");
-    } catch (ThriftProjectionException e) {
-      assertEquals("Cannot select only a subset of the fields in a map key, for path map1", e.getMessage());
-    }
+    assertThatThrownBy(() -> getDeprecatedFilteredSchema(deprecated, MapStructV2.class))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("Cannot select only a subset of the fields in a map key, for path map1");
 
-    try {
-      getStrictFilteredSchema(strict, MapStructV2.class);
-      fail("this should throw");
-    } catch (ThriftProjectionException e) {
-      assertEquals("Cannot select only a subset of the fields in a map key, for path map1", e.getMessage());
-    }
+    assertThatThrownBy(() -> getStrictFilteredSchema(strict, MapStructV2.class))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("Cannot select only a subset of the fields in a map key, for path map1");
   }
 
   @Test
@@ -310,19 +288,13 @@ public class TestThriftSchemaConverter {
 
   @Test
   public void testSetPartialProjection() {
-    try {
-      getDeprecatedFilteredSchema("set1/age", SetStructV2.class);
-      fail("this should throw");
-    } catch (ThriftProjectionException e) {
-      assertEquals("Cannot select only a subset of the fields in a set, for path set1", e.getMessage());
-    }
+    assertThatThrownBy(() -> getDeprecatedFilteredSchema("set1/age", SetStructV2.class))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("Cannot select only a subset of the fields in a set, for path set1");
 
-    try {
-      getStrictFilteredSchema("set1.age", SetStructV2.class);
-      fail("this should throw");
-    } catch (ThriftProjectionException e) {
-      assertEquals("Cannot select only a subset of the fields in a set, for path set1", e.getMessage());
-    }
+    assertThatThrownBy(() -> getStrictFilteredSchema("set1.age", SetStructV2.class))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("Cannot select only a subset of the fields in a set, for path set1");
   }
 
   @Test
@@ -338,7 +310,7 @@ public class TestThriftSchemaConverter {
         new ThriftField("b", (short) 2, REQUIRED, new ThriftType.StringType())));
 
     final MessageType converted = converter.convert(structType);
-    assertEquals(MessageTypeParser.parseMessageType(expected), converted);
+    assertThat(converted).isEqualTo(MessageTypeParser.parseMessageType(expected));
   }
 
   public static void shouldGetProjectedSchema(
@@ -349,8 +321,8 @@ public class TestThriftSchemaConverter {
     MessageType depRequestedSchema = getDeprecatedFilteredSchema(deprecatedFilterDesc, thriftClass);
     MessageType strictRequestedSchema = getStrictFilteredSchema(strictFilterDesc, thriftClass);
     MessageType expectedSchema = parseMessageType(expectedSchemaStr);
-    assertEquals(expectedSchema, depRequestedSchema);
-    assertEquals(expectedSchema, strictRequestedSchema);
+    assertThat(depRequestedSchema).isEqualTo(expectedSchema);
+    assertThat(strictRequestedSchema).isEqualTo(expectedSchema);
   }
 
   private static MessageType getDeprecatedFilteredSchema(
@@ -371,7 +343,7 @@ public class TestThriftSchemaConverter {
     final StructType converted = ThriftSchemaConverter.toStructType(AddressBook.class);
     final String json = converted.toJSON();
     final ThriftType fromJSON = StructType.fromJSON(json);
-    assertEquals(json, fromJSON.toJSON());
+    assertThat(fromJSON.toJSON()).isEqualTo(json);
   }
 
   @Test
@@ -381,6 +353,6 @@ public class TestThriftSchemaConverter {
         + "}\n";
     ThriftSchemaConverter schemaConverter = new ThriftSchemaConverter();
     final MessageType converted = schemaConverter.convert(TestLogicalType.class);
-    assertEquals(MessageTypeParser.parseMessageType(expected), converted);
+    assertThat(converted).isEqualTo(MessageTypeParser.parseMessageType(expected));
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestUUIDRecordConverterFailure.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestUUIDRecordConverterFailure.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.thrift;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -44,12 +44,7 @@ public class TestUUIDRecordConverterFailure {
     ThriftRecordConverter.FieldUUIDConverter uuidConverter =
         new ThriftRecordConverter.FieldUUIDConverter(new ArrayList<TProtocol>(), uuidField);
 
-    try {
-      uuidConverter.addBinary(binary);
-      assertTrue("UUID converter handled binary data", true);
-    } catch (UnsupportedOperationException e) {
-      fail("UUID converter should handle binary data, but got: " + e.getMessage());
-    }
+    assertThatCode(() -> uuidConverter.addBinary(binary)).doesNotThrowAnyException();
   }
 
   private byte[] uuidToBytes(UUID uuid) {

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/TestFieldsPath.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/TestFieldsPath.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.thrift.projection;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.twitter.data.proto.tutorial.thrift.Person;
 import com.twitter.elephantbird.thrift.test.TestStructInMap;
@@ -48,20 +48,18 @@ public class TestFieldsPath {
     StructType person = ThriftSchemaConverter.toStructType(Person.class);
 
     List<String> paths = PrimitivePathVisitor.visit(person, ".");
-    assertEquals(
-        Arrays.asList("name.first_name", "name.last_name", "id", "email", "phones.number", "phones.type"),
-        paths);
+    assertThat(paths)
+        .containsExactly("name.first_name", "name.last_name", "id", "email", "phones.number", "phones.type");
 
     paths = PrimitivePathVisitor.visit(person, "/");
-    assertEquals(
-        Arrays.asList("name/first_name", "name/last_name", "id", "email", "phones/number", "phones/type"),
-        paths);
+    assertThat(paths)
+        .containsExactly("name/first_name", "name/last_name", "id", "email", "phones/number", "phones/type");
 
     StructType structInMap = ThriftSchemaConverter.toStructType(TestStructInMap.class);
 
     paths = PrimitivePathVisitor.visit(structInMap, ".");
-    assertEquals(
-        Arrays.asList(
+    assertThat(paths)
+        .containsExactly(
             "name",
             "names.key",
             "names.value.name.first_name",
@@ -69,12 +67,11 @@ public class TestFieldsPath {
             "names.value.phones.key",
             "names.value.phones.value",
             "name_to_id.key",
-            "name_to_id.value"),
-        paths);
+            "name_to_id.value");
 
     paths = PrimitivePathVisitor.visit(structInMap, "/");
-    assertEquals(
-        Arrays.asList(
+    assertThat(paths)
+        .containsExactly(
             "name",
             "names/key",
             "names/value/name/first_name",
@@ -82,8 +79,7 @@ public class TestFieldsPath {
             "names/value/phones/key",
             "names/value/phones/value",
             "name_to_id/key",
-            "name_to_id/value"),
-        paths);
+            "name_to_id/value");
   }
 
   private static class PrimitivePathVisitor implements ThriftType.StateVisitor<List<String>, FieldsPath> {

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/TestStrictFieldProjectionFilter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/TestStrictFieldProjectionFilter.java
@@ -18,46 +18,26 @@
  */
 package org.apache.parquet.thrift.projection;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
-import java.util.List;
 import org.junit.Test;
 
 public class TestStrictFieldProjectionFilter {
 
   @Test
   public void testFromSemicolonDelimitedString() {
-    List<String> globs = StrictFieldProjectionFilter.parseSemicolonDelimitedString(";x.y.z;*.a.b.c*;;foo;;;;bar;");
-    assertEquals(Arrays.asList("x.y.z", "*.a.b.c*", "foo", "bar"), globs);
+    assertThat(StrictFieldProjectionFilter.parseSemicolonDelimitedString(";x.y.z;*.a.b.c*;;foo;;;;bar;"))
+        .containsExactly("x.y.z", "*.a.b.c*", "foo", "bar");
 
-    try {
-      StrictFieldProjectionFilter.parseSemicolonDelimitedString(";;");
-      fail("this should throw");
-    } catch (ThriftProjectionException e) {
-      assertEquals("Semicolon delimited string ';;' contains 0 glob strings", e.getMessage());
-    }
-  }
-
-  private static void assertMatches(StrictFieldProjectionFilter filter, String... strings) {
-    for (String s : strings) {
-      if (!filter.keep(s)) {
-        fail(String.format("String '%s' was expected to match", s));
-      }
-    }
-  }
-
-  private static void assertDoesNotMatch(StrictFieldProjectionFilter filter, String... strings) {
-    for (String s : strings) {
-      if (filter.keep(s)) {
-        fail(String.format("String '%s' was not expected to match", s));
-      }
-    }
+    assertThatThrownBy(() -> StrictFieldProjectionFilter.parseSemicolonDelimitedString(";;"))
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("Semicolon delimited string ';;' contains 0 glob strings");
   }
 
   @Test
@@ -65,31 +45,27 @@ public class TestStrictFieldProjectionFilter {
     StrictFieldProjectionFilter filter = StrictFieldProjectionFilter.fromSemicolonDelimitedString(
         "home.phone_number;home.address;work.address.zip;base_info;*.average;a.b.c.pre{x,y,z{a,b,c}}post");
 
-    assertMatches(
-        filter,
-        "home.phone_number",
-        "home.address",
-        "work.address.zip",
-        "base_info",
-        "foo.average",
-        "bar.x.y.z.average",
-        "base_info.nested.field",
-        "a.b.c.prexpost",
-        "a.b.c.prezapost");
+    assertThat(filter.keep("home.phone_number")).isTrue();
+    assertThat(filter.keep("home.address")).isTrue();
+    assertThat(filter.keep("work.address.zip")).isTrue();
+    assertThat(filter.keep("base_info")).isTrue();
+    assertThat(filter.keep("foo.average")).isTrue();
+    assertThat(filter.keep("bar.x.y.z.average")).isTrue();
+    assertThat(filter.keep("base_info.nested.field")).isTrue();
+    assertThat(filter.keep("a.b.c.prexpost")).isTrue();
+    assertThat(filter.keep("a.b.c.prezapost")).isTrue();
 
-    assertDoesNotMatch(
-        filter,
-        "home2.phone_number",
-        "home2.address",
-        "work.address",
-        "base_info2",
-        "foo_average",
-        "bar.x.y.z_average",
-        "base_info_nested.field",
-        "hi",
-        "average",
-        "a.b.c.pre{x,y,z{a,b,c}}post",
-        "");
+    assertThat(filter.keep("home2.phone_number")).isFalse();
+    assertThat(filter.keep("home2.address")).isFalse();
+    assertThat(filter.keep("work.address")).isFalse();
+    assertThat(filter.keep("base_info2")).isFalse();
+    assertThat(filter.keep("foo_average")).isFalse();
+    assertThat(filter.keep("bar.x.y.z_average")).isFalse();
+    assertThat(filter.keep("base_info_nested.field")).isFalse();
+    assertThat(filter.keep("hi")).isFalse();
+    assertThat(filter.keep("average")).isFalse();
+    assertThat(filter.keep("a.b.c.pre{x,y,z{a,b,c}}post")).isFalse();
+    assertThat(filter.keep("")).isFalse();
   }
 
   @Test
@@ -97,18 +73,18 @@ public class TestStrictFieldProjectionFilter {
     StrictFieldProjectionFilter filter = StrictFieldProjectionFilter.fromSemicolonDelimitedString(
         "home.phone_number;a.b.c.pre{x,y,z{a,b,c}}post;bar.*.average");
 
-    assertMatches(filter, "home.phone_number", "bar.foo.average", "a.b.c.prexpost", "a.b.c.prezcpost");
-    assertDoesNotMatch(filter, "hello");
-    try {
-      filter.assertNoUnmatchedPatterns();
-      fail("this should throw");
-    } catch (ThriftProjectionException e) {
-      String expectedMessage = "The following projection patterns did not match any columns in this schema:\n"
-          + "Pattern: 'a.b.c.pre{x,y,z{a,b,c}}post' (when expanded to 'a.b.c.preypost')\n"
-          + "Pattern: 'a.b.c.pre{x,y,z{a,b,c}}post' (when expanded to 'a.b.c.prezapost')\n"
-          + "Pattern: 'a.b.c.pre{x,y,z{a,b,c}}post' (when expanded to 'a.b.c.prezbpost')\n";
-      assertEquals(expectedMessage, e.getMessage());
-    }
+    assertThat(filter.keep("home.phone_number")).isTrue();
+    assertThat(filter.keep("bar.foo.average")).isTrue();
+    assertThat(filter.keep("a.b.c.prexpost")).isTrue();
+    assertThat(filter.keep("a.b.c.prezcpost")).isTrue();
+    assertThat(filter.keep("hello")).isFalse();
+
+    assertThatThrownBy(filter::assertNoUnmatchedPatterns)
+        .isInstanceOf(ThriftProjectionException.class)
+        .hasMessage("The following projection patterns did not match any columns in this schema:\n"
+            + "Pattern: 'a.b.c.pre{x,y,z{a,b,c}}post' (when expanded to 'a.b.c.preypost')\n"
+            + "Pattern: 'a.b.c.pre{x,y,z{a,b,c}}post' (when expanded to 'a.b.c.prezapost')\n"
+            + "Pattern: 'a.b.c.pre{x,y,z{a,b,c}}post' (when expanded to 'a.b.c.prezbpost')\n");
   }
 
   @Test
@@ -117,8 +93,10 @@ public class TestStrictFieldProjectionFilter {
         spy(new StrictFieldProjectionFilter(Arrays.asList("a.b.c.{x_average,z_average}", "a.*_average")));
     doNothing().when(filter).warn(anyString());
 
-    assertMatches(filter, "a.b.c.x_average", "a.b.c.z_average", "a.other.w_average");
-    assertDoesNotMatch(filter, "hello");
+    assertThat(filter.keep("a.b.c.x_average")).isTrue();
+    assertThat(filter.keep("a.b.c.z_average")).isTrue();
+    assertThat(filter.keep("a.other.w_average")).isTrue();
+    assertThat(filter.keep("hello")).isFalse();
 
     verify(filter)
         .warn("Field path: 'a.b.c.x_average' matched more than one glob path pattern. "

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/deprecated/PathGlobPatternTest.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/deprecated/PathGlobPatternTest.java
@@ -18,8 +18,7 @@
  */
 package org.apache.parquet.thrift.projection.deprecated;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -30,27 +29,27 @@ public class PathGlobPatternTest {
   @Test
   public void testRecursiveGlob() {
     PathGlobPattern g = new PathGlobPattern("a/**/b");
-    assertFalse(g.matches("a/b"));
-    assertTrue(g.matches("a/asd/b"));
-    assertTrue(g.matches("a/asd/ss/b"));
+    assertThat(g.matches("a/b")).isFalse();
+    assertThat(g.matches("a/asd/b")).isTrue();
+    assertThat(g.matches("a/asd/ss/b")).isTrue();
 
     g = new PathGlobPattern("a/**");
-    assertTrue(g.matches("a/as"));
-    assertTrue(g.matches("a/asd/b"));
-    assertTrue(g.matches("a/asd/ss/b"));
+    assertThat(g.matches("a/as")).isTrue();
+    assertThat(g.matches("a/asd/b")).isTrue();
+    assertThat(g.matches("a/asd/ss/b")).isTrue();
   }
 
   @Test
   public void testStandardGlob() {
     PathGlobPattern g = new PathGlobPattern("a/*");
-    assertTrue(g.matches("a/as"));
-    assertFalse(g.matches("a/asd/b"));
-    assertFalse(g.matches("a/asd/ss/b"));
+    assertThat(g.matches("a/as")).isTrue();
+    assertThat(g.matches("a/asd/b")).isFalse();
+    assertThat(g.matches("a/asd/ss/b")).isFalse();
 
     g = new PathGlobPattern("a/{bb,cc}/d");
-    assertTrue(g.matches("a/bb/d"));
-    assertTrue(g.matches("a/cc/d"));
-    assertFalse(g.matches("a/cc/bb/d"));
-    assertFalse(g.matches("a/d"));
+    assertThat(g.matches("a/bb/d")).isTrue();
+    assertThat(g.matches("a/cc/d")).isTrue();
+    assertThat(g.matches("a/cc/bb/d")).isFalse();
+    assertThat(g.matches("a/d")).isFalse();
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
@@ -18,8 +18,7 @@
  */
 package org.apache.parquet.thrift.struct;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.parquet.thrift.ThriftSchemaConverter;
 import org.apache.parquet.thrift.test.compat.AddRequiredStructV1;
@@ -126,10 +125,9 @@ public class CompatibilityCheckerTest {
   @Test
   public void testEmptyStruct() {
     CompatibilityReport report = getCompatibilityReport(NestedEmptyStruct.class, NestedEmptyStruct.class);
-    assertEquals(
-        "encountered an empty struct: required_empty\nencountered an empty struct: optional_empty",
-        report.prettyMessages());
-    assertTrue(report.hasEmptyStruct());
+    assertThat(report.prettyMessages())
+        .isEqualTo("encountered an empty struct: required_empty\nencountered an empty struct: optional_empty");
+    assertThat(report.hasEmptyStruct()).isTrue();
   }
 
   private ThriftType.StructType struct(Class thriftClass) {
@@ -144,6 +142,6 @@ public class CompatibilityCheckerTest {
 
   private void verifyCompatible(Class oldClass, Class newClass, boolean expectCompatible) {
     CompatibilityReport report = getCompatibilityReport(oldClass, newClass);
-    assertEquals(expectCompatible, report.isCompatible());
+    assertThat(report.isCompatible()).isEqualTo(expectCompatible);
   }
 }

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/TestThriftType.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/TestThriftType.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.thrift.struct;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.LinkedList;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
@@ -30,51 +30,48 @@ public class TestThriftType {
   @Test
   public void testWriteUnionInfo() throws Exception {
     StructType st = new StructType(new LinkedList<ThriftField>(), null);
-    assertEquals(
-        ("{\n"
+    assertThat(st.toJSON())
+        .isEqualTo(("{\n"
                 + "  \"id\" : \"STRUCT\",\n"
                 + "  \"children\" : [ ],\n"
                 + "  \"structOrUnionType\" : \"STRUCT\",\n"
                 + "  \"logicalTypeAnnotation\" : null\n"
                 + "}")
-            .replace("\n", System.lineSeparator()),
-        st.toJSON());
+            .replace("\n", System.lineSeparator()));
 
     st = new StructType(new LinkedList<ThriftField>(), StructOrUnionType.UNION);
-    assertEquals(
-        ("{\n"
+    assertThat(st.toJSON())
+        .isEqualTo(("{\n"
                 + "  \"id\" : \"STRUCT\",\n"
                 + "  \"children\" : [ ],\n"
                 + "  \"structOrUnionType\" : \"UNION\",\n"
                 + "  \"logicalTypeAnnotation\" : null\n"
                 + "}")
-            .replace("\n", System.lineSeparator()),
-        st.toJSON());
+            .replace("\n", System.lineSeparator()));
 
     st = new StructType(new LinkedList<ThriftField>(), StructOrUnionType.STRUCT);
-    assertEquals(
-        ("{\n"
+    assertThat(st.toJSON())
+        .isEqualTo(("{\n"
                 + "  \"id\" : \"STRUCT\",\n"
                 + "  \"children\" : [ ],\n"
                 + "  \"structOrUnionType\" : \"STRUCT\",\n"
                 + "  \"logicalTypeAnnotation\" : null\n"
                 + "}")
-            .replace("\n", System.lineSeparator()),
-        st.toJSON());
+            .replace("\n", System.lineSeparator()));
   }
 
   @Test
   public void testParseUnionInfo() throws Exception {
     StructType st = (StructType)
         StructType.fromJSON("{\"id\": \"STRUCT\", \"children\":[], \"structOrUnionType\": \"UNION\"}");
-    assertEquals(st.getStructOrUnionType(), StructOrUnionType.UNION);
+    assertThat(st.getStructOrUnionType()).isEqualTo(StructOrUnionType.UNION);
     st = (StructType)
         StructType.fromJSON("{\"id\": \"STRUCT\", \"children\":[], \"structOrUnionType\": \"STRUCT\"}");
-    assertEquals(st.getStructOrUnionType(), StructOrUnionType.STRUCT);
+    assertThat(st.getStructOrUnionType()).isEqualTo(StructOrUnionType.STRUCT);
     st = (StructType) StructType.fromJSON("{\"id\": \"STRUCT\", \"children\":[]}");
-    assertEquals(st.getStructOrUnionType(), StructOrUnionType.STRUCT);
+    assertThat(st.getStructOrUnionType()).isEqualTo(StructOrUnionType.STRUCT);
     st = (StructType)
         StructType.fromJSON("{\"id\": \"STRUCT\", \"children\":[], \"structOrUnionType\": \"UNKNOWN\"}");
-    assertEquals(st.getStructOrUnionType(), StructOrUnionType.UNKNOWN);
+    assertThat(st.getStructOrUnionType()).isEqualTo(StructOrUnionType.UNKNOWN);
   }
 }


### PR DESCRIPTION


<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Switching assertions from JUnit4-style Assert to AssertJ makes code easier to read and debug when tests fail.


### What changes are included in this PR?

This updates parquet-format-structures / parquet-encoding / parquet-thrift tests to use AssertJ checks, which provide more fluent assertions and more detailed information when assertions fails on CI.

The changes in this PR were done with the help of Claude but I manually reviewed every single LOC

### Are these changes tested?
yes, existing tests

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
