### PR TITLE
MINOR: Fix PrimitiveStringifier class Javadoc to link UnsupportedOperationException

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java
+++ b/parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java
@@ -33,7 +33,6 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.TimeUnit;
-import javax.naming.OperationNotSupportedException;
 import org.apache.parquet.io.api.Binary;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
@@ -42,7 +41,7 @@ import org.locationtech.jts.io.WKBReader;
 /**
  * Class that provides string representations for the primitive values. These string values are to be used for
  * logging/debugging purposes. The method {@code stringify} is overloaded for each primitive types. The overloaded
- * methods not implemented for the related types throw {@link OperationNotSupportedException}.
+ * methods not implemented for the related types throw {@link UnsupportedOperationException}.
  */
 public abstract class PrimitiveStringifier {
   private final String name;


### PR DESCRIPTION

### Rationale for this change

The class-level Javadoc of the public abstract class `PrimitiveStringifier`
(`parquet-column/src/main/java/org/apache/parquet/schema/PrimitiveStringifier.java`)
documents the wrong exception type. It states:

> The overloaded methods not implemented for the related types throw
> `{@link OperationNotSupportedException}`.

That `{@link}` resolves to `javax.naming.OperationNotSupportedException`, which is
the only reason the `import javax.naming.OperationNotSupportedException;` exists in
the file. Two problems follow from this:

1. Every `stringify(...)` overload that is not implemented for a type actually
   throws `java.lang.UnsupportedOperationException`, and each method's own
   `@throws` tag already documents `UnsupportedOperationException`. So the
   class-level contract contradicts every per-method contract in the same file.
2. `javax.naming.OperationNotSupportedException` is a checked exception
   (`extends NamingException extends Exception`). The unchecked `stringify(...)`
   methods cannot declare or throw it, so the documented behavior is impossible
   and would mislead a caller into catching the wrong exception type.

### What changes are included in this PR?

A documentation-only change in one file:

- Point the class Javadoc `{@link}` at `java.lang.UnsupportedOperationException`
  (no import needed), so the class contract matches the six per-method `@throws`
  tags and the actual `throw` statements.
- Remove the now-unused `import javax.naming.OperationNotSupportedException;`,
  which existed solely to satisfy the incorrect link.

No behavioral change. Net diff is one import line removed and one word changed in
the Javadoc.

### Are these changes tested?

This is a Javadoc/import-only change with no runtime behavior change, so no new
test is added. It was validated locally on `parquet-column` (JDK 21, Maven 3.9):

- `mvn -pl parquet-column -Dspotless.check.skip=true -DskipTests compile` succeeds,
  confirming the removed `javax.naming` import was unused.
- `mvn -pl parquet-column javadoc:javadoc` succeeds with no "reference not found"
  warning for `PrimitiveStringifier`; the generated HTML now links the class
  description to `java.lang.UnsupportedOperationException` and contains no
  `javax.naming` reference.
- `mvn -pl parquet-column spotless:check` succeeds (0 files need reformatting).
- `mvn -pl parquet-column -Dtest=TestPrimitiveStringifier test` passes
  (13 tests, 0 failures), confirming no behavioral change.

### Are there any user-facing changes?

No. This only corrects Javadoc and removes a dead import. There is no API or
behavior change.

