### PR TITLE
GH-3652: Use assertThat checks in parquet-plugins/parquet-protobuf tests

### DIFF
--- a/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking512VectorLE.java
+++ b/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking512VectorLE.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.column.values.bitpacking;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -55,16 +55,16 @@ public class TestByteBitPacking512VectorLE {
         }
 
         unpack8Values(bitWidth, byteOutput, output);
-        assertArrayEquals(intInput, output);
+        assertThat(output).isEqualTo(intInput);
         Arrays.fill(output, 0);
 
         unpackValuesUsingVectorArray(bitWidth, byteOutput, output);
-        assertArrayEquals(intInput, output);
+        assertThat(output).isEqualTo(intInput);
         Arrays.fill(output, 0);
 
         ByteBuffer byteBuffer = ByteBuffer.wrap(byteOutput);
         unpackValuesUsingVectorByteBuffer(bitWidth, byteBuffer, output);
-        assertArrayEquals(intInput, output);
+        assertThat(output).isEqualTo(intInput);
         Arrays.fill(output, 0);
       });
     }

--- a/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestParquetReadRouter.java
+++ b/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestParquetReadRouter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.column.values.bitpacking;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -49,10 +49,10 @@ public class TestParquetReadRouter {
 
       ParquetReadRouter.read(bitWidth, inputStream, 0, output);
       ParquetReadRouter.readBatch(bitWidth, inputStream, 0, outputBatch);
-      assertArrayEquals(output, outputBatch);
+      assertThat(outputBatch).isEqualTo(output);
       Assume.assumeTrue(ParquetReadRouter.getSupportVectorFromCPUFlags() == VectorSupport.VECTOR_512);
       ParquetReadRouter.readBatchUsing512Vector(bitWidth, inputStream, 0, outputBatchVector);
-      assertArrayEquals(output, outputBatchVector);
+      assertThat(outputBatchVector).isEqualTo(output);
     }
   }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoInputOutputFormatTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoInputOutputFormatTest.java
@@ -18,9 +18,8 @@
  */
 package org.apache.parquet.proto;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import com.google.protobuf.BoolValue;
 import com.google.protobuf.ByteString;
@@ -59,15 +58,15 @@ public class ProtoInputOutputFormatTest {
 
     List<Message> result = runMRJobs(input);
 
-    assertEquals(1, result.size());
+    assertThat(result).hasSize(1);
     TestProtobuf.IOFormatMessage output = (TestProtobuf.IOFormatMessage) result.get(0);
 
-    assertEquals(666, output.getOptionalDouble(), 0.00001);
-    assertEquals(323, output.getMsg().getSomeId());
-    assertEquals("Msg1", output.getRepeatedString(0));
-    assertEquals("Msg2", output.getRepeatedString(1));
+    assertThat(output.getOptionalDouble()).isCloseTo(666, offset(0.00001));
+    assertThat(output.getMsg().getSomeId()).isEqualTo(323);
+    assertThat(output.getRepeatedString(0)).isEqualTo("Msg1");
+    assertThat(output.getRepeatedString(1)).isEqualTo("Msg2");
 
-    assertEquals(input, output);
+    assertThat(output).isEqualTo(input);
   }
 
   @Test
@@ -84,15 +83,15 @@ public class ProtoInputOutputFormatTest {
 
     List<Message> result = runMRJobs(input);
 
-    assertEquals(1, result.size());
+    assertThat(result).hasSize(1);
     TestProto3.IOFormatMessage output = (TestProto3.IOFormatMessage) result.get(0);
 
-    assertEquals(666, output.getOptionalDouble(), 0.00001);
-    assertEquals(323, output.getMsg().getSomeId());
-    assertEquals("Msg1", output.getRepeatedString(0));
-    assertEquals("Msg2", output.getRepeatedString(1));
+    assertThat(output.getOptionalDouble()).isCloseTo(666, offset(0.00001));
+    assertThat(output.getMsg().getSomeId()).isEqualTo(323);
+    assertThat(output.getRepeatedString(0)).isEqualTo("Msg1");
+    assertThat(output.getRepeatedString(1)).isEqualTo("Msg2");
 
-    assertEquals(input, output);
+    assertThat(output).isEqualTo(input);
   }
 
   /**
@@ -117,8 +116,10 @@ public class ProtoInputOutputFormatTest {
     TestProtobuf.Document readDocument = (TestProtobuf.Document) output.get(0);
 
     // test that only requested fields were deserialized
-    assertTrue(readDocument.hasDocId());
-    assertTrue("Found data outside projection.", readDocument.getNameCount() == 0);
+    assertThat(readDocument.getDocId()).isEqualTo(12345L);
+    assertThat(readDocument.getNameCount())
+        .as("Found data outside projection.")
+        .isZero();
   }
 
   @Test
@@ -139,9 +140,11 @@ public class ProtoInputOutputFormatTest {
     TestProto3.Document readDocument = (TestProto3.Document) output.get(0);
 
     // test that only requested fields were deserialized
-    assertTrue(readDocument.getDocId() == 12345);
-    assertTrue(readDocument.getNameCount() == 0);
-    assertTrue("Found data outside projection.", readDocument.getNameCount() == 0);
+    assertThat(readDocument.getDocId()).isEqualTo(12345);
+    assertThat(readDocument.getNameCount()).isEqualTo(0);
+    assertThat(readDocument.getNameCount())
+        .as("Found data outside projection.")
+        .isZero();
   }
 
   /**
@@ -160,14 +163,14 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(1, result.size());
+    assertThat(result).hasSize(1);
     Message msg = result.get(0);
-    assertFalse("Class from header returned.", msg instanceof FirstCustomClassMessage);
-    assertTrue("Custom class was not used", msg instanceof SecondCustomClassMessage);
+    assertThat(msg).as("Class from header returned.").isNotInstanceOf(FirstCustomClassMessage.class);
+    assertThat(msg).as("Custom class was not used").isInstanceOf(SecondCustomClassMessage.class);
 
     String stringValue;
     stringValue = ((SecondCustomClassMessage) msg).getString();
-    assertEquals("writtenString", stringValue);
+    assertThat(stringValue).isEqualTo("writtenString");
   }
 
   @Test
@@ -182,14 +185,14 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(1, result.size());
+    assertThat(result).hasSize(1);
     Message msg = result.get(0);
-    assertFalse("Class from header returned.", msg instanceof TestProto3.FirstCustomClassMessage);
-    assertTrue("Custom class was not used", msg instanceof TestProto3.SecondCustomClassMessage);
+    assertThat(msg).as("Class from header returned.").isNotInstanceOf(TestProto3.FirstCustomClassMessage.class);
+    assertThat(msg).as("Custom class was not used").isInstanceOf(TestProto3.SecondCustomClassMessage.class);
 
     String stringValue;
     stringValue = ((TestProto3.SecondCustomClassMessage) msg).getString();
-    assertEquals("writtenString", stringValue);
+    assertThat(stringValue).isEqualTo("writtenString");
   }
 
   @Test
@@ -207,9 +210,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -227,9 +230,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -250,9 +253,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -273,9 +276,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -293,9 +296,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -313,9 +316,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -336,9 +339,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -359,9 +362,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -381,9 +384,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -403,9 +406,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -428,9 +431,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -453,9 +456,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -472,8 +475,8 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(1, result.size());
-    // assertEquals(msgEmpty, result.get(0));
+    assertThat(result).hasSize(1);
+    // assertThat(result.get(0)).isEqualTo(msgEmpty)
     // proto3 will return default values for absent fields which is what is returned in output
     // this is why we can ignore absent fields here as optionalMessage and optionalMap will get default value
     com.google.common.truth.extensions.proto.ProtoTruth.assertThat(result.get(0))
@@ -517,7 +520,7 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(1, result.size());
+    assertThat(result).hasSize(1);
     // proto3 will return default values for absent fields which is what is returned in output
     // this is why we can ignore absent fields here as optionalMap will get default value
     com.google.common.truth.extensions.proto.ProtoTruth.assertThat(result.get(0))
@@ -527,23 +530,23 @@ public class ProtoInputOutputFormatTest {
         .isEqualTo(dataBuilt);
 
     TestProto3.SchemaConverterAllDatatypes o = (TestProto3.SchemaConverterAllDatatypes) result.get(0);
-    assertEquals("Good Will Hunting", o.getOptionalString());
-    assertEquals(true, o.getOptionalBool());
-    assertEquals(ByteString.copyFrom("someText", "UTF-8"), o.getOptionalBytes());
-    assertEquals(0.577, o.getOptionalDouble(), 0.00001);
-    assertEquals(3.1415f, o.getOptionalFloat(), 0.00001);
-    assertEquals(TestProto3.SchemaConverterAllDatatypes.TestEnum.FIRST, o.getOptionalEnum());
-    assertEquals(1000 * 1000 * 1, o.getOptionalFixed32());
-    assertEquals(1000 * 1000 * 1000 * 2, o.getOptionalFixed64());
-    assertEquals(1000 * 1000 * 3, o.getOptionalInt32());
-    assertEquals(1000L * 1000 * 1000 * 4, o.getOptionalInt64());
-    assertEquals(1000 * 1000 * 5, o.getOptionalSFixed32());
-    assertEquals(1000L * 1000 * 1000 * 6, o.getOptionalSFixed64());
-    assertEquals(1000 * 1000 * 56, o.getOptionalSInt32());
-    assertEquals(1000L * 1000 * 1000 * 7, o.getOptionalSInt64());
-    assertEquals(1000 * 1000 * 8, o.getOptionalUInt32());
-    assertEquals(1000L * 1000 * 1000 * 9, o.getOptionalUInt64());
-    assertEquals(1984, o.getOptionalMessage().getSomeId());
+    assertThat(o.getOptionalString()).isEqualTo("Good Will Hunting");
+    assertThat(o.getOptionalBool()).isTrue();
+    assertThat(o.getOptionalBytes()).isEqualTo(ByteString.copyFrom("someText", "UTF-8"));
+    assertThat(o.getOptionalDouble()).isCloseTo(0.577, offset(0.00001));
+    assertThat(o.getOptionalFloat()).isCloseTo(3.1415f, offset(0.00001f));
+    assertThat(o.getOptionalEnum()).isEqualTo(TestProto3.SchemaConverterAllDatatypes.TestEnum.FIRST);
+    assertThat(o.getOptionalFixed32()).isEqualTo(1000 * 1000 * 1);
+    assertThat(o.getOptionalFixed64()).isEqualTo(1000 * 1000 * 1000 * 2);
+    assertThat(o.getOptionalInt32()).isEqualTo(1000 * 1000 * 3);
+    assertThat(o.getOptionalInt64()).isEqualTo(1000L * 1000 * 1000 * 4);
+    assertThat(o.getOptionalSFixed32()).isEqualTo(1000 * 1000 * 5);
+    assertThat(o.getOptionalSFixed64()).isEqualTo(1000L * 1000 * 1000 * 6);
+    assertThat(o.getOptionalSInt32()).isEqualTo(1000 * 1000 * 56);
+    assertThat(o.getOptionalSInt64()).isEqualTo(1000L * 1000 * 1000 * 7);
+    assertThat(o.getOptionalUInt32()).isEqualTo(1000 * 1000 * 8);
+    assertThat(o.getOptionalUInt64()).isEqualTo(1000L * 1000 * 1000 * 9);
+    assertThat(o.getOptionalMessage().getSomeId()).isEqualTo(1984);
   }
 
   @Test
@@ -583,7 +586,7 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(100, result.size());
+    assertThat(result).hasSize(100);
     for (int i = 0; i < 100; i++) {
       // proto3 will return default values for absent fields which is what is returned in output
       // this is why we can ignore absent fields here
@@ -593,10 +596,10 @@ public class ProtoInputOutputFormatTest {
           .reportingMismatchesOnly()
           .isEqualTo(input[i]);
     }
-    assertEquals(
-        "Good Will Hunting 0", ((TestProto3.SchemaConverterAllDatatypes) result.get(0)).getOptionalString());
-    assertEquals(
-        "Good Will Hunting 90", ((TestProto3.SchemaConverterAllDatatypes) result.get(90)).getOptionalString());
+    assertThat(((TestProto3.SchemaConverterAllDatatypes) result.get(0)).getOptionalString())
+        .isEqualTo("Good Will Hunting 0");
+    assertThat(((TestProto3.SchemaConverterAllDatatypes) result.get(90)).getOptionalString())
+        .isEqualTo("Good Will Hunting 90");
   }
 
   @Test
@@ -616,23 +619,23 @@ public class ProtoInputOutputFormatTest {
     List<Message> messages = readUsingMR.read(outputPath);
     TestProto3.TopMessage result = (TestProto3.TopMessage) messages.get(0);
 
-    assertEquals(3, result.getInnerCount());
+    assertThat(result.getInnerCount()).isEqualTo(3);
 
     TestProto3.InnerMessage first = result.getInner(0);
     TestProto3.InnerMessage second = result.getInner(1);
     TestProto3.InnerMessage third = result.getInner(2);
 
-    assertEquals("First inner", first.getOne());
-    assertTrue(first.getTwo().isEmpty());
-    assertTrue(first.getThree().isEmpty());
+    assertThat(first.getOne()).isEqualTo("First inner");
+    assertThat(first.getTwo()).isEmpty();
+    assertThat(first.getThree()).isEmpty();
 
-    assertEquals("Second inner", second.getTwo());
-    assertTrue(second.getOne().isEmpty());
-    assertTrue(second.getThree().isEmpty());
+    assertThat(second.getTwo()).isEqualTo("Second inner");
+    assertThat(second.getOne()).isEmpty();
+    assertThat(second.getThree()).isEmpty();
 
-    assertEquals("Third inner", third.getThree());
-    assertTrue(third.getOne().isEmpty());
-    assertTrue(third.getTwo().isEmpty());
+    assertThat(third.getThree()).isEqualTo("Third inner");
+    assertThat(third.getOne()).isEmpty();
+    assertThat(third.getTwo()).isEmpty();
   }
 
   @Test
@@ -651,9 +654,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -673,9 +676,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(2, result.size());
-    assertEquals(msgEmpty, result.get(0));
-    assertEquals(msgNonEmpty, result.get(1));
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0)).isEqualTo(msgEmpty);
+    assertThat(result.get(1)).isEqualTo(msgNonEmpty);
   }
 
   @Test
@@ -684,15 +687,15 @@ public class ProtoInputOutputFormatTest {
     TestProto3.SchemaConverterAllDatatypes intMin = TestProto3.SchemaConverterAllDatatypes.newBuilder()
         .setOptionalUInt32(Integer.MIN_VALUE)
         .build();
-    assertEquals(intMin.toString(), "optionalUInt32: 2147483648\n");
+    assertThat(intMin).asString().isEqualTo("optionalUInt32: 2147483648\n");
     TestProto3.SchemaConverterAllDatatypes uintMin = TestProto3.SchemaConverterAllDatatypes.newBuilder()
         .setOptionalUInt32(-1)
         .build();
-    assertEquals(uintMin.toString(), "optionalUInt32: 4294967295\n");
+    assertThat(uintMin).asString().isEqualTo("optionalUInt32: 4294967295\n");
     TestProto3.SchemaConverterAllDatatypes uintMax = TestProto3.SchemaConverterAllDatatypes.newBuilder()
         .setOptionalUInt32(Integer.MAX_VALUE)
         .build();
-    assertEquals(uintMax.toString(), "optionalUInt32: 2147483647\n");
+    assertThat(uintMax).asString().isEqualTo("optionalUInt32: 2147483647\n");
 
     Configuration conf = new Configuration();
     Path outputPath = new WriteUsingMR(conf).write(intMin, uintMin, uintMax);
@@ -701,9 +704,9 @@ public class ProtoInputOutputFormatTest {
     ProtoReadSupport.setProtobufClass(readUsingMR.getConfiguration(), customClass);
     List<Message> result = readUsingMR.read(outputPath);
 
-    assertEquals(result.get(0), intMin);
-    assertEquals(result.get(1), uintMin);
-    assertEquals(result.get(2), uintMax);
+    assertThat(result.get(0)).isEqualTo(intMin);
+    assertThat(result.get(1)).isEqualTo(uintMin);
+    assertThat(result.get(2)).isEqualTo(uintMax);
   }
 
   /**

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoParquetWriterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoParquetWriterTest.java
@@ -20,7 +20,7 @@ package org.apache.parquet.proto;
 
 import static org.apache.parquet.proto.TestUtils.readMessages;
 import static org.apache.parquet.proto.TestUtils.someTemporaryFilePath;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.DynamicMessage;
@@ -54,8 +54,8 @@ public class ProtoParquetWriterTest {
     List<TestProto3.InnerMessage> gotBack = TestUtils.readMessages(file, TestProto3.InnerMessage.class);
 
     TestProto3.InnerMessage getFirst = gotBack.get(0);
-    assertEquals(getFirst.getOne(), "oneValue");
-    assertEquals(getFirst.getTwo(), "");
-    assertEquals(getFirst.getThree(), "");
+    assertThat(getFirst.getOne()).isEqualTo("oneValue");
+    assertThat(getFirst.getTwo()).isEqualTo("");
+    assertThat(getFirst.getThree()).isEqualTo("");
   }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoRecordConverterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoRecordConverterTest.java
@@ -20,10 +20,8 @@ package org.apache.parquet.proto;
 
 import static org.apache.parquet.proto.TestUtils.testData;
 import static org.apache.parquet.proto.test.TestProtobuf.SchemaConverterAllDatatypes;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import com.google.protobuf.ByteString;
 import java.util.List;
@@ -65,25 +63,25 @@ public class ProtoRecordConverterTest {
 
     // data are fully checked in testData function. Lets do one more check.
     SchemaConverterAllDatatypes o = result.get(0);
-    assertEquals("Good Will Hunting", o.getOptionalString());
+    assertThat(o.getOptionalString()).isEqualTo("Good Will Hunting");
 
-    assertEquals(true, o.getOptionalBool());
-    assertEquals(ByteString.copyFrom("someText", "UTF-8"), o.getOptionalBytes());
-    assertEquals(0.577, o.getOptionalDouble(), 0.00001);
-    assertEquals(3.1415f, o.getOptionalFloat(), 0.00001);
-    assertEquals(SchemaConverterAllDatatypes.TestEnum.FIRST, o.getOptionalEnum());
-    assertEquals(1000 * 1000 * 1, o.getOptionalFixed32());
-    assertEquals(1000 * 1000 * 1000 * 2, o.getOptionalFixed64());
-    assertEquals(1000 * 1000 * 3, o.getOptionalInt32());
-    assertEquals(1000L * 1000 * 1000 * 4, o.getOptionalInt64());
-    assertEquals(1000 * 1000 * 5, o.getOptionalSFixed32());
-    assertEquals(1000L * 1000 * 1000 * 6, o.getOptionalSFixed64());
-    assertEquals(1000 * 1000 * 56, o.getOptionalSInt32());
-    assertEquals(1000L * 1000 * 1000 * 7, o.getOptionalSInt64());
-    assertEquals(1000 * 1000 * 8, o.getOptionalUInt32());
-    assertEquals(1000L * 1000 * 1000 * 9, o.getOptionalUInt64());
-    assertEquals(1984, o.getOptionalMessage().getSomeId());
-    assertEquals(1492, o.getPbGroup().getGroupInt());
+    assertThat(o.getOptionalBool()).isTrue();
+    assertThat(o.getOptionalBytes()).isEqualTo(ByteString.copyFrom("someText", "UTF-8"));
+    assertThat(o.getOptionalDouble()).isCloseTo(0.577, offset(0.00001));
+    assertThat(o.getOptionalFloat()).isCloseTo(3.1415f, offset(0.00001f));
+    assertThat(o.getOptionalEnum()).isEqualTo(SchemaConverterAllDatatypes.TestEnum.FIRST);
+    assertThat(o.getOptionalFixed32()).isEqualTo(1000 * 1000 * 1);
+    assertThat(o.getOptionalFixed64()).isEqualTo(1000 * 1000 * 1000 * 2);
+    assertThat(o.getOptionalInt32()).isEqualTo(1000 * 1000 * 3);
+    assertThat(o.getOptionalInt64()).isEqualTo(1000L * 1000 * 1000 * 4);
+    assertThat(o.getOptionalSFixed32()).isEqualTo(1000 * 1000 * 5);
+    assertThat(o.getOptionalSFixed64()).isEqualTo(1000L * 1000 * 1000 * 6);
+    assertThat(o.getOptionalSInt32()).isEqualTo(1000 * 1000 * 56);
+    assertThat(o.getOptionalSInt64()).isEqualTo(1000L * 1000 * 1000 * 7);
+    assertThat(o.getOptionalUInt32()).isEqualTo(1000 * 1000 * 8);
+    assertThat(o.getOptionalUInt64()).isEqualTo(1000L * 1000 * 1000 * 9);
+    assertThat(o.getOptionalMessage().getSomeId()).isEqualTo(1984);
+    assertThat(o.getPbGroup().getGroupInt()).isEqualTo(1492);
   }
 
   @Test
@@ -117,24 +115,24 @@ public class ProtoRecordConverterTest {
 
     // data are fully checked in testData function. Lets do one more check.
     TestProto3.SchemaConverterAllDatatypes o = result.get(0);
-    assertEquals("Good Will Hunting", o.getOptionalString());
+    assertThat(o.getOptionalString()).isEqualTo("Good Will Hunting");
 
-    assertEquals(true, o.getOptionalBool());
-    assertEquals(ByteString.copyFrom("someText", "UTF-8"), o.getOptionalBytes());
-    assertEquals(0.577, o.getOptionalDouble(), 0.00001);
-    assertEquals(3.1415f, o.getOptionalFloat(), 0.00001);
-    assertEquals(TestProto3.SchemaConverterAllDatatypes.TestEnum.FIRST, o.getOptionalEnum());
-    assertEquals(1000 * 1000 * 1, o.getOptionalFixed32());
-    assertEquals(1000 * 1000 * 1000 * 2, o.getOptionalFixed64());
-    assertEquals(1000 * 1000 * 3, o.getOptionalInt32());
-    assertEquals(1000L * 1000 * 1000 * 4, o.getOptionalInt64());
-    assertEquals(1000 * 1000 * 5, o.getOptionalSFixed32());
-    assertEquals(1000L * 1000 * 1000 * 6, o.getOptionalSFixed64());
-    assertEquals(1000 * 1000 * 56, o.getOptionalSInt32());
-    assertEquals(1000L * 1000 * 1000 * 7, o.getOptionalSInt64());
-    assertEquals(1000 * 1000 * 8, o.getOptionalUInt32());
-    assertEquals(1000L * 1000 * 1000 * 9, o.getOptionalUInt64());
-    assertEquals(1984, o.getOptionalMessage().getSomeId());
+    assertThat(o.getOptionalBool()).isTrue();
+    assertThat(o.getOptionalBytes()).isEqualTo(ByteString.copyFrom("someText", "UTF-8"));
+    assertThat(o.getOptionalDouble()).isCloseTo(0.577, offset(0.00001));
+    assertThat(o.getOptionalFloat()).isCloseTo(3.1415f, offset(0.00001f));
+    assertThat(o.getOptionalEnum()).isEqualTo(TestProto3.SchemaConverterAllDatatypes.TestEnum.FIRST);
+    assertThat(o.getOptionalFixed32()).isEqualTo(1000 * 1000 * 1);
+    assertThat(o.getOptionalFixed64()).isEqualTo(1000 * 1000 * 1000 * 2);
+    assertThat(o.getOptionalInt32()).isEqualTo(1000 * 1000 * 3);
+    assertThat(o.getOptionalInt64()).isEqualTo(1000L * 1000 * 1000 * 4);
+    assertThat(o.getOptionalSFixed32()).isEqualTo(1000 * 1000 * 5);
+    assertThat(o.getOptionalSFixed64()).isEqualTo(1000L * 1000 * 1000 * 6);
+    assertThat(o.getOptionalSInt32()).isEqualTo(1000 * 1000 * 56);
+    assertThat(o.getOptionalSInt64()).isEqualTo(1000L * 1000 * 1000 * 7);
+    assertThat(o.getOptionalUInt32()).isEqualTo(1000 * 1000 * 8);
+    assertThat(o.getOptionalUInt64()).isEqualTo(1000L * 1000 * 1000 * 9);
+    assertThat(o.getOptionalMessage().getSomeId()).isEqualTo(1984);
   }
 
   @Test
@@ -170,8 +168,8 @@ public class ProtoRecordConverterTest {
     result = testData(input);
 
     // data are fully checked in testData function. Lets do one more check.
-    assertEquals("Good Will Hunting 0", result.get(0).getOptionalString());
-    assertEquals("Good Will Hunting 90", result.get(90).getOptionalString());
+    assertThat(result.get(0).getOptionalString()).isEqualTo("Good Will Hunting 0");
+    assertThat(result.get(90).getOptionalString()).isEqualTo("Good Will Hunting 90");
   }
 
   @Test
@@ -206,8 +204,8 @@ public class ProtoRecordConverterTest {
     result = testData(input);
 
     // data are fully checked in testData function. Lets do one more check.
-    assertEquals("Good Will Hunting 0", result.get(0).getOptionalString());
-    assertEquals("Good Will Hunting 90", result.get(90).getOptionalString());
+    assertThat(result.get(0).getOptionalString()).isEqualTo("Good Will Hunting 0");
+    assertThat(result.get(90).getOptionalString()).isEqualTo("Good Will Hunting 90");
   }
 
   @Test
@@ -217,9 +215,9 @@ public class ProtoRecordConverterTest {
 
     List<SchemaConverterAllDatatypes> result = testData(data.build());
     SchemaConverterAllDatatypes message = result.get(0);
-    assertEquals("", message.getOptionalString());
-    assertEquals(false, message.getOptionalBool());
-    assertEquals(0, message.getOptionalFixed32());
+    assertThat(message.getOptionalString()).isEqualTo("");
+    assertThat(message.getOptionalBool()).isFalse();
+    assertThat(message.getOptionalFixed32()).isEqualTo(0);
   }
 
   @Test
@@ -229,9 +227,9 @@ public class ProtoRecordConverterTest {
 
     List<TestProto3.SchemaConverterAllDatatypes> result = testData(data.build());
     TestProto3.SchemaConverterAllDatatypes message = result.get(0);
-    assertEquals("", message.getOptionalString());
-    assertEquals(false, message.getOptionalBool());
-    assertEquals(0, message.getOptionalFixed32());
+    assertThat(message.getOptionalString()).isEqualTo("");
+    assertThat(message.getOptionalBool()).isFalse();
+    assertThat(message.getOptionalFixed32()).isEqualTo(0);
   }
 
   @Test
@@ -243,23 +241,23 @@ public class ProtoRecordConverterTest {
 
     TestProtobuf.TopMessage result = testData(top.build()).get(0);
 
-    assertEquals(3, result.getInnerCount());
+    assertThat(result.getInnerCount()).isEqualTo(3);
 
     TestProtobuf.InnerMessage first = result.getInner(0);
     TestProtobuf.InnerMessage second = result.getInner(1);
     TestProtobuf.InnerMessage third = result.getInner(2);
 
-    assertEquals("First inner", first.getOne());
-    assertFalse(first.hasTwo());
-    assertFalse(first.hasThree());
+    assertThat(first.getOne()).isEqualTo("First inner");
+    assertThat(first.hasTwo()).isFalse();
+    assertThat(first.hasThree()).isFalse();
 
-    assertEquals("Second inner", second.getTwo());
-    assertFalse(second.hasOne());
-    assertFalse(second.hasThree());
+    assertThat(second.getTwo()).isEqualTo("Second inner");
+    assertThat(second.hasOne()).isFalse();
+    assertThat(second.hasThree()).isFalse();
 
-    assertEquals("Third inner", third.getThree());
-    assertFalse(third.hasOne());
-    assertFalse(third.hasTwo());
+    assertThat(third.getThree()).isEqualTo("Third inner");
+    assertThat(third.hasOne()).isFalse();
+    assertThat(third.hasTwo()).isFalse();
   }
 
   @Test
@@ -271,23 +269,23 @@ public class ProtoRecordConverterTest {
 
     TestProto3.TopMessage result = testData(top.build()).get(0);
 
-    assertEquals(3, result.getInnerCount());
+    assertThat(result.getInnerCount()).isEqualTo(3);
 
     TestProto3.InnerMessage first = result.getInner(0);
     TestProto3.InnerMessage second = result.getInner(1);
     TestProto3.InnerMessage third = result.getInner(2);
 
-    assertEquals("First inner", first.getOne());
-    assertTrue(first.getTwo().isEmpty());
-    assertTrue(first.getThree().isEmpty());
+    assertThat(first.getOne()).isEqualTo("First inner");
+    assertThat(first.getTwo()).isEmpty();
+    assertThat(first.getThree()).isEmpty();
 
-    assertEquals("Second inner", second.getTwo());
-    assertTrue(second.getOne().isEmpty());
-    assertTrue(second.getThree().isEmpty());
+    assertThat(second.getTwo()).isEqualTo("Second inner");
+    assertThat(second.getOne()).isEmpty();
+    assertThat(second.getThree()).isEmpty();
 
-    assertEquals("Third inner", third.getThree());
-    assertTrue(third.getOne().isEmpty());
-    assertTrue(third.getTwo().isEmpty());
+    assertThat(third.getThree()).isEqualTo("Third inner");
+    assertThat(third.getOne()).isEmpty();
+    assertThat(third.getTwo()).isEmpty();
   }
 
   @Test
@@ -300,11 +298,11 @@ public class ProtoRecordConverterTest {
 
     TestProtobuf.RepeatedIntMessage result = testData(top.build()).get(0);
 
-    assertEquals(3, result.getRepeatedIntCount());
+    assertThat(result.getRepeatedIntCount()).isEqualTo(3);
 
-    assertEquals(1, result.getRepeatedInt(0));
-    assertEquals(2, result.getRepeatedInt(1));
-    assertEquals(3, result.getRepeatedInt(2));
+    assertThat(result.getRepeatedInt(0)).isEqualTo(1);
+    assertThat(result.getRepeatedInt(1)).isEqualTo(2);
+    assertThat(result.getRepeatedInt(2)).isEqualTo(3);
   }
 
   @Test
@@ -317,11 +315,11 @@ public class ProtoRecordConverterTest {
 
     TestProto3.RepeatedIntMessage result = testData(top.build()).get(0);
 
-    assertEquals(3, result.getRepeatedIntCount());
+    assertThat(result.getRepeatedIntCount()).isEqualTo(3);
 
-    assertEquals(1, result.getRepeatedInt(0));
-    assertEquals(2, result.getRepeatedInt(1));
-    assertEquals(3, result.getRepeatedInt(2));
+    assertThat(result.getRepeatedInt(0)).isEqualTo(1);
+    assertThat(result.getRepeatedInt(1)).isEqualTo(2);
+    assertThat(result.getRepeatedInt(2)).isEqualTo(3);
   }
 
   @Test
@@ -356,7 +354,7 @@ public class ProtoRecordConverterTest {
 
     // data are fully checked in testData function. Lets do one more check.
     TestProto3.SchemaConverterAllDatatypes o = result.get(0);
-    assertSame(o.getOptionalEnum(), TestProto3.SchemaConverterAllDatatypes.TestEnum.UNRECOGNIZED);
-    assertEquals(o.getOptionalEnumValue(), 42);
+    assertThat(o.getOptionalEnum()).isSameAs(TestProto3.SchemaConverterAllDatatypes.TestEnum.UNRECOGNIZED);
+    assertThat(o.getOptionalEnumValue()).isEqualTo(42);
   }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.proto;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Joiner;
 import com.google.protobuf.Message;
@@ -56,7 +56,7 @@ public class ProtoSchemaConverterTest {
       Class<? extends Message> pbClass, String parquetSchemaString, ProtoSchemaConverter converter) {
     MessageType schema = converter.convert(pbClass);
     MessageType expectedMT = MessageTypeParser.parseMessageType(parquetSchemaString);
-    assertEquals(expectedMT.toString(), schema.toString());
+    assertThat(schema).asString().isEqualTo(expectedMT.toString());
   }
 
   private void testConversion(
@@ -588,16 +588,16 @@ public class ProtoSchemaConverterTest {
     for (int i = 0; i < 10; ++i) {
       MessageType deepSchema = new ProtoSchemaConverter(true, i, false).convert(Trees.WideTree.class);
       // 3, 5, 7, 9, 11, 13, 15, 17, 19, 21
-      assertEquals(2 * i + 3, deepSchema.getPaths().size());
+      assertThat(deepSchema.getPaths()).hasSize(2 * i + 3);
 
       deepSchema = new ProtoSchemaConverter(true, i, false).convert(Trees.BinaryTree.class);
       // 4, 10, 22, 46, 94, 190, 382, 766, 1534, 3070
-      assertEquals(expectedBinaryTreeSize, deepSchema.getPaths().size());
+      assertThat(deepSchema.getPaths()).hasSize((int) expectedBinaryTreeSize);
       expectedBinaryTreeSize = 2 * expectedBinaryTreeSize + 2;
 
       deepSchema = new ProtoSchemaConverter(true, i, false).convert(Struct.class);
       // 7, 18, 40, 84, 172, 348, 700, 1404, 2812, 5628
-      assertEquals(expectedStructSize, deepSchema.getPaths().size());
+      assertThat(deepSchema.getPaths()).hasSize((int) expectedStructSize);
       expectedStructSize = 2 * expectedStructSize + 4;
     }
   }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaEvolutionTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaEvolutionTest.java
@@ -20,8 +20,7 @@ package org.apache.parquet.proto;
 
 import static org.apache.parquet.proto.TestUtils.readMessages;
 import static org.apache.parquet.proto.TestUtils.writeMessages;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
@@ -47,8 +46,8 @@ public class ProtoSchemaEvolutionTest {
         .build();
     Path file = writeMessages(dataV2);
     List<TestProto3SchemaV1.MessageSchema> messagesV1 = readMessages(file, TestProto3SchemaV1.MessageSchema.class);
-    assertEquals(messagesV1.size(), 1);
-    assertEquals(messagesV1.get(0).getOptionalLabelNumberPairValue(), 2);
+    assertThat(messagesV1).hasSize(1);
+    assertThat(messagesV1.get(0).getOptionalLabelNumberPairValue()).isEqualTo(2);
   }
 
   /**
@@ -63,10 +62,9 @@ public class ProtoSchemaEvolutionTest {
         .build();
     Path file = writeMessages(dataV1WithEnumValueFromV2);
     List<TestProto3SchemaV2.MessageSchema> messagesV2 = readMessages(file, TestProto3SchemaV2.MessageSchema.class);
-    assertEquals(messagesV2.size(), 1);
-    assertSame(
-        messagesV2.get(0).getOptionalLabelNumberPair(),
-        TestProto3SchemaV2.MessageSchema.LabelNumberPair.SECOND);
+    assertThat(messagesV2).hasSize(1);
+    assertThat(messagesV2.get(0).getOptionalLabelNumberPair())
+        .isSameAs(TestProto3SchemaV2.MessageSchema.LabelNumberPair.SECOND);
   }
 
   /**
@@ -91,9 +89,9 @@ public class ProtoSchemaEvolutionTest {
     Path file = writeMessages(dataV3);
     List<TestProto3SchemaV1.MessageSchema> messagesV1 =
         readMessages(file, TestProto3SchemaV1.MessageSchema.class, true);
-    assertEquals(messagesV1.size(), 1);
-    assertEquals(messagesV1.get(0).getOptionalLabelNumberPairValue(), 2);
-    assertEquals(messagesV1.get(0).getOptionalString(), "string value");
+    assertThat(messagesV1).hasSize(1);
+    assertThat(messagesV1.get(0).getOptionalLabelNumberPairValue()).isEqualTo(2);
+    assertThat(messagesV1.get(0).getOptionalString()).isEqualTo("string value");
   }
 
   /**
@@ -107,10 +105,9 @@ public class ProtoSchemaEvolutionTest {
         .build();
     Path file = writeMessages(dataV1WithEnumValueFromV1);
     List<TestProto3SchemaV3.MessageSchema> messagesV3 = readMessages(file, TestProto3SchemaV3.MessageSchema.class);
-    assertEquals(messagesV3.size(), 1);
-    assertSame(
-        messagesV3.get(0).getOptionalLabelNumberPair(),
-        TestProto3SchemaV3.MessageSchema.LabelNumberPair.SECOND);
+    assertThat(messagesV3).hasSize(1);
+    assertThat(messagesV3.get(0).getOptionalLabelNumberPair())
+        .isSameAs(TestProto3SchemaV3.MessageSchema.LabelNumberPair.SECOND);
   }
 
   /**
@@ -134,18 +131,19 @@ public class ProtoSchemaEvolutionTest {
     Path file = writeMessages(dataV3);
     List<TestProto3SchemaV3.MessageSchema> messagesV3 =
         readMessages(file, TestProto3SchemaV3.MessageSchema.class, false);
-    assertEquals(messagesV3.size(), 1);
-    assertEquals(messagesV3.get(0).getOptionalLabelNumberPairValue(), 2);
-    assertEquals(messagesV3.get(0).getOptionalString(), "string value");
-    assertEquals(messagesV3.get(0).getRepeatedDubMessageSchemaList().get(0).getOptionalFirstString(), "abc");
-    assertEquals(messagesV3.get(0).getRepeatedDubMessageSchemaList().get(0).getOptionalFirstInt32(0), 1);
-    assertEquals(
-        messagesV3
+    assertThat(messagesV3).hasSize(1);
+    assertThat(messagesV3.get(0).getOptionalLabelNumberPairValue()).isEqualTo(2);
+    assertThat(messagesV3.get(0).getOptionalString()).isEqualTo("string value");
+    assertThat(messagesV3.get(0).getRepeatedDubMessageSchemaList().get(0).getOptionalFirstString())
+        .isEqualTo("abc");
+    assertThat(messagesV3.get(0).getRepeatedDubMessageSchemaList().get(0).getOptionalFirstInt32(0))
+        .isEqualTo(1);
+    assertThat(messagesV3
             .get(0)
             .getRepeatedDubMessageSchemaList()
             .get(0)
             .getLevel2Schema()
-            .getOptionalValues(0),
-        "axc");
+            .getOptionalValues(0))
+        .isEqualTo("axc");
   }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
@@ -18,10 +18,9 @@
  */
 package org.apache.parquet.proto;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.data.Offset.offset;
 
 import com.google.protobuf.*;
 import com.google.protobuf.util.Timestamps;
@@ -1038,17 +1037,18 @@ public class ProtoWriteSupportTest {
 
     // First message
     TestProto3.OneOfTestMessage gotBackFirst = gotBack.get(0);
-    assertEquals(gotBackFirst.getSecond(), 99);
-    assertEquals(gotBackFirst.getTheOneofCase(), TestProto3.OneOfTestMessage.TheOneofCase.SECOND);
+    assertThat(gotBackFirst.getSecond()).isEqualTo(99);
+    assertThat(gotBackFirst.getTheOneofCase()).isEqualTo(TestProto3.OneOfTestMessage.TheOneofCase.SECOND);
 
     // Second message with nothing set
     TestProto3.OneOfTestMessage gotBackSecond = gotBack.get(1);
-    assertEquals(gotBackSecond.getTheOneofCase(), TestProto3.OneOfTestMessage.TheOneofCase.THEONEOF_NOT_SET);
+    assertThat(gotBackSecond.getTheOneofCase())
+        .isEqualTo(TestProto3.OneOfTestMessage.TheOneofCase.THEONEOF_NOT_SET);
 
     // Third message with opposite field set
     TestProto3.OneOfTestMessage gotBackThird = gotBack.get(2);
-    assertEquals(gotBackThird.getFirst(), 42);
-    assertEquals(gotBackThird.getTheOneofCase(), TestProto3.OneOfTestMessage.TheOneofCase.FIRST);
+    assertThat(gotBackThird.getFirst()).isEqualTo(42);
+    assertThat(gotBackThird.getTheOneofCase()).isEqualTo(TestProto3.OneOfTestMessage.TheOneofCase.FIRST);
   }
 
   @Test
@@ -1295,9 +1295,9 @@ public class ProtoWriteSupportTest {
         TestUtils.readMessages(tmpFilePath, TestProto3.DateTimeMessage.class);
 
     TestProto3.DateTimeMessage gotBackFirst = gotBack.get(0);
-    assertEquals(timestamp, gotBackFirst.getTimestamp());
-    assertEquals(protoDate, gotBackFirst.getDate());
-    assertEquals(protoTime, gotBackFirst.getTime());
+    assertThat(gotBackFirst.getTimestamp()).isEqualTo(timestamp);
+    assertThat(gotBackFirst.getDate()).isEqualTo(protoDate);
+    assertThat(gotBackFirst.getTime()).isEqualTo(protoTime);
   }
 
   @Test
@@ -1347,17 +1347,15 @@ public class ProtoWriteSupportTest {
     List<TestProto3.WrappedMessage> gotBack = TestUtils.readMessages(tmpFilePath, TestProto3.WrappedMessage.class);
 
     TestProto3.WrappedMessage gotBackFirst = gotBack.get(0);
-    assertEquals(0.577, gotBackFirst.getWrappedDouble().getValue(), 1e-5);
-    assertEquals(3.1415f, gotBackFirst.getWrappedFloat().getValue(), 1e-5f);
-    assertEquals(1_000_000_000L * 4, gotBackFirst.getWrappedInt64().getValue());
-    assertEquals(1_000_000_000L * 9, gotBackFirst.getWrappedUInt64().getValue());
-    assertEquals(1_000_000 * 3, gotBackFirst.getWrappedInt32().getValue());
-    assertEquals(1_000_000 * 8, gotBackFirst.getWrappedUInt32().getValue());
-    assertEquals(BoolValue.of(true), gotBackFirst.getWrappedBool());
-    assertEquals("Good Will Hunting", gotBackFirst.getWrappedString().getValue());
-    assertEquals(
-        ByteString.copyFrom("someText", "UTF-8"),
-        gotBackFirst.getWrappedBytes().getValue());
+    assertThat(gotBackFirst.getWrappedDouble().getValue()).isCloseTo(0.577, offset(1e-5));
+    assertThat(gotBackFirst.getWrappedFloat().getValue()).isCloseTo(3.1415f, offset(1e-5f));
+    assertThat(gotBackFirst.getWrappedInt64().getValue()).isEqualTo(1_000_000_000L * 4);
+    assertThat(gotBackFirst.getWrappedUInt64().getValue()).isEqualTo(1_000_000_000L * 9);
+    assertThat(gotBackFirst.getWrappedInt32().getValue()).isEqualTo(1_000_000 * 3);
+    assertThat(gotBackFirst.getWrappedUInt32().getValue()).isEqualTo(1_000_000 * 8);
+    assertThat(gotBackFirst.getWrappedBool()).isEqualTo(BoolValue.of(true));
+    assertThat(gotBackFirst.getWrappedString().getValue()).isEqualTo("Good Will Hunting");
+    assertThat(gotBackFirst.getWrappedBytes().getValue()).isEqualTo(ByteString.copyFrom("someText", "UTF-8"));
   }
 
   @Test
@@ -1366,17 +1364,17 @@ public class ProtoWriteSupportTest {
     TestProto3.WrappedMessage msgMin = TestProto3.WrappedMessage.newBuilder()
         .setWrappedUInt32(UInt32Value.of(Integer.MIN_VALUE))
         .build();
-    assertEquals(TextFormat.shortDebugString(msgMin), "wrappedUInt32 { value: 2147483648 }");
+    assertThat(TextFormat.shortDebugString(msgMin)).isEqualTo("wrappedUInt32 { value: 2147483648 }");
 
     TestProto3.WrappedMessage msgMax = TestProto3.WrappedMessage.newBuilder()
         .setWrappedUInt32(UInt32Value.of(Integer.MAX_VALUE))
         .build();
-    assertEquals(TextFormat.shortDebugString(msgMax), "wrappedUInt32 { value: 2147483647 }");
+    assertThat(TextFormat.shortDebugString(msgMax)).isEqualTo("wrappedUInt32 { value: 2147483647 }");
 
     TestProto3.WrappedMessage msgMinusOne = TestProto3.WrappedMessage.newBuilder()
         .setWrappedUInt32(UInt32Value.of(-1))
         .build();
-    assertEquals(TextFormat.shortDebugString(msgMinusOne), "wrappedUInt32 { value: 4294967295 }");
+    assertThat(TextFormat.shortDebugString(msgMinusOne)).isEqualTo("wrappedUInt32 { value: 4294967295 }");
 
     Path tmpFilePath = TestUtils.someTemporaryFilePath();
     ParquetWriter<MessageOrBuilder> writer = ProtoParquetWriter.<MessageOrBuilder>builder(tmpFilePath)
@@ -1389,9 +1387,9 @@ public class ProtoWriteSupportTest {
     writer.close();
     List<TestProto3.WrappedMessage> gotBack = TestUtils.readMessages(tmpFilePath, TestProto3.WrappedMessage.class);
 
-    assertEquals(msgMin, gotBack.get(0));
-    assertEquals(msgMax, gotBack.get(1));
-    assertEquals(msgMinusOne, gotBack.get(2));
+    assertThat(gotBack.get(0)).isEqualTo(msgMin);
+    assertThat(gotBack.get(1)).isEqualTo(msgMax);
+    assertThat(gotBack.get(2)).isEqualTo(msgMinusOne);
   }
 
   @Test
@@ -1412,18 +1410,18 @@ public class ProtoWriteSupportTest {
     List<TestProto3.WrappedMessage> gotBack = TestUtils.readMessages(tmpFilePath, TestProto3.WrappedMessage.class);
 
     TestProto3.WrappedMessage gotBackFirst = gotBack.get(0);
-    assertFalse(gotBackFirst.hasWrappedDouble());
-    assertEquals(3.1415f, gotBackFirst.getWrappedFloat().getValue(), 1e-5f);
+    assertThat(gotBackFirst.hasWrappedDouble()).isFalse();
+    assertThat(gotBackFirst.getWrappedFloat().getValue()).isCloseTo(3.1415f, offset(1e-5f));
 
     // double-check that nulls are honored
-    assertTrue(gotBackFirst.hasWrappedFloat());
-    assertFalse(gotBackFirst.hasWrappedInt64());
-    assertFalse(gotBackFirst.hasWrappedUInt64());
-    assertTrue(gotBackFirst.hasWrappedInt32());
-    assertFalse(gotBackFirst.hasWrappedUInt32());
-    assertEquals(0, gotBackFirst.getWrappedUInt32().getValue());
-    assertFalse(gotBackFirst.hasWrappedBool());
-    assertEquals("Good Will Hunting", gotBackFirst.getWrappedString().getValue());
-    assertFalse(gotBackFirst.hasWrappedBytes());
+    assertThat(gotBackFirst.hasWrappedFloat()).isTrue();
+    assertThat(gotBackFirst.hasWrappedInt64()).isFalse();
+    assertThat(gotBackFirst.hasWrappedUInt64()).isFalse();
+    assertThat(gotBackFirst.hasWrappedInt32()).isTrue();
+    assertThat(gotBackFirst.hasWrappedUInt32()).isFalse();
+    assertThat(gotBackFirst.getWrappedUInt32().getValue()).isEqualTo(0);
+    assertThat(gotBackFirst.hasWrappedBool()).isFalse();
+    assertThat(gotBackFirst.getWrappedString().getValue()).isEqualTo("Good Will Hunting");
+    assertThat(gotBackFirst.hasWrappedBytes()).isFalse();
   }
 }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/TestUtils.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/TestUtils.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.proto;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Switching assertions from JUnit4-style Assert to AssertJ makes code easier to read and debug when tests fail.

### What changes are included in this PR?
This updates parquet-plugins / parquet-protobuf tests to use AssertJ checks, which provide more fluent assertions and more detailed information when assertions fails on CI.

The changes in this PR were done with the help of Claude but I manually reviewed every single LOC

### Are these changes tested?
yes, existing tests

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
