### PR TITLE
GH-3652: Use assertThat checks in parquet-avro tests

### DIFF
--- a/parquet-avro/src/test/java/org/apache/parquet/avro/AvroTestUtil.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/AvroTestUtil.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
@@ -34,7 +36,6 @@ import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.variant.Variant;
-import org.junit.Assert;
 import org.junit.rules.TemporaryFolder;
 
 public class AvroTestUtil {
@@ -111,7 +112,7 @@ public class AvroTestUtil {
   public static <D> File write(TemporaryFolder temp, Configuration conf, GenericData model, Schema schema, D... data)
       throws IOException {
     File file = temp.newFile();
-    Assert.assertTrue(file.delete());
+    assertThat(file.delete()).isTrue();
 
     try (ParquetWriter<D> writer = AvroParquetWriter.<D>builder(new Path(file.toString()))
         .withDataModel(model)
@@ -136,30 +137,30 @@ public class AvroTestUtil {
    * E.g. values in an object may be ordered differently in the binary.
    */
   static void assertEquivalent(Variant expected, Variant actual) {
-    Assert.assertEquals(expected.getType(), actual.getType());
+    assertThat(actual.getType()).isEqualTo(expected.getType());
     switch (expected.getType()) {
       case STRING:
         // Short strings may use the compact or extended representation.
-        Assert.assertEquals(expected.getString(), actual.getString());
+        assertThat(actual.getString()).isEqualTo(expected.getString());
         break;
       case ARRAY:
-        Assert.assertEquals(expected.numArrayElements(), actual.numArrayElements());
+        assertThat(actual.numArrayElements()).isEqualTo(expected.numArrayElements());
         for (int i = 0; i < expected.numArrayElements(); ++i) {
           assertEquivalent(expected.getElementAtIndex(i), actual.getElementAtIndex(i));
         }
         break;
       case OBJECT:
-        Assert.assertEquals(expected.numObjectElements(), actual.numObjectElements());
+        assertThat(actual.numObjectElements()).isEqualTo(expected.numObjectElements());
         for (int i = 0; i < expected.numObjectElements(); ++i) {
           Variant.ObjectField expectedField = expected.getFieldAtIndex(i);
           Variant.ObjectField actualField = actual.getFieldAtIndex(i);
-          Assert.assertEquals(expectedField.key, actualField.key);
+          assertThat(actualField.key).isEqualTo(expectedField.key);
           assertEquivalent(expectedField.value, actualField.value);
         }
         break;
       default:
         // All other types have a single representation, and must be bit-for-bit identical.
-        Assert.assertEquals(expected.getValueBuffer(), actual.getValueBuffer());
+        assertThat(actual.getValueBuffer()).isEqualTo(expected.getValueBuffer());
     }
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestArrayCompatibility.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestArrayCompatibility.java
@@ -26,6 +26,8 @@ import static org.apache.parquet.avro.AvroTestUtil.optional;
 import static org.apache.parquet.avro.AvroTestUtil.optionalField;
 import static org.apache.parquet.avro.AvroTestUtil.primitive;
 import static org.apache.parquet.avro.AvroTestUtil.record;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -41,7 +43,6 @@ import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1046,10 +1047,9 @@ public class TestArrayCompatibility extends DirectWriterTest {
     final MessageType fileSchema;
     try (ParquetFileReader reader = ParquetFileReader.open(new Configuration(), test)) {
       fileSchema = reader.getFileMetaData().getSchema();
-      Assert.assertEquals(
-          "Converted schema should assume 2-layer structure",
-          oldSchema,
-          new AvroSchemaConverter(OLD_BEHAVIOR_CONF).convert(fileSchema));
+      assertThat(new AvroSchemaConverter(OLD_BEHAVIOR_CONF).convert(fileSchema))
+          .as("Converted schema should assume 2-layer structure")
+          .isEqualTo(oldSchema);
     }
 
     // both should default to the 2-layer structure
@@ -1066,10 +1066,9 @@ public class TestArrayCompatibility extends DirectWriterTest {
             instance(structWithElementField, "element", 34.0F)));
 
     // check the schema
-    Assert.assertEquals(
-        "Converted schema should assume 3-layer structure",
-        newSchema,
-        new AvroSchemaConverter(NEW_BEHAVIOR_CONF).convert(fileSchema));
+    assertThat(new AvroSchemaConverter(NEW_BEHAVIOR_CONF).convert(fileSchema))
+        .as("Converted schema should assume 3-layer structure")
+        .isEqualTo(newSchema);
     assertReaderContains(newBehaviorReader(test), newSchema, newRecord);
 
     // check that this works with compatible nested schemas
@@ -1118,9 +1117,10 @@ public class TestArrayCompatibility extends DirectWriterTest {
         + "}");
     Schema avroSchema = new AvroSchemaConverter().convert(parquetSchema);
 
-    Assert.assertTrue(AvroRecordConverter.isElementType(
-        parquetSchema.getType("list_field").asGroupType().getType("list_field_tuple"),
-        avroSchema.getFields().get(0).schema()));
+    assertThat(AvroRecordConverter.isElementType(
+            parquetSchema.getType("list_field").asGroupType().getType("list_field_tuple"),
+            avroSchema.getFields().get(0).schema()))
+        .isTrue();
 
     // Test `array` style naming
     parquetSchema = MessageTypeParser.parseMessageType("message SchemaWithList {\n"
@@ -1132,9 +1132,10 @@ public class TestArrayCompatibility extends DirectWriterTest {
         + "}");
     avroSchema = new AvroSchemaConverter().convert(parquetSchema);
 
-    Assert.assertTrue(AvroRecordConverter.isElementType(
-        parquetSchema.getType("list_field"),
-        avroSchema.getFields().get(0).schema()));
+    assertThat(AvroRecordConverter.isElementType(
+            parquetSchema.getType("list_field"),
+            avroSchema.getFields().get(0).schema()))
+        .isTrue();
   }
 
   @Test
@@ -1150,10 +1151,12 @@ public class TestArrayCompatibility extends DirectWriterTest {
         + "  }\n"
         + "}");
     Schema avroSchema = new AvroSchemaConverter(configuration).convert(parquetSchema);
-    Assert.assertTrue(AvroRecordConverter.isElementType(
-        parquetSchema.getType("list").asGroupType().getType("list"),
-        AvroSchemaConverter.getNonNull(avroSchema.getFields().get(0).schema())
-            .getElementType()));
+    assertThat(AvroRecordConverter.isElementType(
+            parquetSchema.getType("list").asGroupType().getType("list"),
+            AvroSchemaConverter.getNonNull(
+                    avroSchema.getFields().get(0).schema())
+                .getElementType()))
+        .isTrue();
   }
 
   @Test
@@ -1168,9 +1171,10 @@ public class TestArrayCompatibility extends DirectWriterTest {
         + "}");
     Schema avroSchema = new AvroSchemaConverter().convert(parquetSchema);
 
-    Assert.assertTrue(AvroRecordConverter.isElementType(
-        parquetSchema.getType("list_field").asGroupType().getType("list_field_tuple"),
-        avroSchema.getFields().get(0).schema()));
+    assertThat(AvroRecordConverter.isElementType(
+            parquetSchema.getType("list_field").asGroupType().getType("list_field_tuple"),
+            avroSchema.getFields().get(0).schema()))
+        .isTrue();
 
     // Test `array` style naming
     parquetSchema = MessageTypeParser.parseMessageType("message SchemaWithList {\n"
@@ -1182,9 +1186,10 @@ public class TestArrayCompatibility extends DirectWriterTest {
         + "}");
     avroSchema = new AvroSchemaConverter().convert(parquetSchema);
 
-    Assert.assertTrue(AvroRecordConverter.isElementType(
-        parquetSchema.getType("list_field"),
-        avroSchema.getFields().get(0).schema()));
+    assertThat(AvroRecordConverter.isElementType(
+            parquetSchema.getType("list_field"),
+            avroSchema.getFields().get(0).schema()))
+        .isTrue();
   }
 
   @Test
@@ -1246,7 +1251,9 @@ public class TestArrayCompatibility extends DirectWriterTest {
     AvroReadSupport.setAvroReadSchema(oldConfWithSchema, newSchema);
 
     AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(oldConfWithSchema, test);
-    Assert.assertThrows(InvalidRecordException.class, reader::read);
+    assertThatThrownBy(reader::read)
+        .isInstanceOf(InvalidRecordException.class)
+        .hasMessage("Parquet/Avro schema mismatch. Avro field 'element' not found.");
   }
 
   public <T extends IndexedRecord> AvroParquetReader<T> oldBehaviorReader(Path path) throws IOException {
@@ -1275,11 +1282,14 @@ public class TestArrayCompatibility extends DirectWriterTest {
       AvroParquetReader<T> reader, Schema expectedSchema, T... expectedRecords) throws IOException {
     for (T expectedRecord : expectedRecords) {
       T actualRecord = reader.read();
-      Assert.assertEquals("Should match expected schema", expectedSchema, actualRecord.getSchema());
-      Assert.assertEquals("Should match the expected record", expectedRecord, actualRecord);
+      assertThat(actualRecord.getSchema())
+          .as("Should match expected schema")
+          .isEqualTo(expectedSchema);
+      assertThat(actualRecord).as("Should match the expected record").isEqualTo(expectedRecord);
     }
-    Assert.assertNull(
-        "Should only contain " + expectedRecords.length + " record" + (expectedRecords.length == 1 ? "" : "s"),
-        reader.read());
+    assertThat(reader.read())
+        .as("Should only contain " + expectedRecords.length + " record"
+            + (expectedRecords.length == 1 ? "" : "s"))
+        .isNull();
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroDataSupplier.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroDataSupplier.java
@@ -18,9 +18,10 @@
  */
 package org.apache.parquet.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestAvroDataSupplier {
@@ -36,9 +37,8 @@ public class TestAvroDataSupplier {
   public void testSetSupplierMethod() {
     Configuration conf = new Configuration(false);
     AvroReadSupport.setAvroDataSupplier(conf, GenericDataSupplier.class);
-    Assert.assertEquals(
-        "Should contain the class name",
-        "org.apache.parquet.avro.TestAvroDataSupplier$GenericDataSupplier",
-        conf.get(AvroReadSupport.AVRO_DATA_SUPPLIER));
+    assertThat(conf.get(AvroReadSupport.AVRO_DATA_SUPPLIER))
+        .as("Should contain the class name")
+        .isEqualTo("org.apache.parquet.avro.TestAvroDataSupplier$GenericDataSupplier");
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
@@ -18,10 +18,7 @@
  */
 package org.apache.parquet.avro;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 
 import com.google.common.collect.Lists;
@@ -61,16 +58,16 @@ public class TestAvroRecordConverter {
 
     // Test that model is generated correctly
     Collection<Conversion<?>> conversions = model.getConversions();
-    assertEquals(conversions.size(), 3);
-    assertNotNull(model.getConversionByClass(Instant.class));
-    assertNotNull(model.getConversionByClass(LocalDate.class));
-    assertNotNull(model.getConversionByClass(LocalTime.class));
+    assertThat(conversions).hasSize(3);
+    assertThat(model.getConversionByClass(Instant.class)).isNotNull();
+    assertThat(model.getConversionByClass(LocalDate.class)).isNotNull();
+    assertThat(model.getConversionByClass(LocalTime.class)).isNotNull();
   }
 
   @Test
   public void testModelForSpecificRecordWithoutLogicalTypes() {
     SpecificData model = AvroRecordConverter.getModelForSchema(Car.SCHEMA$);
-    assertTrue(model.getConversions().isEmpty());
+    assertThat(model.getConversions()).isEmpty();
   }
 
   @Test
@@ -83,7 +80,7 @@ public class TestAvroRecordConverter {
         Lists.newArrayList(new Schema.Field("strField", Schema.create(Schema.Type.STRING)))));
 
     // There is no class "someSchema" on the classpath, so should return null
-    assertNull(model);
+    assertThat(model).isNull();
   }
 
   // Test logical type support for older Avro versions
@@ -95,18 +92,18 @@ public class TestAvroRecordConverter {
     SpecificData model = AvroRecordConverter.getModelForSchema(LogicalTypesTestDeprecated.SCHEMA$);
     // Test that model is generated correctly
     Collection<Conversion<?>> conversions = model.getConversions();
-    assertEquals(3, conversions.size());
-    assertNotNull(model.getConversionByClass(Instant.class));
-    assertNotNull(model.getConversionByClass(LocalDate.class));
-    assertNotNull(model.getConversionByClass(LocalTime.class));
+    assertThat(conversions).hasSize(3);
+    assertThat(model.getConversionByClass(Instant.class)).isNotNull();
+    assertThat(model.getConversionByClass(LocalDate.class)).isNotNull();
+    assertThat(model.getConversionByClass(LocalTime.class)).isNotNull();
 
     // Test that model is generated correctly when record contains only nested logical types
     model = AvroRecordConverter.getModelForSchema(NestedOnlyLogicalTypesDeprecated.SCHEMA$);
     // Test that model is generated correctly
     conversions = model.getConversions();
-    assertEquals(2, conversions.size());
-    assertNotNull(model.getConversionByClass(LocalDate.class));
-    assertNotNull(model.getConversionByClass(LocalTime.class));
+    assertThat(conversions).hasSize(2);
+    assertThat(model.getConversionByClass(LocalDate.class)).isNotNull();
+    assertThat(model.getConversionByClass(LocalTime.class)).isNotNull();
   }
 
   @Test
@@ -117,10 +114,10 @@ public class TestAvroRecordConverter {
     final SpecificData model = AvroRecordConverter.getModelForSchema(LogicalTypesTestDeprecated.SCHEMA$);
     // Test that model is generated correctly
     Collection<Conversion<?>> conversions = model.getConversions();
-    assertEquals(conversions.size(), 3);
-    assertNotNull(model.getConversionByClass(Instant.class));
-    assertNotNull(model.getConversionByClass(LocalDate.class));
-    assertNotNull(model.getConversionByClass(LocalTime.class));
+    assertThat(conversions).hasSize(3);
+    assertThat(model.getConversionByClass(Instant.class)).isNotNull();
+    assertThat(model.getConversionByClass(LocalDate.class)).isNotNull();
+    assertThat(model.getConversionByClass(LocalTime.class)).isNotNull();
   }
 
   // Pseudo generated code with bug from avro compiler < 1.8

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -43,8 +43,8 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 
 import com.google.common.collect.ImmutableSet;
@@ -64,7 +64,6 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -130,6 +129,9 @@ public class TestAvroSchemaConverter {
       + "  required fixed_len_byte_array(1) myfixed;\n"
       + "}\n";
 
+  private static final String INT96_DEPRECATED_MESSAGE =
+      "INT96 is deprecated. As interim enable READ_INT96_AS_FIXED flag to read as byte array.";
+
   private void testAvroToParquetConversion(Schema avroSchema, String schemaString) throws Exception {
     testAvroToParquetConversion(new Configuration(false), avroSchema, schemaString);
   }
@@ -139,7 +141,10 @@ public class TestAvroSchemaConverter {
     AvroSchemaConverter avroSchemaConverter = new AvroSchemaConverter(conf);
     MessageType schema = avroSchemaConverter.convert(avroSchema);
     MessageType expectedMT = MessageTypeParser.parseMessageType(schemaString);
-    assertEquals("converting " + schema + " to " + schemaString, expectedMT.toString(), schema.toString());
+    assertThat(schema)
+        .as("converting " + schema + " to " + schemaString)
+        .asString()
+        .isEqualTo(expectedMT.toString());
   }
 
   private void testParquetToAvroConversion(Schema avroSchema, String schemaString) throws Exception {
@@ -150,7 +155,10 @@ public class TestAvroSchemaConverter {
       throws Exception {
     AvroSchemaConverter avroSchemaConverter = new AvroSchemaConverter(conf);
     Schema schema = avroSchemaConverter.convert(MessageTypeParser.parseMessageType(schemaString));
-    assertEquals("converting " + schemaString + " to " + avroSchema, avroSchema.toString(), schema.toString());
+    assertThat(schema)
+        .as("converting " + schemaString + " to " + avroSchema)
+        .asString()
+        .isEqualTo(avroSchema.toString());
   }
 
   private void testRoundTripConversion(Schema avroSchema, String schemaString) throws Exception {
@@ -161,12 +169,15 @@ public class TestAvroSchemaConverter {
     AvroSchemaConverter avroSchemaConverter = new AvroSchemaConverter(conf);
     MessageType schema = avroSchemaConverter.convert(avroSchema);
     MessageType expectedMT = MessageTypeParser.parseMessageType(schemaString);
-    assertEquals("converting " + schema + " to " + schemaString, expectedMT.toString(), schema.toString());
+    assertThat(schema)
+        .as("converting " + schema + " to " + schemaString)
+        .asString()
+        .isEqualTo(expectedMT.toString());
     Schema convertedAvroSchema = avroSchemaConverter.convert(expectedMT);
-    assertEquals(
-        "converting " + expectedMT + " to " + avroSchema.toString(true),
-        avroSchema.toString(),
-        convertedAvroSchema.toString());
+    assertThat(convertedAvroSchema)
+        .as("converting " + expectedMT + " to " + avroSchema.toString(true))
+        .asString()
+        .isEqualTo(avroSchema.toString());
   }
 
   @Test
@@ -595,10 +606,9 @@ public class TestAvroSchemaConverter {
     MessageType parquetSchemaWithInt96 =
         MessageTypeParser.parseMessageType("message myrecord {\n  required int96 int96_field;\n}\n");
 
-    assertThrows(
-        "INT96 is deprecated. As interim enable READ_INT96_AS_FIXED  flag to read as byte array.",
-        IllegalArgumentException.class,
-        () -> new AvroSchemaConverter().convert(parquetSchemaWithInt96));
+    assertThatThrownBy(() -> new AvroSchemaConverter().convert(parquetSchemaWithInt96))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(INT96_DEPRECATED_MESSAGE);
   }
 
   @Test
@@ -616,16 +626,16 @@ public class TestAvroSchemaConverter {
 
     String schemaString = avroSchema.toString(true);
 
-    Assert.assertTrue(
-        "First field should have full timestamp_1 definition",
-        schemaString.contains("\"name\" : \"timestamp_1\""));
-    Assert.assertTrue(
-        "Second field should have full timestamp_2 definition",
-        schemaString.contains("\"name\" : \"timestamp_2\""));
+    assertThat(schemaString)
+        .as("First field should have full timestamp_1 definition")
+        .contains("\"name\" : \"timestamp_1\"");
+    assertThat(schemaString)
+        .as("Second field should have full timestamp_2 definition")
+        .contains("\"name\" : \"timestamp_2\"");
 
-    Assert.assertFalse(
-        "Should not reference bare 'INT96' type anymore",
-        schemaString.contains("\"type\" : [ \"null\", \"INT96\" ]"));
+    assertThat(schemaString)
+        .as("Should not reference bare 'INT96' type anymore")
+        .doesNotContain("\"type\" : [ \"null\", \"INT96\" ]");
   }
 
   @Test
@@ -645,10 +655,11 @@ public class TestAvroSchemaConverter {
         type = new PrimitiveType(REQUIRED, primitive, "test", DATE);
       }
 
-      assertThrows(
-          "Should not allow TIME_MICROS with " + primitive,
-          IllegalArgumentException.class,
-          () -> new AvroSchemaConverter().convert(message(type)));
+      final String expectedMessage =
+          primitive == INT96 ? INT96_DEPRECATED_MESSAGE : "Date can only be used with an underlying int type";
+      assertThatThrownBy(() -> new AvroSchemaConverter().convert(message(type)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(expectedMessage);
     }
   }
 
@@ -670,10 +681,12 @@ public class TestAvroSchemaConverter {
         type = new PrimitiveType(REQUIRED, primitive, "test", TIME_MILLIS);
       }
 
-      assertThrows(
-          "Should not allow TIME_MICROS with " + primitive,
-          IllegalArgumentException.class,
-          () -> new AvroSchemaConverter().convert(message(type)));
+      final String expectedMessage = primitive == INT96
+          ? INT96_DEPRECATED_MESSAGE
+          : "Time (millis) can only be used with an underlying int type";
+      assertThatThrownBy(() -> new AvroSchemaConverter().convert(message(type)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(expectedMessage);
     }
   }
 
@@ -695,10 +708,12 @@ public class TestAvroSchemaConverter {
         type = new PrimitiveType(REQUIRED, primitive, "test", TIME_MICROS);
       }
 
-      assertThrows(
-          "Should not allow TIME_MICROS with " + primitive,
-          IllegalArgumentException.class,
-          () -> new AvroSchemaConverter().convert(message(type)));
+      final String expectedMessage = primitive == INT96
+          ? INT96_DEPRECATED_MESSAGE
+          : "Time (micros) can only be used with an underlying long type";
+      assertThatThrownBy(() -> new AvroSchemaConverter().convert(message(type)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(expectedMessage);
     }
   }
 
@@ -725,13 +740,12 @@ public class TestAvroSchemaConverter {
                   .named("timestamp_type"))
               .named("TestAvro"));
 
-      assertEquals(
-          avroVersion.matches("1\\.[789]\\.\\d+") ? "timestamp-millis" : "local-timestamp-millis",
-          converted
+      assertThat(converted
               .getField("timestamp_type")
               .schema()
               .getLogicalType()
-              .getName());
+              .getName())
+          .isEqualTo(avroVersion.matches("1\\.[789]\\.\\d+") ? "timestamp-millis" : "local-timestamp-millis");
     }
 
     for (PrimitiveTypeName primitive :
@@ -743,10 +757,12 @@ public class TestAvroSchemaConverter {
         type = new PrimitiveType(REQUIRED, primitive, "test", TIMESTAMP_MILLIS);
       }
 
-      assertThrows(
-          "Should not allow TIMESTAMP_MILLIS with " + primitive,
-          IllegalArgumentException.class,
-          () -> new AvroSchemaConverter().convert(message(type)));
+      final String expectedMessage = primitive == INT96
+          ? INT96_DEPRECATED_MESSAGE
+          : "Timestamp (millis) can only be used with an underlying long type";
+      assertThatThrownBy(() -> new AvroSchemaConverter().convert(message(type)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(expectedMessage);
     }
   }
 
@@ -768,10 +784,12 @@ public class TestAvroSchemaConverter {
         type = new PrimitiveType(REQUIRED, primitive, "test", TIMESTAMP_MILLIS);
       }
 
-      assertThrows(
-          "Should not allow TIMESTAMP_MILLIS with " + primitive,
-          IllegalArgumentException.class,
-          () -> new AvroSchemaConverter().convert(message(type)));
+      final String expectedMessage = primitive == INT96
+          ? INT96_DEPRECATED_MESSAGE
+          : "Timestamp (millis) can only be used with an underlying long type";
+      assertThatThrownBy(() -> new AvroSchemaConverter().convert(message(type)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(expectedMessage);
     }
   }
 
@@ -793,10 +811,12 @@ public class TestAvroSchemaConverter {
         type = new PrimitiveType(REQUIRED, primitive, "test", TIMESTAMP_MICROS);
       }
 
-      assertThrows(
-          "Should not allow TIMESTAMP_MICROS with " + primitive,
-          IllegalArgumentException.class,
-          () -> new AvroSchemaConverter().convert(message(type)));
+      final String expectedMessage = primitive == INT96
+          ? INT96_DEPRECATED_MESSAGE
+          : "Timestamp (micros) can only be used with an underlying long type";
+      assertThatThrownBy(() -> new AvroSchemaConverter().convert(message(type)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(expectedMessage);
     }
 
     // Test that conversions for timestamp types only use APIs that are available in the user's Avro version
@@ -813,13 +833,12 @@ public class TestAvroSchemaConverter {
                   .named("timestamp_type"))
               .named("TestAvro"));
 
-      assertEquals(
-          avroVersion.matches("1\\.[789]\\.\\d+") ? "timestamp-micros" : "local-timestamp-micros",
-          converted
+      assertThat(converted
               .getField("timestamp_type")
               .schema()
               .getLogicalType()
-              .getName());
+              .getName())
+          .isEqualTo(avroVersion.matches("1\\.[789]\\.\\d+") ? "timestamp-micros" : "local-timestamp-micros");
     }
   }
 
@@ -841,10 +860,12 @@ public class TestAvroSchemaConverter {
         type = new PrimitiveType(REQUIRED, primitive, "test", TIMESTAMP_MICROS);
       }
 
-      assertThrows(
-          "Should not allow TIMESTAMP_MICROS with " + primitive,
-          IllegalArgumentException.class,
-          () -> new AvroSchemaConverter().convert(message(type)));
+      final String expectedMessage = primitive == INT96
+          ? INT96_DEPRECATED_MESSAGE
+          : "Timestamp (micros) can only be used with an underlying long type";
+      assertThatThrownBy(() -> new AvroSchemaConverter().convert(message(type)))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage(expectedMessage);
     }
   }
 
@@ -942,8 +963,7 @@ public class TestAvroSchemaConverter {
     testAvroToParquetConversion(fromAvro, parquet);
     testParquetToAvroConversion(toAvro, parquet);
 
-    assertEquals(
-        COMPATIBLE, checkReaderWriterCompatibility(fromAvro, toAvro).getType());
+    assertThat(checkReaderWriterCompatibility(fromAvro, toAvro).getType()).isEqualTo(COMPATIBLE);
   }
 
   @Test
@@ -992,10 +1012,9 @@ public class TestAvroSchemaConverter {
             + "}");
 
     conf.setStrings(WRITE_FIXED_AS_INT96, "onebytefixed");
-    assertThrows(
-        "Exception should be thrown for fixed types to be converted to INT96 where the size is not 12 bytes",
-        IllegalArgumentException.class,
-        () -> new AvroSchemaConverter(conf).convert(schema));
+    assertThatThrownBy(() -> new AvroSchemaConverter(conf).convert(schema))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("The size of the fixed type field onebytefixed must be 12 bytes for INT96 conversion");
   }
 
   @Test
@@ -1012,10 +1031,9 @@ public class TestAvroSchemaConverter {
 
     Schema recursiveSchema = new Schema.Parser().parse(recursiveSchemaJson);
 
-    assertThrows(
-        "Recursive Avro schema should throw UnsupportedOperationException for cycles",
-        UnsupportedOperationException.class,
-        () -> new AvroSchemaConverter().convert(recursiveSchema));
+    assertThatThrownBy(() -> new AvroSchemaConverter().convert(recursiveSchema))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Recursive Avro schemas are not supported by parquet-avro: Node");
   }
 
   @Test
@@ -1043,10 +1061,9 @@ public class TestAvroSchemaConverter {
 
     Schema issueSchema = new Schema.Parser().parse(issueSchemaJson);
 
-    assertThrows(
-        "Schema hould throw UnsupportedOperationException for cycles",
-        UnsupportedOperationException.class,
-        () -> new AvroSchemaConverter().convert(issueSchema));
+    assertThatThrownBy(() -> new AvroSchemaConverter().convert(issueSchema))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Recursive Avro schemas are not supported by parquet-avro: ObjStructAdd");
   }
 
   @Test
@@ -1059,10 +1076,9 @@ public class TestAvroSchemaConverter {
     Schema recursiveSchema = new Schema.Parser().parse(recursiveSchemaJson);
 
     // With our cycle detection fix, this should throw UnsupportedOperationException
-    assertThrows(
-        "Recursive schema should throw UnsupportedOperationException with clear error message",
-        UnsupportedOperationException.class,
-        () -> new AvroSchemaConverter().convert(recursiveSchema));
+    assertThatThrownBy(() -> new AvroSchemaConverter().convert(recursiveSchema))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Recursive Avro schemas are not supported by parquet-avro: TestRecord");
   }
 
   @Test
@@ -1074,8 +1090,10 @@ public class TestAvroSchemaConverter {
 
     AvroSchemaConverter converter = new AvroSchemaConverter();
     MessageType result = converter.convert(rootSchema);
-    Assert.assertNotNull("Non-recursive deep schema should convert successfully", result);
-    Assert.assertEquals("Root schema name should be preserved", "Root", result.getName());
+    assertThat(result)
+        .as("Non-recursive deep schema should convert successfully")
+        .isNotNull();
+    assertThat(result.getName()).as("Root schema name should be preserved").isEqualTo("Root");
   }
 
   public static Schema optional(Schema original) {
@@ -1084,26 +1102,5 @@ public class TestAvroSchemaConverter {
 
   public static MessageType message(PrimitiveType primitive) {
     return Types.buildMessage().addField(primitive).named("myrecord");
-  }
-
-  /**
-   * A convenience method to avoid a large number of @Test(expected=...) tests
-   *
-   * @param message  A String message to describe this assertion
-   * @param expected An Exception class that the Runnable should throw
-   * @param runnable A Runnable that is expected to throw the exception
-   */
-  public static void assertThrows(String message, Class<? extends Exception> expected, Runnable runnable) {
-    try {
-      runnable.run();
-      Assert.fail("No exception was thrown (" + message + "), expected: " + expected.getName());
-    } catch (Exception actual) {
-      try {
-        Assert.assertEquals(message, expected, actual.getClass());
-      } catch (AssertionError e) {
-        e.addSuppressed(actual);
-        throw e;
-      }
-    }
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroWriteSupport.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroWriteSupport.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.io.Resources;
 import java.io.IOException;
 import org.apache.avro.Schema;
@@ -27,7 +29,6 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestAvroWriteSupport {
@@ -46,8 +47,9 @@ public class TestAvroWriteSupport {
     int idx = actual.getFieldIndex(listField);
     ColumnDescriptor columnDescriptor = actual.getColumns().get(idx);
     PrimitiveType primitiveType = columnDescriptor.getPrimitiveType();
-    Assert.assertEquals(
-        "Confirm that old list type was not used", AvroWriteSupport.LIST_ELEMENT_NAME, primitiveType.getName());
+    assertThat(primitiveType.getName())
+        .as("Confirm that old list type was not used")
+        .isEqualTo(AvroWriteSupport.LIST_ELEMENT_NAME);
     // Default configuration
     configuration = new Configuration();
     AvroWriteSupport.setSchema(configuration, schema);
@@ -57,6 +59,8 @@ public class TestAvroWriteSupport {
     idx = actual.getFieldIndex(listField);
     columnDescriptor = actual.getColumns().get(idx);
     primitiveType = columnDescriptor.getPrimitiveType();
-    Assert.assertEquals("Confirm that old list type was used if not specified", "array", primitiveType.getName());
+    assertThat(primitiveType.getName())
+        .as("Confirm that old list type was used if not specified")
+        .isEqualTo("array");
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestBackwardCompatibility.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestBackwardCompatibility.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.io.Resources;
 import java.io.IOException;
 import org.apache.avro.generic.GenericRecord;
@@ -25,7 +27,6 @@ import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestBackwardCompatibility {
@@ -43,7 +44,7 @@ public class TestBackwardCompatibility {
         .build();
     GenericRecord r;
     while ((r = reader.read()) != null) {
-      Assert.assertTrue("Should read value into a String", r.get("text") instanceof String);
+      assertThat(r.get("text")).as("Should read value into a String").isInstanceOf(String.class);
     }
   }
 
@@ -57,7 +58,7 @@ public class TestBackwardCompatibility {
         .build();
     GenericRecord r;
     while ((r = reader.read()) != null) {
-      Assert.assertTrue("Should read value into a String", r.get("text") instanceof Utf8);
+      assertThat(r.get("text")).as("Should read value into a String").isInstanceOf(Utf8.class);
     }
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestByteStreamSplitE2E.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestByteStreamSplitE2E.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
@@ -32,7 +34,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -85,7 +86,7 @@ public class TestByteStreamSplitE2E {
       }
     }
 
-    Assert.assertEquals("Content should match", expected, records);
+    assertThat(records).as("Content should match").containsExactlyElementsOf(expected);
   }
 
   @Test

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestCircularReferences.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestCircularReferences.java
@@ -17,6 +17,8 @@
  */
 package org.apache.parquet.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +34,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -361,16 +362,26 @@ public class TestCircularReferences {
     Record actual = records.get(0);
 
     // because the record is a recursive structure, equals won't work
-    Assert.assertEquals("Should correctly read back the parent id", 1L, actual.get("id"));
-    Assert.assertEquals("Should correctly read back the parent data", new Utf8("parent data!"), actual.get("p"));
+    assertThat(actual.get("id"))
+        .as("Should correctly read back the parent id")
+        .isEqualTo(1L);
+    assertThat(actual.get("p"))
+        .as("Should correctly read back the parent data")
+        .isEqualTo(new Utf8("parent data!"));
 
     Record actualChild = (Record) actual.get("child");
-    Assert.assertEquals("Should correctly read back the child data", new Utf8("child data!"), actualChild.get("c"));
+    assertThat(actualChild.get("c"))
+        .as("Should correctly read back the child data")
+        .isEqualTo(new Utf8("child data!"));
     Object childParent = actualChild.get("parent");
-    Assert.assertTrue("Should have a parent Record object", childParent instanceof Record);
+    assertThat(childParent).as("Should have a parent Record object").isInstanceOf(Record.class);
 
     Record childParentRecord = (Record) actualChild.get("parent");
-    Assert.assertEquals("Should have the right parent id", 1L, childParentRecord.get("id"));
-    Assert.assertEquals("Should have the right parent data", new Utf8("parent data!"), childParentRecord.get("p"));
+    assertThat(childParentRecord.get("id"))
+        .as("Should have the right parent id")
+        .isEqualTo(1L);
+    assertThat(childParentRecord.get("p"))
+        .as("Should have the right parent data")
+        .isEqualTo(new Utf8("parent data!"));
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestGenericLogicalTypes.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestGenericLogicalTypes.java
@@ -25,6 +25,7 @@ import static org.apache.parquet.avro.AvroTestUtil.instance;
 import static org.apache.parquet.avro.AvroTestUtil.optionalField;
 import static org.apache.parquet.avro.AvroTestUtil.read;
 import static org.apache.parquet.avro.AvroTestUtil.record;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -43,7 +44,6 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -87,7 +87,9 @@ public class TestGenericLogicalTypes {
     GenericRecord s2 = instance(stringSchema, "uuid", u2.get("uuid").toString());
 
     File test = write(stringSchema, s1, s2);
-    Assert.assertEquals("Should convert Strings to UUIDs", Arrays.asList(u1, u2), read(GENERIC, uuidSchema, test));
+    assertThat(read(GENERIC, uuidSchema, test))
+        .as("Should convert Strings to UUIDs")
+        .containsExactly(u1, u2);
   }
 
   @Test
@@ -97,13 +99,16 @@ public class TestGenericLogicalTypes {
     GenericRecord u2 = instance(uuidSchema, "uuid", UUID.randomUUID());
     File test = write(conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), uuidSchema, u1, u2);
 
-    Assert.assertEquals("Should read UUID objects", Arrays.asList(u1, u2), read(GENERIC, uuidSchema, test));
+    assertThat(read(GENERIC, uuidSchema, test))
+        .as("Should read UUID objects")
+        .containsExactly(u1, u2);
 
     GenericRecord s1 = instance(uuidSchema, "uuid", u1.get("uuid").toString());
     GenericRecord s2 = instance(uuidSchema, "uuid", u2.get("uuid").toString());
 
-    Assert.assertEquals(
-        "Should read UUID as Strings", Arrays.asList(s1, s2), read(GenericData.get(), uuidSchema, test));
+    assertThat(read(GenericData.get(), uuidSchema, test))
+        .as("Should read UUID as Strings")
+        .containsExactly(s1, s2);
   }
 
   @Test
@@ -119,7 +124,9 @@ public class TestGenericLogicalTypes {
     GenericRecord s2 = instance(stringSchema, "uuid", u2.get("uuid").toString());
 
     File test = write(GENERIC, uuidSchema, u1, u2);
-    Assert.assertEquals("Should read UUIDs as Strings", Arrays.asList(s1, s2), read(GENERIC, stringSchema, test));
+    assertThat(read(GENERIC, stringSchema, test))
+        .as("Should read UUIDs as Strings")
+        .containsExactly(s1, s2);
   }
 
   @Test
@@ -132,8 +139,9 @@ public class TestGenericLogicalTypes {
     GenericRecord s2 = instance(uuidSchema, "uuid", new Utf8(u2.get("uuid").toString()));
 
     File test = write(GENERIC, uuidSchema, u1, u2);
-    Assert.assertEquals(
-        "Should read UUIDs as Strings", Arrays.asList(s1, s2), read(GenericData.get(), uuidSchema, test));
+    assertThat(read(GenericData.get(), uuidSchema, test))
+        .as("Should read UUIDs as Strings")
+        .containsExactly(s1, s2);
   }
 
   @Test
@@ -150,8 +158,9 @@ public class TestGenericLogicalTypes {
     GenericRecord s2 = instance(nullableStringSchema, "uuid", null);
 
     File test = write(GENERIC, nullableUuidSchema, u1, u2);
-    Assert.assertEquals(
-        "Should read UUIDs as Strings", Arrays.asList(s1, s2), read(GENERIC, nullableStringSchema, test));
+    assertThat(read(GENERIC, nullableStringSchema, test))
+        .as("Should read UUIDs as Strings")
+        .containsExactly(s1, s2);
   }
 
   @Test
@@ -165,10 +174,9 @@ public class TestGenericLogicalTypes {
     GenericRecord s2 = instance(nullableUuidSchema, "uuid", null);
 
     File test = write(GENERIC, nullableUuidSchema, u1, u2);
-    Assert.assertEquals(
-        "Should read UUIDs as Strings",
-        Arrays.asList(s1, s2),
-        read(GenericData.get(), nullableUuidSchema, test));
+    assertThat(read(GenericData.get(), nullableUuidSchema, test))
+        .as("Should read UUIDs as Strings")
+        .containsExactly(s1, s2);
   }
 
   @Test
@@ -189,7 +197,9 @@ public class TestGenericLogicalTypes {
     GenericRecord r2fixed = instance(fixedRecord, "dec", conversion.toFixed(D2, fixedSchema, DECIMAL_9_2));
 
     File test = write(fixedRecord, r1fixed, r2fixed);
-    Assert.assertEquals("Should convert fixed to BigDecimals", expected, read(GENERIC, decimalRecord, test));
+    assertThat(read(GENERIC, decimalRecord, test))
+        .as("Should convert fixed to BigDecimals")
+        .containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -210,7 +220,9 @@ public class TestGenericLogicalTypes {
     List<GenericRecord> expected = Arrays.asList(r1fixed, r2fixed);
 
     File test = write(GENERIC, decimalRecord, r1, r2);
-    Assert.assertEquals("Should read BigDecimals as fixed", expected, read(GENERIC, fixedRecord, test));
+    assertThat(read(GENERIC, fixedRecord, test))
+        .as("Should read BigDecimals as fixed")
+        .containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -231,7 +243,9 @@ public class TestGenericLogicalTypes {
     GenericRecord r2bytes = instance(bytesRecord, "dec", conversion.toBytes(D2, bytesSchema, DECIMAL_9_2));
 
     File test = write(bytesRecord, r1bytes, r2bytes);
-    Assert.assertEquals("Should convert bytes to BigDecimals", expected, read(GENERIC, decimalRecord, test));
+    assertThat(read(GENERIC, decimalRecord, test))
+        .as("Should convert bytes to BigDecimals")
+        .containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -253,7 +267,9 @@ public class TestGenericLogicalTypes {
     List<GenericRecord> expected = Arrays.asList(r1bytes, r2bytes);
 
     File test = write(GENERIC, decimalRecord, r1, r2);
-    Assert.assertEquals("Should read BigDecimals as bytes", expected, read(GENERIC, bytesRecord, test));
+    assertThat(read(GENERIC, bytesRecord, test))
+        .as("Should read BigDecimals as bytes")
+        .containsExactlyElementsOf(expected);
   }
 
   private <D> File write(Schema schema, D... data) throws IOException {

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestInputOutputFormat.java
@@ -19,8 +19,7 @@
 package org.apache.parquet.avro;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -126,10 +125,10 @@ public class TestInputOutputFormat {
       while ((lineOut = out.readLine()) != null) {
         lineOut = lineOut.substring(lineOut.indexOf("\t") + 1);
         GenericRecord a = nextRecord(lineNumber == 4 ? null : lineNumber);
-        assertEquals("line " + lineNumber, a.toString(), lineOut);
+        assertThat(a).as("line " + lineNumber).asString().isEqualTo(lineOut);
         ++lineNumber;
       }
-      assertNull("line " + lineNumber, out.readLine());
+      assertThat(out.readLine()).as("line " + lineNumber).isNull();
     }
   }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadVariant.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadVariant.java
@@ -21,10 +21,8 @@ package org.apache.parquet.avro;
 import static org.apache.parquet.avro.AvroTestUtil.field;
 import static org.apache.parquet.avro.AvroTestUtil.instance;
 import static org.apache.parquet.avro.AvroTestUtil.record;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
@@ -37,7 +35,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -540,12 +537,15 @@ public class TestReadVariant extends DirectWriterTest {
       AvroParquetReader<T> reader, Schema expectedSchema, T... expectedRecords) throws IOException {
     for (T expectedRecord : expectedRecords) {
       T actualRecord = reader.read();
-      assertEquals("Should match expected schema", expectedSchema, actualRecord.getSchema());
-      assertEquals("Should match the expected record", expectedRecord, actualRecord);
+      assertThat(actualRecord.getSchema())
+          .as("Should match expected schema")
+          .isEqualTo(expectedSchema);
+      assertThat(actualRecord).as("Should match the expected record").isEqualTo(expectedRecord);
     }
-    assertNull(
-        "Should only contain " + expectedRecords.length + " record" + (expectedRecords.length == 1 ? "" : "s"),
-        reader.read());
+    assertThat(reader.read())
+        .as("Should only contain " + expectedRecords.length + " record"
+            + (expectedRecords.length == 1 ? "" : "s"))
+        .isNull();
   }
 
   // We need to store two copies of the schema: one without the Variant type annotation that is used to construct the
@@ -590,7 +590,7 @@ public class TestReadVariant extends DirectWriterTest {
       GenericRecord record =
           recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
       GenericRecord actual = writeAndRead(schema, record);
-      assertEquals(actual.get("id"), 1);
+      assertThat(actual.get("id")).isEqualTo(1);
 
       GenericRecord actualVariant = (GenericRecord) actual.get("var");
       assertEquivalent(t.metadata, t.value, actualVariant);
@@ -608,7 +608,7 @@ public class TestReadVariant extends DirectWriterTest {
       GenericRecord record =
           recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
       GenericRecord actual = writeAndRead(schema, record);
-      assertEquals(actual.get("id"), 1);
+      assertThat(actual.get("id")).isEqualTo(1);
 
       GenericRecord actualVariant = (GenericRecord) actual.get("var");
       assertEquivalent(t.metadata, t.value, actualVariant);
@@ -631,7 +631,7 @@ public class TestReadVariant extends DirectWriterTest {
           recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
       GenericRecord actual = writeAndRead(schema, record);
-      assertEquals(actual.get("id"), 1);
+      assertThat(actual.get("id")).isEqualTo(1);
 
       GenericRecord actualVariant = (GenericRecord) actual.get("var");
       assertEquivalent(EMPTY_METADATA, p.value, actualVariant);
@@ -647,7 +647,7 @@ public class TestReadVariant extends DirectWriterTest {
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
     GenericRecord actual = writeAndRead(schema, record);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, NULL_VALUE, actualVariant);
@@ -677,7 +677,7 @@ public class TestReadVariant extends DirectWriterTest {
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
     GenericRecord actual = writeAndRead(schema, record);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, variant(34), actualVariant);
@@ -692,10 +692,11 @@ public class TestReadVariant extends DirectWriterTest {
         ImmutableMap.of("metadata", EMPTY_METADATA, "value", variant("str"), "typed_value", 34));
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
-    assertThrows(
-        () -> writeAndRead(schema, record),
-        IllegalStateException.class,
-        "Cannot call multiple append() methods");
+    assertThatThrownBy(() -> writeAndRead(schema, record))
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .cause()
+        .hasMessageContaining("Cannot call multiple append() methods");
   }
 
   @Test
@@ -707,10 +708,9 @@ public class TestReadVariant extends DirectWriterTest {
         recordFromMap(schema.unannotatedVariantType, ImmutableMap.of("metadata", EMPTY_METADATA));
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
-    assertThrows(
-        () -> writeAndRead(schema, record),
-        UnsupportedOperationException.class,
-        "Unsupported shredded value type: INTEGER(32,false)");
+    assertThatThrownBy(() -> writeAndRead(schema, record))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Unsupported shredded value type: INTEGER(32,false)");
   }
 
   @Test
@@ -723,10 +723,9 @@ public class TestReadVariant extends DirectWriterTest {
         recordFromMap(schema.unannotatedVariantType, ImmutableMap.of("metadata", EMPTY_METADATA));
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
-    assertThrows(
-        () -> writeAndRead(schema, record),
-        UnsupportedOperationException.class,
-        "Unsupported shredded value type: optional fixed_len_byte_array(4) typed_value");
+    assertThatThrownBy(() -> writeAndRead(schema, record))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("Unsupported shredded value type: optional fixed_len_byte_array(4) typed_value");
   }
 
   @Test
@@ -744,7 +743,7 @@ public class TestReadVariant extends DirectWriterTest {
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
     GenericRecord actual = writeAndRead(schema, record);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -789,7 +788,7 @@ public class TestReadVariant extends DirectWriterTest {
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
     GenericRecord actual = writeAndRead(schema, record);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -821,7 +820,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -850,7 +849,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -884,7 +883,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -922,7 +921,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -957,7 +956,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -1016,7 +1015,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -1058,7 +1057,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -1099,7 +1098,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     ByteBuffer expectedValue = variant(TEST_METADATA, b -> {
       VariantObjectBuilder ob = b.startObject();
@@ -1140,7 +1139,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     // The reader is expected to ignore fields in value that are present in the typed_value schema.
     // This matches Iceberg behaviour, but we could also consider failing with an error.
@@ -1182,7 +1181,7 @@ public class TestReadVariant extends DirectWriterTest {
 
     GenericRecord actual = writeAndRead(schema, record);
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     // The reader is expected to ignore fields in value that are present in the typed_value schema, even if they are
     // missing in typed_value.
@@ -1209,7 +1208,7 @@ public class TestReadVariant extends DirectWriterTest {
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
     GenericRecord actual = writeAndRead(schema, record);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
 
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(TEST_METADATA, variant(34), actualVariant);
@@ -1230,10 +1229,11 @@ public class TestReadVariant extends DirectWriterTest {
         ImmutableMap.of("metadata", TEST_METADATA, "value", variant(34), "typed_value", fields));
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
-    assertThrows(
-        () -> writeAndRead(schema, record),
-        IllegalStateException.class,
-        "Invalid variant, conflicting value and typed_value");
+    assertThatThrownBy(() -> writeAndRead(schema, record))
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .cause()
+        .hasMessageContaining("Invalid variant, conflicting value and typed_value");
   }
 
   @Test
@@ -1257,10 +1257,11 @@ public class TestReadVariant extends DirectWriterTest {
             fields));
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
-    assertThrows(
-        () -> writeAndRead(schema, record),
-        IllegalStateException.class,
-        "Invalid variant, conflicting value and typed_value");
+    assertThatThrownBy(() -> writeAndRead(schema, record))
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .cause()
+        .hasMessageContaining("Invalid variant, conflicting value and typed_value");
   }
 
   @Test
@@ -1337,24 +1338,24 @@ public class TestReadVariant extends DirectWriterTest {
     });
 
     List<GenericRecord> records = writeAndRead(schema, Arrays.asList(zero, one, two, three));
-    assertEquals(records.size(), 4);
+    assertThat(records).hasSize(4);
 
     GenericRecord actualZero = records.get(0);
-    assertEquals(actualZero.get("id"), 0);
-    assertEquals(actualZero.get("var"), null);
+    assertThat(actualZero.get("id")).isEqualTo(0);
+    assertThat(actualZero.get("var")).isNull();
 
     GenericRecord actualOne = records.get(1);
-    assertEquals(actualOne.get("id"), 1);
+    assertThat(actualOne.get("id")).isEqualTo(1);
     GenericRecord actualOneVariant = (GenericRecord) actualOne.get("var");
     assertEquivalent(TEST_METADATA, expectedOne, actualOneVariant);
 
     GenericRecord actualTwo = records.get(2);
-    assertEquals(actualTwo.get("id"), 2);
+    assertThat(actualTwo.get("id")).isEqualTo(2);
     GenericRecord actualTwoVariant = (GenericRecord) actualTwo.get("var");
     assertEquivalent(TEST_METADATA, expectedTwo, actualTwoVariant);
 
     GenericRecord actualThree = records.get(3);
-    assertEquals(actualThree.get("id"), 3);
+    assertThat(actualThree.get("id")).isEqualTo(3);
     GenericRecord actualThreeVariant = (GenericRecord) actualThree.get("var");
     assertEquivalent(TEST_METADATA, expectedThree, actualThreeVariant);
   }
@@ -1381,7 +1382,7 @@ public class TestReadVariant extends DirectWriterTest {
     });
 
     GenericRecord actual = writeAndRead(schema, row);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, expected, actualVariant);
   }
@@ -1396,7 +1397,7 @@ public class TestReadVariant extends DirectWriterTest {
     GenericRecord row = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", var));
 
     GenericRecord actual = writeAndRead(schema, row);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, NULL_VALUE, actualVariant);
   }
@@ -1418,7 +1419,7 @@ public class TestReadVariant extends DirectWriterTest {
       b.endArray();
     });
 
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, emptyArray, actualVariant);
   }
@@ -1447,7 +1448,7 @@ public class TestReadVariant extends DirectWriterTest {
     });
 
     GenericRecord actual = writeAndRead(schema, row);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, expected, actualVariant);
   }
@@ -1481,7 +1482,7 @@ public class TestReadVariant extends DirectWriterTest {
     });
 
     GenericRecord actual = writeAndRead(schema, row);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, expected, actualVariant);
   }
@@ -1600,12 +1601,12 @@ public class TestReadVariant extends DirectWriterTest {
     // verify
     List<GenericRecord> actual = writeAndRead(schema, Arrays.asList(row1, row2));
     GenericRecord actual1 = actual.get(0);
-    assertEquals(actual1.get("id"), 1);
+    assertThat(actual1.get("id")).isEqualTo(1);
     GenericRecord actualVariant1 = (GenericRecord) actual1.get("var");
     assertEquivalent(TEST_METADATA, expected1, actualVariant1);
 
     GenericRecord actual2 = actual.get(1);
-    assertEquals(actual2.get("id"), 2);
+    assertThat(actual2.get("id")).isEqualTo(2);
     GenericRecord actualVariant2 = (GenericRecord) actual2.get("var");
     assertEquivalent(TEST_METADATA, expected2, actualVariant2);
   }
@@ -1666,22 +1667,22 @@ public class TestReadVariant extends DirectWriterTest {
 
     List<GenericRecord> actual = writeAndRead(schema, Arrays.asList(row1, row2, row3, row4));
     GenericRecord actual1 = actual.get(0);
-    assertEquals(actual1.get("id"), 1);
+    assertThat(actual1.get("id")).isEqualTo(1);
     GenericRecord actualVariant1 = (GenericRecord) actual1.get("var");
     assertEquivalent(EMPTY_METADATA, expectedArray1, actualVariant1);
 
     GenericRecord actual2 = actual.get(1);
-    assertEquals(actual2.get("id"), 2);
+    assertThat(actual2.get("id")).isEqualTo(2);
     GenericRecord actualVariant2 = (GenericRecord) actual2.get("var");
     assertEquivalent(EMPTY_METADATA, expectedValue2, actualVariant2);
 
     GenericRecord actual3 = actual.get(2);
-    assertEquals(actual3.get("id"), 3);
+    assertThat(actual3.get("id")).isEqualTo(3);
     GenericRecord actualVariant3 = (GenericRecord) actual3.get("var");
     assertEquivalent(TEST_METADATA, expectedObject3, actualVariant3);
 
     GenericRecord actual4 = actual.get(3);
-    assertEquals(actual4.get("id"), 4);
+    assertThat(actual4.get("id")).isEqualTo(4);
     GenericRecord actualVariant4 = (GenericRecord) actual4.get("var");
     assertEquivalent(TEST_METADATA, expectedArray4, actualVariant4);
   }
@@ -1722,7 +1723,7 @@ public class TestReadVariant extends DirectWriterTest {
     });
 
     GenericRecord actual = writeAndRead(schema, row);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, expectedArray, actualVariant);
   }
@@ -1751,7 +1752,7 @@ public class TestReadVariant extends DirectWriterTest {
     });
 
     GenericRecord actual = writeAndRead(schema, row);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, expectedArray, actualVariant);
   }
@@ -1777,7 +1778,7 @@ public class TestReadVariant extends DirectWriterTest {
     });
 
     GenericRecord actual = writeAndRead(schema, record);
-    assertEquals(actual.get("id"), 1);
+    assertThat(actual.get("id")).isEqualTo(1);
     GenericRecord actualVariant = (GenericRecord) actual.get("var");
     assertEquivalent(EMPTY_METADATA, expectedArray, actualVariant);
   }
@@ -1796,10 +1797,11 @@ public class TestReadVariant extends DirectWriterTest {
         ImmutableMap.of("metadata", EMPTY_METADATA, "typed_value", Arrays.asList(element)));
     GenericRecord record = recordFromMap(schema.unannotatedParquetSchema, ImmutableMap.of("id", 1, "var", variant));
 
-    assertThrows(
-        () -> writeAndRead(schema, record),
-        IllegalStateException.class,
-        "Invalid variant, conflicting value and typed_value");
+    assertThatThrownBy(() -> writeAndRead(schema, record))
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .cause()
+        .hasMessageContaining("Invalid variant, conflicting value and typed_value");
   }
 
   /**
@@ -2082,35 +2084,12 @@ public class TestReadVariant extends DirectWriterTest {
   }
 
   /**
-   * Check for the given exception with message, possibly wrapped by a ParquetDecodingException.
-   */
-  void assertThrows(Callable callable, Class<? extends Exception> exception, String msg) {
-    try {
-      callable.call();
-      fail("No exception was thrown. Expected: " + exception.getName());
-    } catch (Exception actual) {
-      try {
-        if (actual.getClass().equals(ParquetDecodingException.class)) {
-          assertTrue(actual.getCause().getMessage().contains(msg));
-          assertEquals(actual.getCause().getClass(), exception);
-        } else {
-          assertTrue(actual.getMessage().contains(msg));
-          assertEquals(actual.getClass(), exception);
-        }
-      } catch (AssertionError e) {
-        e.addSuppressed(actual);
-        throw e;
-      }
-    }
-  }
-
-  /**
    * Assert that metadata contains identical bytes to expected, and value is logically equivalent.
    * E.g. object fields may be ordered differently in the binary.
    */
   void assertEquivalent(ByteBuffer expectedMetadata, ByteBuffer expectedValue, GenericRecord actual) {
-    assertEquals(expectedMetadata, (ByteBuffer) actual.get("metadata"));
-    assertEquals(expectedMetadata, (ByteBuffer) actual.get("metadata"));
+    assertThat((ByteBuffer) actual.get("metadata")).isEqualTo(expectedMetadata);
+    assertThat((ByteBuffer) actual.get("metadata")).isEqualTo(expectedMetadata);
     AvroTestUtil.assertEquivalent(
         new Variant(expectedValue, expectedMetadata),
         new Variant(((ByteBuffer) actual.get("value")), expectedMetadata));

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
@@ -22,9 +22,8 @@ import static org.apache.parquet.avro.AvroTestUtil.optional;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -82,7 +81,6 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -197,8 +195,8 @@ public class TestReadWrite {
     try (ParquetReader<GenericRecord> reader = reader(file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(emptyArray, nextRecord.get("myarray"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("myarray")).isEqualTo(emptyArray);
     }
   }
 
@@ -221,8 +219,8 @@ public class TestReadWrite {
     try (ParquetReader<GenericRecord> reader = reader(file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(emptyMap, nextRecord.get("mymap"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("mymap")).isEqualTo(emptyMap);
     }
   }
 
@@ -252,8 +250,8 @@ public class TestReadWrite {
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(map, nextRecord.get("mymap"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("mymap")).isEqualTo(map);
     }
   }
 
@@ -306,8 +304,8 @@ public class TestReadWrite {
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("mymap")).isEqualTo(ImmutableMap.of(str("a"), 1, str("b"), 2));
     }
   }
 
@@ -358,9 +356,10 @@ public class TestReadWrite {
       }
     }
 
-    Assert.assertTrue(
-        "dec field should be a BigDecimal instance", records.get(0).get("dec") instanceof BigDecimal);
-    Assert.assertEquals("Content should match", expected, records);
+    assertThat(records.get(0).get("dec"))
+        .as("dec field should be a BigDecimal instance")
+        .isInstanceOf(BigDecimal.class);
+    assertThat(records).as("Content should match").containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -407,9 +406,10 @@ public class TestReadWrite {
       }
     }
 
-    Assert.assertTrue(
-        "dec field should be a BigDecimal instance", records.get(0).get("dec") instanceof BigDecimal);
-    Assert.assertEquals("Content should match", expected, records);
+    assertThat(records.get(0).get("dec"))
+        .as("dec field should be a BigDecimal instance")
+        .isInstanceOf(BigDecimal.class);
+    assertThat(records).as("Content should match").containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -455,23 +455,27 @@ public class TestReadWrite {
       }
     }
 
-    Assert.assertEquals("Should read 2 records", 2, records.size());
+    assertThat(records).as("Should read 2 records").hasSize(2);
 
     // INT32 values
     Object firstAge = records.get(0).get("decimal_age");
     Object secondAge = records.get(1).get("decimal_age");
 
-    Assert.assertTrue("Should be BigDecimal, but is " + firstAge.getClass(), firstAge instanceof BigDecimal);
-    Assert.assertEquals("Should be 25.34, but is " + firstAge, new BigDecimal("25.34"), firstAge);
-    Assert.assertEquals("Should be 42.67, but is " + secondAge, new BigDecimal("42.67"), secondAge);
+    assertThat(firstAge)
+        .as("Should be BigDecimal, but is " + firstAge.getClass())
+        .isInstanceOf(BigDecimal.class);
+    assertThat(firstAge).as("Should be 25.34, but is " + firstAge).isEqualTo(new BigDecimal("25.34"));
+    assertThat(secondAge).as("Should be 42.67, but is " + secondAge).isEqualTo(new BigDecimal("42.67"));
 
     // INT64 values
     Object firstSalary = records.get(0).get("decimal_salary");
     Object secondSalary = records.get(1).get("decimal_salary");
 
-    Assert.assertTrue("Should be BigDecimal, but is " + firstSalary.getClass(), firstSalary instanceof BigDecimal);
-    Assert.assertEquals("Should be 23.4, but is " + firstSalary, new BigDecimal("23.4"), firstSalary);
-    Assert.assertEquals("Should be 120.3, but is " + secondSalary, new BigDecimal("120.3"), secondSalary);
+    assertThat(firstSalary)
+        .as("Should be BigDecimal, but is " + firstSalary.getClass())
+        .isInstanceOf(BigDecimal.class);
+    assertThat(firstSalary).as("Should be 23.4, but is " + firstSalary).isEqualTo(new BigDecimal("23.4"));
+    assertThat(secondSalary).as("Should be 120.3, but is " + secondSalary).isEqualTo(new BigDecimal("120.3"));
   }
 
   @Test
@@ -533,24 +537,24 @@ public class TestReadWrite {
         ? "a"
         : new GenericData.EnumSymbol(schema.getField("myenum").schema(), "a");
 
-    assertNotNull(nextRecord);
-    assertEquals(null, nextRecord.get("mynull"));
-    assertEquals(true, nextRecord.get("myboolean"));
-    assertEquals(1, nextRecord.get("myint"));
-    assertEquals(2L, nextRecord.get("mylong"));
-    assertEquals(3.1f, nextRecord.get("myfloat"));
-    assertEquals(4.1, nextRecord.get("mydouble"));
-    assertEquals(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), nextRecord.get("mybytes"));
-    assertEquals(str("hello"), nextRecord.get("mystring"));
-    assertEquals(expectedEnumSymbol, nextRecord.get("myenum"));
-    assertEquals(nestedRecord, nextRecord.get("mynestedrecord"));
-    assertEquals(integerArray, nextRecord.get("myarray"));
-    assertEquals(emptyArray, nextRecord.get("myemptyarray"));
-    assertEquals(integerArray, nextRecord.get("myoptionalarray"));
-    assertEquals(genericIntegerArrayWithNulls, nextRecord.get("myarrayofoptional"));
-    assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
-    assertEquals(emptyMap, nextRecord.get("myemptymap"));
-    assertEquals(genericFixed, nextRecord.get("myfixed"));
+    assertThat(nextRecord).isNotNull();
+    assertThat(nextRecord.get("mynull")).isEqualTo(null);
+    assertThat(nextRecord.get("myboolean")).isEqualTo(true);
+    assertThat(nextRecord.get("myint")).isEqualTo(1);
+    assertThat(nextRecord.get("mylong")).isEqualTo(2L);
+    assertThat(nextRecord.get("myfloat")).isEqualTo(3.1f);
+    assertThat(nextRecord.get("mydouble")).isEqualTo(4.1);
+    assertThat(nextRecord.get("mybytes")).isEqualTo(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+    assertThat(nextRecord.get("mystring")).isEqualTo(str("hello"));
+    assertThat(nextRecord.get("myenum")).isEqualTo(expectedEnumSymbol);
+    assertThat(nextRecord.get("mynestedrecord")).isEqualTo(nestedRecord);
+    assertThat(nextRecord.get("myarray")).isEqualTo(integerArray);
+    assertThat(nextRecord.get("myemptyarray")).isEqualTo(emptyArray);
+    assertThat(nextRecord.get("myoptionalarray")).isEqualTo(integerArray);
+    assertThat(nextRecord.get("myarrayofoptional")).isEqualTo(genericIntegerArrayWithNulls);
+    assertThat(nextRecord.get("mymap")).isEqualTo(ImmutableMap.of(str("a"), 1, str("b"), 2));
+    assertThat(nextRecord.get("myemptymap")).isEqualTo(emptyMap);
+    assertThat(nextRecord.get("myfixed")).isEqualTo(genericFixed);
   }
 
   @Test
@@ -755,22 +759,22 @@ public class TestReadWrite {
 
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
-      assertNotNull(nextRecord);
-      assertEquals(true, nextRecord.get("myboolean"));
-      assertEquals(1, nextRecord.get("myint"));
-      assertEquals(2L, nextRecord.get("mylong"));
-      assertEquals(3.1f, nextRecord.get("myfloat"));
-      assertEquals(4.1, nextRecord.get("mydouble"));
-      assertEquals(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), nextRecord.get("mybytes"));
-      assertEquals(str("hello"), nextRecord.get("mystring"));
-      assertEquals(str("a"), nextRecord.get("myenum")); // enum symbols are unknown
-      assertEquals(nestedRecord, nextRecord.get("mynestedrecord"));
-      assertEquals(integerArray, nextRecord.get("myarray"));
-      assertEquals(integerArray, nextRecord.get("myoptionalarray"));
-      assertEquals(ingeterArrayWithNulls, nextRecord.get("myarrayofoptional"));
-      assertEquals(genericRecordArray, nextRecord.get("myrecordarray"));
-      assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
-      assertEquals(genericFixed, nextRecord.get("myfixed"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("myboolean")).isEqualTo(true);
+      assertThat(nextRecord.get("myint")).isEqualTo(1);
+      assertThat(nextRecord.get("mylong")).isEqualTo(2L);
+      assertThat(nextRecord.get("myfloat")).isEqualTo(3.1f);
+      assertThat(nextRecord.get("mydouble")).isEqualTo(4.1);
+      assertThat(nextRecord.get("mybytes")).isEqualTo(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+      assertThat(nextRecord.get("mystring")).isEqualTo(str("hello"));
+      assertThat(nextRecord.get("myenum")).isEqualTo(str("a")); // enum symbols are unknown
+      assertThat(nextRecord.get("mynestedrecord")).isEqualTo(nestedRecord);
+      assertThat(nextRecord.get("myarray")).isEqualTo(integerArray);
+      assertThat(nextRecord.get("myoptionalarray")).isEqualTo(integerArray);
+      assertThat(nextRecord.get("myarrayofoptional")).isEqualTo(ingeterArrayWithNulls);
+      assertThat(nextRecord.get("myrecordarray")).isEqualTo(genericRecordArray);
+      assertThat(nextRecord.get("mymap")).isEqualTo(ImmutableMap.of(str("a"), 1, str("b"), 2));
+      assertThat(nextRecord.get("myfixed")).isEqualTo(genericFixed);
     }
   }
 
@@ -798,8 +802,8 @@ public class TestReadWrite {
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(str("theValue"), nextRecord.get("value"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("value")).isEqualTo(str("theValue"));
     }
   }
 
@@ -833,7 +837,7 @@ public class TestReadWrite {
         ByteBuffer buf = (ByteBuffer) rec.get("value");
         byte[] bytes = new byte[buf.remaining()];
         buf.get(bytes);
-        assertEquals(records[i++], new String(bytes));
+        assertThat(new String(bytes)).isEqualTo(records[i++]);
       }
     }
   }
@@ -869,12 +873,12 @@ public class TestReadWrite {
     ParquetReader<GenericRecord> reader = reader(file);
     GenericRecord nextRecord = reader.read();
 
-    assertNotNull(nextRecord);
-    assertNotNull(nextRecord.get("l1"));
+    assertThat(nextRecord).isNotNull();
+    assertThat(nextRecord.get("l1")).isNotNull();
     List l1List = (List) nextRecord.get("l1");
-    assertNotNull(l1List.get(0));
+    assertThat(l1List.get(0)).isNotNull();
     List l2List = (List) ((GenericRecord) l1List.get(0)).get("l2");
-    assertEquals(str("hello"), l2List.get(0));
+    assertThat(l2List.get(0)).isEqualTo(str("hello"));
   }
 
   /**
@@ -911,12 +915,12 @@ public class TestReadWrite {
     try (ParquetReader<GenericRecord> reader = AvroParquetReader.genericRecordReader(file)) {
 
       final GenericRecord r1 = reader.read();
-      assertEquals("foo", r1.get("name").toString());
-      assertEquals(123, r1.get("weight"));
+      assertThat(r1.get("name")).asString().isEqualTo("foo");
+      assertThat(r1.get("weight")).isEqualTo(123);
 
       final GenericRecord r2 = reader.read();
-      assertEquals("oof", r2.get("name").toString());
-      assertEquals(321, r2.get("weight"));
+      assertThat(r2.get("name")).asString().isEqualTo("oof");
+      assertThat(r2.get("weight")).isEqualTo(321);
     }
   }
 
@@ -992,9 +996,10 @@ public class TestReadWrite {
       }
     }
 
-    Assert.assertTrue(
-        "date field should be a LocalDate instance", records.get(0).get("date") instanceof LocalDate);
-    Assert.assertEquals("Content should match", expected, records);
+    assertThat(records.get(0).get("date"))
+        .as("date field should be a LocalDate instance")
+        .isInstanceOf(LocalDate.class);
+    assertThat(records).as("Content should match").containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -1004,15 +1009,15 @@ public class TestReadWrite {
     InputFile inputFile = new LocalInputFile(Paths.get(testFile));
     ParquetReader<Group> reader =
         AvroParquetReader.<Group>builder(inputFile).build();
-    assertNotNull(reader);
+    assertThat(reader).isNotNull();
 
     reader = AvroParquetReader.<Group>builder(inputFile, new HadoopParquetConfiguration(new Configuration()))
         .build();
-    assertNotNull(reader);
+    assertThat(reader).isNotNull();
 
     reader = AvroParquetReader.builder(new GroupReadSupport(), new Path(testFile))
         .build();
-    assertNotNull(reader);
+    assertThat(reader).isNotNull();
   }
 
   private File createTempFile() throws IOException {

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
@@ -23,10 +23,8 @@ import static org.apache.parquet.avro.AvroTestUtil.optional;
 import static org.apache.parquet.avro.AvroTestUtil.optionalField;
 import static org.apache.parquet.avro.AvroTestUtil.primitive;
 import static org.apache.parquet.avro.AvroTestUtil.record;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -55,7 +53,6 @@ import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -101,8 +98,8 @@ public class TestReadWriteOldListBehavior {
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(emptyArray, nextRecord.get("myarray"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("myarray")).isEqualTo(emptyArray);
     }
   }
 
@@ -127,8 +124,8 @@ public class TestReadWriteOldListBehavior {
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(emptyMap, nextRecord.get("mymap"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("mymap")).isEqualTo(emptyMap);
     }
   }
 
@@ -157,8 +154,8 @@ public class TestReadWriteOldListBehavior {
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(map, nextRecord.get("mymap"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("mymap")).isEqualTo(map);
     }
   }
 
@@ -209,8 +206,8 @@ public class TestReadWriteOldListBehavior {
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
 
-      assertNotNull(nextRecord);
-      assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("mymap")).isEqualTo(ImmutableMap.of(str("a"), 1, str("b"), 2));
     }
   }
 
@@ -270,24 +267,24 @@ public class TestReadWriteOldListBehavior {
           ? "a"
           : new GenericData.EnumSymbol(schema.getField("myenum").schema(), "a");
 
-      assertNotNull(nextRecord);
-      assertEquals(null, nextRecord.get("mynull"));
-      assertEquals(true, nextRecord.get("myboolean"));
-      assertEquals(1, nextRecord.get("myint"));
-      assertEquals(2L, nextRecord.get("mylong"));
-      assertEquals(3.1f, nextRecord.get("myfloat"));
-      assertEquals(4.1, nextRecord.get("mydouble"));
-      assertEquals(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), nextRecord.get("mybytes"));
-      assertEquals(str("hello"), nextRecord.get("mystring"));
-      assertEquals(expectedEnumSymbol, nextRecord.get("myenum"));
-      assertEquals(nestedRecord, nextRecord.get("mynestedrecord"));
-      assertEquals(integerArray, nextRecord.get("myarray"));
-      assertEquals(emptyArray, nextRecord.get("myemptyarray"));
-      assertEquals(integerArray, nextRecord.get("myoptionalarray"));
-      assertEquals(integerArray, nextRecord.get("myarrayofoptional"));
-      assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
-      assertEquals(emptyMap, nextRecord.get("myemptymap"));
-      assertEquals(genericFixed, nextRecord.get("myfixed"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("mynull")).isEqualTo(null);
+      assertThat(nextRecord.get("myboolean")).isEqualTo(true);
+      assertThat(nextRecord.get("myint")).isEqualTo(1);
+      assertThat(nextRecord.get("mylong")).isEqualTo(2L);
+      assertThat(nextRecord.get("myfloat")).isEqualTo(3.1f);
+      assertThat(nextRecord.get("mydouble")).isEqualTo(4.1);
+      assertThat(nextRecord.get("mybytes")).isEqualTo(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+      assertThat(nextRecord.get("mystring")).isEqualTo(str("hello"));
+      assertThat(nextRecord.get("myenum")).isEqualTo(expectedEnumSymbol);
+      assertThat(nextRecord.get("mynestedrecord")).isEqualTo(nestedRecord);
+      assertThat(nextRecord.get("myarray")).isEqualTo(integerArray);
+      assertThat(nextRecord.get("myemptyarray")).isEqualTo(emptyArray);
+      assertThat(nextRecord.get("myoptionalarray")).isEqualTo(integerArray);
+      assertThat(nextRecord.get("myarrayofoptional")).isEqualTo(integerArray);
+      assertThat(nextRecord.get("mymap")).isEqualTo(ImmutableMap.of(str("a"), 1, str("b"), 2));
+      assertThat(nextRecord.get("myemptymap")).isEqualTo(emptyMap);
+      assertThat(nextRecord.get("myfixed")).isEqualTo(genericFixed);
     }
   }
 
@@ -340,14 +337,13 @@ public class TestReadWriteOldListBehavior {
         .set("myfixed", genericFixed)
         .build();
 
-    try (AvroParquetWriter<GenericRecord> writer = new AvroParquetWriter<>(file, schema)) {
-      writer.write(record);
-      fail("Should not succeed writing an array with null values");
-    } catch (Exception e) {
-      Assert.assertTrue(
-          "Error message should provide context and help",
-          e.getMessage().contains("parquet.avro.write-old-list-structure"));
-    }
+    assertThatThrownBy(() -> {
+          try (AvroParquetWriter<GenericRecord> writer = new AvroParquetWriter<>(file, schema)) {
+            writer.write(record);
+          }
+        })
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("parquet.avro.write-old-list-structure");
   }
 
   @Test
@@ -567,22 +563,22 @@ public class TestReadWriteOldListBehavior {
 
     try (AvroParquetReader<GenericRecord> reader = new AvroParquetReader<>(testConf, file)) {
       GenericRecord nextRecord = reader.read();
-      assertNotNull(nextRecord);
-      assertEquals(true, nextRecord.get("myboolean"));
-      assertEquals(1, nextRecord.get("myint"));
-      assertEquals(2L, nextRecord.get("mylong"));
-      assertEquals(3.1f, nextRecord.get("myfloat"));
-      assertEquals(4.1, nextRecord.get("mydouble"));
-      assertEquals(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)), nextRecord.get("mybytes"));
-      assertEquals(str("hello"), nextRecord.get("mystring"));
-      assertEquals(str("a"), nextRecord.get("myenum"));
-      assertEquals(nestedRecord, nextRecord.get("mynestedrecord"));
-      assertEquals(integerArray, nextRecord.get("myarray"));
-      assertEquals(integerArray, nextRecord.get("myoptionalarray"));
-      assertEquals(genericRecordArrayWithNullIntegers, nextRecord.get("myarrayofoptional"));
-      assertEquals(genericRecordArray, nextRecord.get("myrecordarray"));
-      assertEquals(ImmutableMap.of(str("a"), 1, str("b"), 2), nextRecord.get("mymap"));
-      assertEquals(genericFixed, nextRecord.get("myfixed"));
+      assertThat(nextRecord).isNotNull();
+      assertThat(nextRecord.get("myboolean")).isEqualTo(true);
+      assertThat(nextRecord.get("myint")).isEqualTo(1);
+      assertThat(nextRecord.get("mylong")).isEqualTo(2L);
+      assertThat(nextRecord.get("myfloat")).isEqualTo(3.1f);
+      assertThat(nextRecord.get("mydouble")).isEqualTo(4.1);
+      assertThat(nextRecord.get("mybytes")).isEqualTo(ByteBuffer.wrap("hello".getBytes(StandardCharsets.UTF_8)));
+      assertThat(nextRecord.get("mystring")).isEqualTo(str("hello"));
+      assertThat(nextRecord.get("myenum")).isEqualTo(str("a"));
+      assertThat(nextRecord.get("mynestedrecord")).isEqualTo(nestedRecord);
+      assertThat(nextRecord.get("myarray")).isEqualTo(integerArray);
+      assertThat(nextRecord.get("myoptionalarray")).isEqualTo(integerArray);
+      assertThat(nextRecord.get("myarrayofoptional")).isEqualTo(genericRecordArrayWithNullIntegers);
+      assertThat(nextRecord.get("myrecordarray")).isEqualTo(genericRecordArray);
+      assertThat(nextRecord.get("mymap")).isEqualTo(ImmutableMap.of(str("a"), 1, str("b"), 2));
+      assertThat(nextRecord.get("myfixed")).isEqualTo(genericFixed);
     }
   }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectInputOutputFormat.java
@@ -19,11 +19,7 @@
 package org.apache.parquet.avro;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -397,18 +393,16 @@ public class TestReflectInputOutputFormat {
       while ((car = out.read()) != null) {
         if (previousCar != null) {
           // Testing reference equality here. The "model" field should be dictionary-encoded.
-          assertTrue(car.model == previousCar.model);
+          assertThat(car.model).isSameAs(previousCar.model);
         }
         // Make sure that predicate push down worked as expected
-        if (car.engine.type == EngineType.PETROL) {
-          fail("UnboundRecordFilter failed to remove cars with PETROL engines");
-        }
+        assertThat(car.engine.type).isNotEqualTo(EngineType.PETROL);
         // Note we use lineNumber * 2 because of predicate push down
         Car expectedCar = nextRecord(lineNumber * 2);
         // We removed the optional extra field using projection so we shouldn't
         // see it here...
         expectedCar.optionalExtra = null;
-        assertEquals("line " + lineNumber, expectedCar, car);
+        assertThat(car).as("line " + lineNumber).isEqualTo(expectedCar);
         ++lineNumber;
         previousCar = car;
       }
@@ -459,10 +453,10 @@ public class TestReflectInputOutputFormat {
         // Note we use lineNumber * 2 because of predicate push down
         Car expectedCar = nextRecord(lineNumber * 2);
         // We removed the optional extra field using projection so we shouldn't see it here...
-        assertNull(car.make);
-        assertEquals(car.engine, expectedCar.engine);
-        assertEquals(car.year, expectedCar.year);
-        assertArrayEquals(car.vin, expectedCar.vin);
+        assertThat(car.make).isNull();
+        assertThat(car.engine).isEqualTo(expectedCar.engine);
+        assertThat(car.year).isEqualTo(expectedCar.year);
+        assertThat(car.vin).isEqualTo(expectedCar.vin);
         ++lineNumber;
       }
     }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectLogicalTypes.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectLogicalTypes.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.avro;
 
 import static org.apache.parquet.avro.AvroTestUtil.read;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +42,6 @@ import org.apache.avro.reflect.AvroSchema;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.specific.SpecificData;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,7 +83,7 @@ public class TestReflectLogicalTypes {
 
     Schema actual = REFLECT.getSchema(RecordWithUUIDList.class);
 
-    Assert.assertEquals("Should use the UUID logical type", expected, actual);
+    assertThat(actual).as("Should use the UUID logical type").isEqualTo(expected);
   }
 
   // this can be static because the schema only comes from reflection
@@ -123,22 +123,21 @@ public class TestReflectLogicalTypes {
   @Test
   public void testDecimalBytes() throws IOException {
     Schema schema = REFLECT.getSchema(DecimalRecordBytes.class);
-    Assert.assertEquals(
-        "Should have the correct record name",
-        "org.apache.parquet.avro.TestReflectLogicalTypes",
-        schema.getNamespace());
-    Assert.assertEquals("Should have the correct record name", "DecimalRecordBytes", schema.getName());
-    Assert.assertEquals(
-        "Should have the correct logical type",
-        LogicalTypes.decimal(9, 2),
-        LogicalTypes.fromSchema(schema.getField("decimal").schema()));
+    assertThat(schema.getNamespace())
+        .as("Should have the correct record name")
+        .isEqualTo("org.apache.parquet.avro.TestReflectLogicalTypes");
+    assertThat(schema.getName()).as("Should have the correct record name").isEqualTo("DecimalRecordBytes");
+    assertThat(LogicalTypes.fromSchema(schema.getField("decimal").schema()))
+        .as("Should have the correct logical type")
+        .isEqualTo(LogicalTypes.decimal(9, 2));
 
     DecimalRecordBytes record = new DecimalRecordBytes();
     record.decimal = new BigDecimal("3.14");
 
     File test = write(REFLECT, schema, record);
-    Assert.assertEquals(
-        "Should match the decimal after round trip", Arrays.asList(record), read(REFLECT, schema, test));
+    assertThat(read(REFLECT, schema, test))
+        .as("Should match the decimal after round trip")
+        .containsExactly(record);
   }
 
   // this can be static because the schema only comes from reflection
@@ -180,22 +179,21 @@ public class TestReflectLogicalTypes {
   @Test
   public void testDecimalFixed() throws IOException {
     Schema schema = REFLECT.getSchema(DecimalRecordFixed.class);
-    Assert.assertEquals(
-        "Should have the correct record name",
-        "org.apache.parquet.avro.TestReflectLogicalTypes",
-        schema.getNamespace());
-    Assert.assertEquals("Should have the correct record name", "DecimalRecordFixed", schema.getName());
-    Assert.assertEquals(
-        "Should have the correct logical type",
-        LogicalTypes.decimal(9, 2),
-        LogicalTypes.fromSchema(schema.getField("decimal").schema()));
+    assertThat(schema.getNamespace())
+        .as("Should have the correct record name")
+        .isEqualTo("org.apache.parquet.avro.TestReflectLogicalTypes");
+    assertThat(schema.getName()).as("Should have the correct record name").isEqualTo("DecimalRecordFixed");
+    assertThat(LogicalTypes.fromSchema(schema.getField("decimal").schema()))
+        .as("Should have the correct logical type")
+        .isEqualTo(LogicalTypes.decimal(9, 2));
 
     DecimalRecordFixed record = new DecimalRecordFixed();
     record.decimal = new BigDecimal("3.14");
 
     File test = write(REFLECT, schema, record);
-    Assert.assertEquals(
-        "Should match the decimal after round trip", Arrays.asList(record), read(REFLECT, schema, test));
+    assertThat(read(REFLECT, schema, test))
+        .as("Should match the decimal after round trip")
+        .containsExactly(record);
   }
 
   public static class Pair<X, Y> {
@@ -297,15 +295,13 @@ public class TestReflectLogicalTypes {
     });
 
     Schema schema = model.getSchema(PairRecord.class);
-    Assert.assertEquals(
-        "Should have the correct record name",
-        "org.apache.parquet.avro.TestReflectLogicalTypes",
-        schema.getNamespace());
-    Assert.assertEquals("Should have the correct record name", "PairRecord", schema.getName());
-    Assert.assertEquals(
-        "Should have the correct logical type",
-        "pair",
-        LogicalTypes.fromSchema(schema.getField("pair").schema()).getName());
+    assertThat(schema.getNamespace())
+        .as("Should have the correct record name")
+        .isEqualTo("org.apache.parquet.avro.TestReflectLogicalTypes");
+    assertThat(schema.getName()).as("Should have the correct record name").isEqualTo("PairRecord");
+    assertThat(LogicalTypes.fromSchema(schema.getField("pair").schema()).getName())
+        .as("Should have the correct logical type")
+        .isEqualTo("pair");
 
     PairRecord record = new PairRecord();
     record.pair = Pair.of(34L, 35L);
@@ -315,8 +311,12 @@ public class TestReflectLogicalTypes {
     File test = write(model, schema, record);
     Pair<Long, Long> actual =
         AvroTestUtil.<PairRecord>read(model, schema, test).get(0).pair;
-    Assert.assertEquals("Data should match after serialization round-trip", 34L, (long) actual.first);
-    Assert.assertEquals("Data should match after serialization round-trip", 35L, (long) actual.second);
+    assertThat((long) actual.first)
+        .as("Data should match after serialization round-trip")
+        .isEqualTo(34L);
+    assertThat((long) actual.second)
+        .as("Data should match after serialization round-trip")
+        .isEqualTo(35L);
   }
 
   @Test
@@ -341,7 +341,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(ReflectData.get().getSchema(RecordWithStringUUID.class), r1, r2);
 
-    Assert.assertEquals("Should convert Strings to UUIDs", expected, read(REFLECT, uuidSchema, test));
+    assertThat(read(REFLECT, uuidSchema, test))
+        .as("Should convert Strings to UUIDs")
+        .containsExactlyElementsOf(expected);
 
     // verify that the field's type overrides the logical type
     Schema uuidStringSchema = SchemaBuilder.record(RecordWithStringUUID.class.getName())
@@ -350,10 +352,9 @@ public class TestReflectLogicalTypes {
         .endRecord();
     LogicalTypes.uuid().addToSchema(uuidStringSchema.getField("uuid").schema());
 
-    Assert.assertEquals(
-        "Should not convert to UUID if accessor is String",
-        Arrays.asList(r1, r2),
-        read(REFLECT, uuidStringSchema, test));
+    assertThat(read(REFLECT, uuidStringSchema, test))
+        .as("Should not convert to UUID if accessor is String")
+        .containsExactly(r1, r2);
   }
 
   @Test
@@ -378,7 +379,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(AvroTestUtil.conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), uuidSchema, r1, r2);
 
-    Assert.assertEquals("Should convert Strings to UUIDs", expected, read(REFLECT, uuidSchema, test));
+    assertThat(read(REFLECT, uuidSchema, test))
+        .as("Should convert Strings to UUIDs")
+        .containsExactlyElementsOf(expected);
 
     // verify that the field's type overrides the logical type
     Schema uuidStringSchema = SchemaBuilder.record(RecordWithStringUUID.class.getName())
@@ -387,10 +390,9 @@ public class TestReflectLogicalTypes {
         .endRecord();
     LogicalTypes.uuid().addToSchema(uuidStringSchema.getField("uuid").schema());
 
-    Assert.assertEquals(
-        "Should not convert to UUID if accessor is String",
-        Arrays.asList(r1, r2),
-        read(REFLECT, uuidStringSchema, test));
+    assertThat(read(REFLECT, uuidStringSchema, test))
+        .as("Should not convert to UUID if accessor is String")
+        .containsExactly(r1, r2);
   }
 
   @Test
@@ -421,14 +423,14 @@ public class TestReflectLogicalTypes {
         .requiredString("uuid")
         .endRecord();
 
-    Assert.assertEquals(
-        "Should read uuid as String without UUID conversion", expected, read(REFLECT, uuidStringSchema, test));
+    assertThat(read(REFLECT, uuidStringSchema, test))
+        .as("Should read uuid as String without UUID conversion")
+        .containsExactlyElementsOf(expected);
 
     LogicalTypes.uuid().addToSchema(uuidStringSchema.getField("uuid").schema());
-    Assert.assertEquals(
-        "Should read uuid as String without UUID logical type",
-        expected,
-        read(ReflectData.get(), uuidStringSchema, test));
+    assertThat(read(ReflectData.get(), uuidStringSchema, test))
+        .as("Should read uuid as String without UUID logical type")
+        .containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -453,14 +455,18 @@ public class TestReflectLogicalTypes {
 
     File test = write(AvroTestUtil.conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), REFLECT, uuidSchema, r1, r2);
 
-    Assert.assertEquals("Should read UUID objects", Arrays.asList(r1, r2), read(REFLECT, uuidSchema, test));
+    assertThat(read(REFLECT, uuidSchema, test))
+        .as("Should read UUID objects")
+        .containsExactly(r1, r2);
 
     Schema uuidStringSchema = SchemaBuilder.record(RecordWithStringUUID.class.getName())
         .fields()
         .requiredString("uuid")
         .endRecord();
     LogicalTypes.uuid().addToSchema(uuidStringSchema.getField("uuid").schema());
-    Assert.assertEquals("Should read uuid as Strings", expected, read(ReflectData.get(), uuidStringSchema, test));
+    assertThat(read(ReflectData.get(), uuidStringSchema, test))
+        .as("Should read uuid as Strings")
+        .containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -493,10 +499,9 @@ public class TestReflectLogicalTypes {
         .optionalString("uuid")
         .endRecord();
 
-    Assert.assertEquals(
-        "Should read uuid as String without UUID conversion",
-        expected,
-        read(REFLECT, nullableUuidStringSchema, test));
+    assertThat(read(REFLECT, nullableUuidStringSchema, test))
+        .as("Should read uuid as String without UUID conversion")
+        .containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -524,8 +529,9 @@ public class TestReflectLogicalTypes {
     File test = write(
         AvroTestUtil.conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), REFLECT, nullableUuidSchema, r1, r2);
 
-    Assert.assertEquals(
-        "Should read uuid as UUID objects", Arrays.asList(r1, r2), read(REFLECT, nullableUuidSchema, test));
+    assertThat(read(REFLECT, nullableUuidSchema, test))
+        .as("Should read uuid as UUID objects")
+        .containsExactly(r1, r2);
 
     Schema nullableUuidStringSchema = SchemaBuilder.record(RecordWithStringUUID.class.getName())
         .fields()
@@ -538,10 +544,9 @@ public class TestReflectLogicalTypes {
             .getTypes()
             .get(1));
 
-    Assert.assertEquals(
-        "Should read uuid as String without UUID conversion",
-        expected,
-        read(REFLECT, nullableUuidStringSchema, test));
+    assertThat(read(REFLECT, nullableUuidStringSchema, test))
+        .as("Should read uuid as String without UUID conversion")
+        .containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -573,13 +578,13 @@ public class TestReflectLogicalTypes {
         .requiredString("uuid")
         .endRecord();
 
-    Assert.assertEquals(
-        "Should read uuid as String without UUID conversion", expected, read(REFLECT, uuidStringSchema, test));
+    assertThat(read(REFLECT, uuidStringSchema, test))
+        .as("Should read uuid as String without UUID conversion")
+        .containsExactlyElementsOf(expected);
 
-    Assert.assertEquals(
-        "Should read uuid as String without UUID logical type",
-        expected,
-        read(ReflectData.get(), uuidStringSchema, test));
+    assertThat(read(ReflectData.get(), uuidStringSchema, test))
+        .as("Should read uuid as String without UUID logical type")
+        .containsExactlyElementsOf(expected);
   }
 
   @Test
@@ -605,7 +610,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(ReflectData.get().getSchema(RecordWithStringUUID.class), r1, r2);
 
-    Assert.assertEquals("Should convert Strings to UUIDs", expected, read(REFLECT, uuidSchema, test));
+    assertThat(read(REFLECT, uuidSchema, test))
+        .as("Should convert Strings to UUIDs")
+        .containsExactlyElementsOf(expected);
 
     // verify that the field's type overrides the logical type
     Schema uuidStringSchema = SchemaBuilder.record(RecordWithStringUUID.class.getName())
@@ -614,10 +621,9 @@ public class TestReflectLogicalTypes {
         .endRecord();
     LogicalTypes.uuid().addToSchema(uuidSchema.getField("uuid").schema());
 
-    Assert.assertEquals(
-        "Should not convert to UUID if accessor is String",
-        Arrays.asList(r1, r2),
-        read(REFLECT, uuidStringSchema, test));
+    assertThat(read(REFLECT, uuidStringSchema, test))
+        .as("Should not convert to UUID if accessor is String")
+        .containsExactly(r1, r2);
   }
 
   @Test
@@ -643,7 +649,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(AvroTestUtil.conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), uuidSchema, r1, r2);
 
-    Assert.assertEquals("Should convert Strings to UUIDs", expected, read(REFLECT, uuidSchema, test));
+    assertThat(read(REFLECT, uuidSchema, test))
+        .as("Should convert Strings to UUIDs")
+        .containsExactlyElementsOf(expected);
 
     Schema uuidStringSchema = SchemaBuilder.record(RecordWithStringUUID.class.getName())
         .fields()
@@ -651,10 +659,9 @@ public class TestReflectLogicalTypes {
         .endRecord();
     LogicalTypes.uuid().addToSchema(uuidStringSchema.getField("uuid").schema());
 
-    Assert.assertEquals(
-        "Should not convert to UUID if accessor is String",
-        Arrays.asList(r1, r2),
-        read(REFLECT, uuidStringSchema, test));
+    assertThat(read(REFLECT, uuidStringSchema, test))
+        .as("Should not convert to UUID if accessor is String")
+        .containsExactly(r1, r2);
   }
 
   @Test
@@ -682,10 +689,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(uuidArraySchema, r);
 
-    Assert.assertEquals(
-        "Should convert Strings to UUIDs",
-        expected,
-        read(REFLECT, uuidArraySchema, test).get(0));
+    assertThat(read(REFLECT, uuidArraySchema, test).get(0))
+        .as("Should convert Strings to UUIDs")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -713,10 +719,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(AvroTestUtil.conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), uuidArraySchema, r);
 
-    Assert.assertEquals(
-        "Should convert Strings to UUIDs",
-        expected,
-        read(REFLECT, uuidArraySchema, test).get(0));
+    assertThat(read(REFLECT, uuidArraySchema, test).get(0))
+        .as("Should convert Strings to UUIDs")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -758,10 +763,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(REFLECT, uuidArraySchema, r);
 
-    Assert.assertEquals(
-        "Should read UUIDs as Strings",
-        expected,
-        read(ReflectData.get(), stringArraySchema, test).get(0));
+    assertThat(read(ReflectData.get(), stringArraySchema, test).get(0))
+        .as("Should read UUIDs as Strings")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -805,10 +809,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(AvroTestUtil.conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), REFLECT, uuidArraySchema, r);
 
-    Assert.assertEquals(
-        "Should read UUIDs as Strings",
-        expected,
-        read(ReflectData.get(), stringArraySchema, test).get(0));
+    assertThat(read(ReflectData.get(), stringArraySchema, test).get(0))
+        .as("Should read UUIDs as Strings")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -837,10 +840,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(uuidListSchema, r);
 
-    Assert.assertEquals(
-        "Should convert Strings to UUIDs",
-        expected,
-        read(REFLECT, uuidListSchema, test).get(0));
+    assertThat(read(REFLECT, uuidListSchema, test).get(0))
+        .as("Should convert Strings to UUIDs")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -869,10 +871,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(AvroTestUtil.conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), uuidListSchema, r);
 
-    Assert.assertEquals(
-        "Should convert Strings to UUIDs",
-        expected,
-        read(REFLECT, uuidListSchema, test).get(0));
+    assertThat(read(REFLECT, uuidListSchema, test).get(0))
+        .as("Should convert Strings to UUIDs")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -912,10 +913,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(REFLECT, uuidListSchema, r);
 
-    Assert.assertEquals(
-        "Should read UUIDs as Strings",
-        expected,
-        read(REFLECT, stringArraySchema, test).get(0));
+    assertThat(read(REFLECT, stringArraySchema, test).get(0))
+        .as("Should read UUIDs as Strings")
+        .isEqualTo(expected);
   }
 
   @Test
@@ -956,10 +956,9 @@ public class TestReflectLogicalTypes {
 
     File test = write(AvroTestUtil.conf(AvroWriteSupport.WRITE_PARQUET_UUID, true), REFLECT, uuidListSchema, r);
 
-    Assert.assertEquals(
-        "Should read UUID objects",
-        expected,
-        read(REFLECT, reflectSchema, test).get(0));
+    assertThat(read(REFLECT, reflectSchema, test).get(0))
+        .as("Should read UUID objects")
+        .isEqualTo(expected);
   }
 
   @SuppressWarnings("unchecked")

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java
@@ -18,8 +18,7 @@
  */
 package org.apache.parquet.avro;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import java.io.File;
@@ -54,9 +53,9 @@ public class TestReflectReadWrite {
     try (ParquetReader<Pojo> reader = new AvroParquetReader<Pojo>(conf, path)) {
       Pojo object = getPojo();
       for (int i = 0; i < 10; i++) {
-        assertEquals(object, reader.read());
+        assertThat(reader.read()).isEqualTo(object);
       }
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -70,9 +69,9 @@ public class TestReflectReadWrite {
     try (ParquetReader<GenericRecord> reader = new AvroParquetReader<GenericRecord>(conf, path)) {
       GenericRecord object = getGenericPojoUtf8();
       for (int i = 0; i < 2; i += 1) {
-        assertEquals(object, reader.read());
+        assertThat(reader.read()).isEqualTo(object);
       }
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificInputOutputFormat.java
@@ -19,10 +19,7 @@
 package org.apache.parquet.avro;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -190,18 +187,16 @@ public class TestSpecificInputOutputFormat {
       while ((car = out.read()) != null) {
         if (previousCar != null) {
           // Testing reference equality here. The "model" field should be dictionary-encoded.
-          assertTrue(car.getModel() == previousCar.getModel());
+          assertThat(car.getModel()).isSameAs(previousCar.getModel());
         }
         // Make sure that predicate push down worked as expected
-        if (car.getEngine().getType() == EngineType.PETROL) {
-          fail("UnboundRecordFilter failed to remove cars with PETROL engines");
-        }
+        assertThat(car.getEngine().getType()).isNotEqualTo(EngineType.PETROL);
         // Note we use lineNumber * 2 because of predicate push down
         Car expectedCar = nextRecord(lineNumber * 2);
         // We removed the optional extra field using projection so we shouldn't
         // see it here...
         expectedCar.setOptionalExtra(null);
-        assertEquals("line " + lineNumber, expectedCar, car);
+        assertThat(car).as("line " + lineNumber).isEqualTo(expectedCar);
         ++lineNumber;
         previousCar = car;
       }
@@ -251,10 +246,10 @@ public class TestSpecificInputOutputFormat {
         // Note we use lineNumber * 2 because of predicate push down
         Car expectedCar = nextRecord(lineNumber * 2);
         // We removed the optional extra field using projection so we shouldn't see it here...
-        assertNull(car.getMake());
-        assertEquals(car.getEngine(), expectedCar.getEngine());
-        assertEquals(car.getYear(), expectedCar.getYear());
-        assertEquals(car.getVin(), expectedCar.getVin());
+        assertThat(car.getMake()).isNull();
+        assertThat(car.getEngine()).isEqualTo(expectedCar.getEngine());
+        assertThat(car.getYear()).isEqualTo(expectedCar.getYear());
+        assertThat(car.getVin()).isEqualTo(expectedCar.getVin());
         ++lineNumber;
       }
     }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificReadWrite.java
@@ -22,10 +22,7 @@ import static org.apache.parquet.filter.ColumnPredicates.equalTo;
 import static org.apache.parquet.filter.ColumnRecordFilter.column;
 import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_BLOCK_SIZE;
 import static org.apache.parquet.hadoop.ParquetWriter.DEFAULT_PAGE_SIZE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import java.io.File;
@@ -77,11 +74,11 @@ public class TestSpecificReadWrite {
     Path path = writeCarsToParquetFile(10, CompressionCodecName.UNCOMPRESSED, false);
     try (ParquetReader<Car> reader = new AvroParquetReader<>(testConf, path)) {
       for (int i = 0; i < 10; i++) {
-        assertEquals(getVwPolo().toString(), reader.read().toString());
-        assertEquals(getVwPassat().toString(), reader.read().toString());
-        assertEquals(getBmwMini().toString(), reader.read().toString());
+        assertThat(reader.read()).asString().isEqualTo(getVwPolo().toString());
+        assertThat(reader.read()).asString().isEqualTo(getVwPassat().toString());
+        assertThat(reader.read()).asString().isEqualTo(getBmwMini().toString());
       }
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -90,11 +87,11 @@ public class TestSpecificReadWrite {
     Path path = writeCarsToParquetFile(10, CompressionCodecName.UNCOMPRESSED, true);
     try (ParquetReader<Car> reader = new AvroParquetReader<>(testConf, path)) {
       for (int i = 0; i < 10; i++) {
-        assertEquals(getVwPolo().toString(), reader.read().toString());
-        assertEquals(getVwPassat().toString(), reader.read().toString());
-        assertEquals(getBmwMini().toString(), reader.read().toString());
+        assertThat(reader.read()).asString().isEqualTo(getVwPolo().toString());
+        assertThat(reader.read()).asString().isEqualTo(getVwPassat().toString());
+        assertThat(reader.read()).asString().isEqualTo(getBmwMini().toString());
       }
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -104,10 +101,10 @@ public class TestSpecificReadWrite {
     try (ParquetReader<Car> reader =
         new AvroParquetReader<>(testConf, path, column("make", equalTo("Volkswagen")))) {
       for (int i = 0; i < 10; i++) {
-        assertEquals(getVwPolo().toString(), reader.read().toString());
-        assertEquals(getVwPassat().toString(), reader.read().toString());
+        assertThat(reader.read()).asString().isEqualTo(getVwPolo().toString());
+        assertThat(reader.read()).asString().isEqualTo(getVwPassat().toString());
       }
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -118,10 +115,10 @@ public class TestSpecificReadWrite {
     try (ParquetReader<Car> reader =
         new AvroParquetReader<>(testConf, path, column("make", equalTo("Volkswagen")))) {
       for (int i = 0; i < 10000; i++) {
-        assertEquals(getVwPolo().toString(), reader.read().toString());
-        assertEquals(getVwPassat().toString(), reader.read().toString());
+        assertThat(reader.read()).asString().isEqualTo(getVwPolo().toString());
+        assertThat(reader.read()).asString().isEqualTo(getVwPassat().toString());
       }
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -130,7 +127,7 @@ public class TestSpecificReadWrite {
     Path path = writeCarsToParquetFile(
         10000, CompressionCodecName.UNCOMPRESSED, false, DEFAULT_BLOCK_SIZE / 64, DEFAULT_PAGE_SIZE / 64);
     try (ParquetReader<Car> reader = new AvroParquetReader<>(testConf, path, column("make", equalTo("Bogus")))) {
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -161,8 +158,8 @@ public class TestSpecificReadWrite {
     }
 
     try (ParquetReader<Car> reader = new AvroParquetReader<Car>(testConf, path, column("make", equalTo("BMW")))) {
-      assertEquals(getBmwMini().toString(), reader.read().toString());
-      assertNull(reader.read());
+      assertThat(reader.read()).asString().isEqualTo(getBmwMini().toString());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -171,9 +168,9 @@ public class TestSpecificReadWrite {
     Path path = writeCarsToParquetFile(1, CompressionCodecName.UNCOMPRESSED, true);
     try (ParquetReader<Car> reader =
         new AvroParquetReader<>(testConf, path, column("make", equalTo("Volkswagen")))) {
-      assertEquals(getVwPolo().toString(), reader.read().toString());
-      assertEquals(getVwPassat().toString(), reader.read().toString());
-      assertNull(reader.read());
+      assertThat(reader.read()).asString().isEqualTo(getVwPolo().toString());
+      assertThat(reader.read()).asString().isEqualTo(getVwPassat().toString());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -183,16 +180,16 @@ public class TestSpecificReadWrite {
 
     ParquetReader<Car> reader =
         new AvroParquetReader<Car>(testConf, path, column("engine.type", equalTo(EngineType.DIESEL)));
-    assertEquals(reader.read().toString(), getVwPassat().toString());
-    assertNull(reader.read());
+    assertThat(reader.read()).asString().isEqualTo(getVwPassat().toString());
+    assertThat(reader.read()).isNull();
 
     reader = new AvroParquetReader<Car>(testConf, path, column("engine.capacity", equalTo(1.4f)));
-    assertEquals(getVwPolo().toString(), reader.read().toString());
-    assertNull(reader.read());
+    assertThat(reader.read()).asString().isEqualTo(getVwPolo().toString());
+    assertThat(reader.read()).isNull();
 
     reader = new AvroParquetReader<Car>(testConf, path, column("engine.hasTurboCharger", equalTo(true)));
-    assertEquals(getBmwMini().toString(), reader.read().toString());
-    assertNull(reader.read());
+    assertThat(reader.read()).asString().isEqualTo(getBmwMini().toString());
+    assertThat(reader.read()).isNull();
   }
 
   @Test
@@ -223,14 +220,14 @@ public class TestSpecificReadWrite {
 
     try (ParquetReader<Car> reader = new AvroParquetReader<Car>(conf, path)) {
       for (Car car = reader.read(); car != null; car = reader.read()) {
-        assertTrue(car.getDoors() == 4 || car.getDoors() == 5);
-        assertNotNull(car.getEngine());
-        assertNotNull(car.getMake());
-        assertNotNull(car.getModel());
-        assertEquals(2010, car.getYear());
-        assertNotNull(car.getVin());
-        assertNull(car.getOptionalExtra());
-        assertNull(car.getServiceHistory());
+        assertThat(car.getDoors()).isIn(4, 5);
+        assertThat(car.getEngine()).isNotNull();
+        assertThat(car.getMake()).isNotNull();
+        assertThat(car.getModel()).isNotNull();
+        assertThat(car.getYear()).isEqualTo(2010);
+        assertThat(car.getVin()).isNotNull();
+        assertThat(car.getOptionalExtra()).isNull();
+        assertThat(car.getServiceHistory()).isNull();
       }
     }
   }
@@ -264,10 +261,10 @@ public class TestSpecificReadWrite {
 
     try (ParquetReader<Car> reader = new AvroParquetReader<>(conf, path)) {
       for (Car car = reader.read(); car != null; car = reader.read()) {
-        assertNotNull(car.getServiceHistory());
+        assertThat(car.getServiceHistory()).isNotNull();
         car.getServiceHistory().forEach(service -> {
-          assertNotNull(service.getMechanic());
-          assertEquals(0L, service.getDate());
+          assertThat(service.getMechanic()).isNotNull();
+          assertThat(service.getDate()).isEqualTo(0L);
         });
       }
     }
@@ -281,12 +278,12 @@ public class TestSpecificReadWrite {
 
     try (ParquetReader<NewCar> reader = new AvroParquetReader<>(conf, path)) {
       for (NewCar car = reader.read(); car != null; car = reader.read()) {
-        assertNotNull(car.getEngine());
-        assertNotNull(car.getBrand());
-        assertEquals(2010, car.getYear());
-        assertNotNull(car.getVin());
-        assertNull(car.getDescription());
-        assertEquals(5, car.getOpt());
+        assertThat(car.getEngine()).isNotNull();
+        assertThat(car.getBrand()).isNotNull();
+        assertThat(car.getYear()).isEqualTo(2010);
+        assertThat(car.getVin()).isNotNull();
+        assertThat(car.getDescription()).isNull();
+        assertThat(car.getOpt()).isEqualTo(5);
       }
     }
   }
@@ -328,7 +325,7 @@ public class TestSpecificReadWrite {
       }
     }
 
-    assertEquals(records, output);
+    assertThat(output).containsExactlyElementsOf(records);
   }
 
   private Path writeCarsToParquetFile(int num, CompressionCodecName compression, boolean enableDictionary)

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestStringBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestStringBehavior.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.avro;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
@@ -46,7 +47,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -120,55 +120,47 @@ public class TestStringBehavior {
       parquetRecord = parquet.read();
     }
 
-    Assert.assertEquals(
-        "Avro default string class should be Utf8",
-        Utf8.class,
-        avroRecord.get("default_class").getClass());
-    Assert.assertEquals(
-        "Parquet default string class should be Utf8",
-        Utf8.class,
-        parquetRecord.get("default_class").getClass());
+    assertThat(avroRecord.get("default_class").getClass())
+        .as("Avro default string class should be Utf8")
+        .isEqualTo(Utf8.class);
+    assertThat(parquetRecord.get("default_class").getClass())
+        .as("Parquet default string class should be Utf8")
+        .isEqualTo(Utf8.class);
 
-    Assert.assertEquals(
-        "Avro avro.java.string=String class should be String",
-        String.class,
-        avroRecord.get("string_class").getClass());
-    Assert.assertEquals(
-        "Parquet avro.java.string=String class should be String",
-        String.class,
-        parquetRecord.get("string_class").getClass());
+    assertThat(avroRecord.get("string_class").getClass())
+        .as("Avro avro.java.string=String class should be String")
+        .isEqualTo(String.class);
+    assertThat(parquetRecord.get("string_class").getClass())
+        .as("Parquet avro.java.string=String class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro stringable class should be Utf8",
-        Utf8.class,
-        avroRecord.get("stringable_class").getClass());
-    Assert.assertEquals(
-        "Parquet stringable class should be Utf8",
-        Utf8.class,
-        parquetRecord.get("stringable_class").getClass());
+    assertThat(avroRecord.get("stringable_class").getClass())
+        .as("Avro stringable class should be Utf8")
+        .isEqualTo(Utf8.class);
+    assertThat(parquetRecord.get("stringable_class").getClass())
+        .as("Parquet stringable class should be Utf8")
+        .isEqualTo(Utf8.class);
 
-    Assert.assertEquals(
-        "Avro map default string class should be Utf8", Utf8.class, keyClass(avroRecord.get("default_map")));
-    Assert.assertEquals(
-        "Parquet map default string class should be Utf8",
-        Utf8.class,
-        keyClass(parquetRecord.get("default_map")));
+    assertThat(keyClass(avroRecord.get("default_map")))
+        .as("Avro map default string class should be Utf8")
+        .isEqualTo(Utf8.class);
+    assertThat(keyClass(parquetRecord.get("default_map")))
+        .as("Parquet map default string class should be Utf8")
+        .isEqualTo(Utf8.class);
 
-    Assert.assertEquals(
-        "Avro map avro.java.string=String class should be String",
-        String.class,
-        keyClass(avroRecord.get("string_map")));
-    Assert.assertEquals(
-        "Parquet map avro.java.string=String class should be String",
-        String.class,
-        keyClass(parquetRecord.get("string_map")));
+    assertThat(keyClass(avroRecord.get("string_map")))
+        .as("Avro map avro.java.string=String class should be String")
+        .isEqualTo(String.class);
+    assertThat(keyClass(parquetRecord.get("string_map")))
+        .as("Parquet map avro.java.string=String class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro map stringable class should be Utf8", Utf8.class, keyClass(avroRecord.get("stringable_map")));
-    Assert.assertEquals(
-        "Parquet map stringable class should be Utf8",
-        Utf8.class,
-        keyClass(parquetRecord.get("stringable_map")));
+    assertThat(keyClass(avroRecord.get("stringable_map")))
+        .as("Avro map stringable class should be Utf8")
+        .isEqualTo(Utf8.class);
+    assertThat(keyClass(parquetRecord.get("stringable_map")))
+        .as("Parquet map stringable class should be Utf8")
+        .isEqualTo(Utf8.class);
   }
 
   @Test
@@ -189,59 +181,50 @@ public class TestStringBehavior {
       parquetRecord = parquet.read();
     }
 
-    Assert.assertEquals(
-        "Avro default string class should be String",
-        Utf8.class,
-        avroRecord.getDefaultClass().getClass());
-    Assert.assertEquals(
-        "Parquet default string class should be String",
-        Utf8.class,
-        parquetRecord.getDefaultClass().getClass());
+    assertThat(avroRecord.getDefaultClass().getClass())
+        .as("Avro default string class should be String")
+        .isEqualTo(Utf8.class);
+    assertThat(parquetRecord.getDefaultClass().getClass())
+        .as("Parquet default string class should be String")
+        .isEqualTo(Utf8.class);
 
-    Assert.assertEquals(
-        "Avro avro.java.string=String class should be String",
-        String.class,
-        avroRecord.getStringClass().getClass());
-    Assert.assertEquals(
-        "Parquet avro.java.string=String class should be String",
-        String.class,
-        parquetRecord.getStringClass().getClass());
+    assertThat(avroRecord.getStringClass().getClass())
+        .as("Avro avro.java.string=String class should be String")
+        .isEqualTo(String.class);
+    assertThat(parquetRecord.getStringClass().getClass())
+        .as("Parquet avro.java.string=String class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro stringable class should be BigDecimal",
-        BigDecimal.class,
-        avroRecord.getStringableClass().getClass());
-    Assert.assertEquals(
-        "Parquet stringable class should be BigDecimal",
-        BigDecimal.class,
-        parquetRecord.getStringableClass().getClass());
-    Assert.assertEquals(
-        "Should have the correct BigDecimal value", BIG_DECIMAL, parquetRecord.getStringableClass());
+    assertThat(avroRecord.getStringableClass().getClass())
+        .as("Avro stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
+    assertThat(parquetRecord.getStringableClass().getClass())
+        .as("Parquet stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
+    assertThat(parquetRecord.getStringableClass())
+        .as("Should have the correct BigDecimal value")
+        .isEqualTo(BIG_DECIMAL);
 
-    Assert.assertEquals(
-        "Avro map default string class should be String", Utf8.class, keyClass(avroRecord.getDefaultMap()));
-    Assert.assertEquals(
-        "Parquet map default string class should be String",
-        Utf8.class,
-        keyClass(parquetRecord.getDefaultMap()));
+    assertThat(keyClass(avroRecord.getDefaultMap()))
+        .as("Avro map default string class should be String")
+        .isEqualTo(Utf8.class);
+    assertThat(keyClass(parquetRecord.getDefaultMap()))
+        .as("Parquet map default string class should be String")
+        .isEqualTo(Utf8.class);
 
-    Assert.assertEquals(
-        "Avro map avro.java.string=String class should be String",
-        String.class,
-        keyClass(avroRecord.getStringMap()));
-    Assert.assertEquals(
-        "Parquet map avro.java.string=String class should be String",
-        String.class,
-        keyClass(parquetRecord.getStringMap()));
+    assertThat(keyClass(avroRecord.getStringMap()))
+        .as("Avro map avro.java.string=String class should be String")
+        .isEqualTo(String.class);
+    assertThat(keyClass(parquetRecord.getStringMap()))
+        .as("Parquet map avro.java.string=String class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro map stringable class should be BigDecimal",
-        BigDecimal.class,
-        keyClass(avroRecord.getStringableMap()));
-    Assert.assertEquals(
-        "Parquet map stringable class should be BigDecimal",
-        BigDecimal.class,
-        keyClass(parquetRecord.getStringableMap()));
+    assertThat(keyClass(avroRecord.getStringableMap()))
+        .as("Avro map stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
+    assertThat(keyClass(parquetRecord.getStringableMap()))
+        .as("Parquet map stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
   }
 
   @Test
@@ -266,50 +249,50 @@ public class TestStringBehavior {
       parquetRecord = parquet.read();
     }
 
-    Assert.assertEquals(
-        "Avro default string class should be String", String.class, avroRecord.default_class.getClass());
-    Assert.assertEquals(
-        "Parquet default string class should be String", String.class, parquetRecord.default_class.getClass());
+    assertThat(avroRecord.default_class.getClass())
+        .as("Avro default string class should be String")
+        .isEqualTo(String.class);
+    assertThat(parquetRecord.default_class.getClass())
+        .as("Parquet default string class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro avro.java.string=String class should be String",
-        String.class,
-        avroRecord.string_class.getClass());
-    Assert.assertEquals(
-        "Parquet avro.java.string=String class should be String",
-        String.class,
-        parquetRecord.string_class.getClass());
+    assertThat(avroRecord.string_class.getClass())
+        .as("Avro avro.java.string=String class should be String")
+        .isEqualTo(String.class);
+    assertThat(parquetRecord.string_class.getClass())
+        .as("Parquet avro.java.string=String class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro stringable class should be BigDecimal", BigDecimal.class, avroRecord.stringable_class.getClass());
-    Assert.assertEquals(
-        "Parquet stringable class should be BigDecimal",
-        BigDecimal.class,
-        parquetRecord.stringable_class.getClass());
-    Assert.assertEquals("Should have the correct BigDecimal value", BIG_DECIMAL, parquetRecord.stringable_class);
+    assertThat(avroRecord.stringable_class.getClass())
+        .as("Avro stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
+    assertThat(parquetRecord.stringable_class.getClass())
+        .as("Parquet stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
+    assertThat(parquetRecord.stringable_class)
+        .as("Should have the correct BigDecimal value")
+        .isEqualTo(BIG_DECIMAL);
 
-    Assert.assertEquals(
-        "Avro map default string class should be String", String.class, keyClass(avroRecord.default_map));
-    Assert.assertEquals(
-        "Parquet map default string class should be String", String.class, keyClass(parquetRecord.default_map));
+    assertThat(keyClass(avroRecord.default_map))
+        .as("Avro map default string class should be String")
+        .isEqualTo(String.class);
+    assertThat(keyClass(parquetRecord.default_map))
+        .as("Parquet map default string class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro map avro.java.string=String class should be String",
-        String.class,
-        keyClass(avroRecord.string_map));
-    Assert.assertEquals(
-        "Parquet map avro.java.string=String class should be String",
-        String.class,
-        keyClass(parquetRecord.string_map));
+    assertThat(keyClass(avroRecord.string_map))
+        .as("Avro map avro.java.string=String class should be String")
+        .isEqualTo(String.class);
+    assertThat(keyClass(parquetRecord.string_map))
+        .as("Parquet map avro.java.string=String class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro map stringable class should be BigDecimal",
-        BigDecimal.class,
-        keyClass(avroRecord.stringable_map));
-    Assert.assertEquals(
-        "Parquet map stringable class should be BigDecimal",
-        BigDecimal.class,
-        keyClass(parquetRecord.stringable_map));
+    assertThat(keyClass(avroRecord.stringable_map))
+        .as("Avro map stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
+    assertThat(keyClass(parquetRecord.stringable_map))
+        .as("Parquet map stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
   }
 
   @Test
@@ -337,18 +320,22 @@ public class TestStringBehavior {
     }
 
     // Avro uses String even if CharSequence is set
-    Assert.assertEquals(
-        "Avro default string class should be String", String.class, avroRecord.default_class.getClass());
-    Assert.assertEquals(
-        "Parquet default string class should be String", String.class, parquetRecord.default_class.getClass());
+    assertThat(avroRecord.default_class.getClass())
+        .as("Avro default string class should be String")
+        .isEqualTo(String.class);
+    assertThat(parquetRecord.default_class.getClass())
+        .as("Parquet default string class should be String")
+        .isEqualTo(String.class);
 
-    Assert.assertEquals(
-        "Avro stringable class should be BigDecimal", BigDecimal.class, avroRecord.stringable_class.getClass());
-    Assert.assertEquals(
-        "Parquet stringable class should be BigDecimal",
-        BigDecimal.class,
-        parquetRecord.stringable_class.getClass());
-    Assert.assertEquals("Should have the correct BigDecimal value", BIG_DECIMAL, parquetRecord.stringable_class);
+    assertThat(avroRecord.stringable_class.getClass())
+        .as("Avro stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
+    assertThat(parquetRecord.stringable_class.getClass())
+        .as("Parquet stringable class should be BigDecimal")
+        .isEqualTo(BigDecimal.class);
+    assertThat(parquetRecord.stringable_class)
+        .as("Should have the correct BigDecimal value")
+        .isEqualTo(BIG_DECIMAL);
   }
 
   @Test
@@ -434,7 +421,7 @@ public class TestStringBehavior {
   }
 
   public static Class<?> keyClass(Object obj) {
-    Assert.assertTrue("Should be a map", obj instanceof Map);
+    assertThat(obj).as("Should be a map").isInstanceOf(Map.class);
     Map<?, ?> map = (Map<?, ?>) obj;
     return Iterables.getFirst(map.keySet(), null).getClass();
   }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestWriteVariant.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestWriteVariant.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.avro;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -348,9 +348,9 @@ public class TestWriteVariant extends DirectWriterTest {
 
       GenericRecord actual = writeAndRead(testSchema, record);
 
-      assertEquals(record.get(0), actual.get(0));
-      assertEquals(((GenericRecord) record.get(1)).get(0), ((GenericRecord) actual.get(1)).get(0));
-      assertEquals(((GenericRecord) record.get(1)).get(1), ((GenericRecord) actual.get(1)).get(1));
+      assertThat(actual.get(0)).isEqualTo(record.get(0));
+      assertThat(((GenericRecord) actual.get(1)).get(0)).isEqualTo(((GenericRecord) record.get(1)).get(0));
+      assertThat(((GenericRecord) actual.get(1)).get(1)).isEqualTo(((GenericRecord) record.get(1)).get(1));
     }
   }
 
@@ -362,7 +362,7 @@ public class TestWriteVariant extends DirectWriterTest {
       TestSchema testSchema = new TestSchema(writeSchema, READ_SCHEMA);
 
       GenericRecord actual = writeAndRead(testSchema, record);
-      assertEquals(record.get(0), actual.get(0));
+      assertThat(actual.get(0)).isEqualTo(record.get(0));
       Variant actualV = new Variant((ByteBuffer) ((GenericRecord) actual.get(1)).get(1), (ByteBuffer)
           ((GenericRecord) actual.get(1)).get(0));
       AvroTestUtil.assertEquivalent(v, actualV);
@@ -381,7 +381,7 @@ public class TestWriteVariant extends DirectWriterTest {
       TestSchema testSchema = new TestSchema(writeSchema, READ_SCHEMA);
 
       List<GenericRecord> actual = writeAndRead(testSchema, expected);
-      assertEquals(actual.size(), expected.size());
+      assertThat(actual).hasSameSizeAs(expected);
       for (int i = 0; i < expected.size(); i++) {
         Variant actualV =
             new Variant((ByteBuffer) ((GenericRecord) actual.get(i).get(1)).get(1), (ByteBuffer)
@@ -431,7 +431,7 @@ public class TestWriteVariant extends DirectWriterTest {
 
   GenericRecord writeAndRead(TestSchema testSchema, GenericRecord record) throws IOException {
     List<GenericRecord> result = writeAndRead(testSchema, Arrays.asList(record));
-    assertEquals(result.size(), 1);
+    assertThat(result).hasSize(1);
     return result.get(0);
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Switching assertions from JUnit4-style Assert to AssertJ makes code easier to read and debug when tests fail.


### What changes are included in this PR?
This updates parquet-avro tests to use AssertJ checks, which provide more fluent assertions and more detailed information when assertions fails on CI.

The changes in this PR were done with the help of Claude but I manually reviewed every single LOC

### Are these changes tested?
yes, existing tests

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
