### PR TITLE
GH-3652: Use assertThat checks in parquet-cli tests

### DIFF
--- a/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,19 +49,19 @@ public class BaseCommandTest {
   @Test
   public void qualifiedPathTest() throws IOException {
     Path path = this.command.qualifiedPath(FILE_PATH);
-    Assert.assertEquals("test.parquet", path.getName());
+    assertThat(path.getName()).isEqualTo("test.parquet");
   }
 
   @Test
   public void qualifiedURITest() throws IOException {
     URI uri = this.command.qualifiedURI(FILE_PATH);
-    Assert.assertEquals("/var/tmp/test.parquet", uri.getPath());
+    assertThat(uri.getPath()).isEqualTo("/var/tmp/test.parquet");
   }
 
   @Test
   public void qualifiedURIResourceURITest() throws IOException {
     URI uri = this.command.qualifiedURI("resource:/a");
-    Assert.assertEquals("/a", uri.getPath());
+    assertThat(uri.getPath()).isEqualTo("/a");
   }
 
   @Test
@@ -93,14 +92,14 @@ public class BaseCommandTest {
   public void qualifiedPathTestForWindows() throws IOException {
     Assume.assumeTrue(System.getProperty("os.name").toLowerCase().startsWith("win"));
     Path path = this.command.qualifiedPath(WIN_FILE_PATH);
-    Assert.assertEquals("test.parquet", path.getName());
+    assertThat(path.getName()).isEqualTo("test.parquet");
   }
 
   @Test
   public void qualifiedURITestForWindows() throws IOException {
     Assume.assumeTrue(System.getProperty("os.name").toLowerCase().startsWith("win"));
     URI uri = this.command.qualifiedURI(WIN_FILE_PATH);
-    Assert.assertEquals("/C:/Test/Downloads/test.parquet", uri.getPath());
+    assertThat(uri.getPath()).isEqualTo("/C:/Test/Downloads/test.parquet");
   }
 
   class TestCommand extends BaseCommand {

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+
 import java.io.File;
 import java.io.FileWriter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
 
@@ -30,8 +31,9 @@ public class MainTest {
 
   @Test
   public void mainTest() throws Exception {
-    ToolRunner.run(new Configuration(), new Main(LoggerFactory.getLogger(MainTest.class)), new String[] {});
-    Assert.assertTrue("we simply verify there are no errors here", true);
+    assertThatCode(() -> ToolRunner.run(
+            new Configuration(), new Main(LoggerFactory.getLogger(MainTest.class)), new String[] {}))
+        .doesNotThrowAnyException();
   }
 
   @Test
@@ -43,28 +45,28 @@ public class MainTest {
       writer.write("test.key=test.value\n");
     }
 
-    try {
-      new Main(LoggerFactory.getLogger(MainTest.class))
-          .run(new String[] {"--config-file", configFile.getAbsolutePath(), "help"});
-      Assert.assertTrue("Config file loading should not throw exception", true);
-    } catch (IllegalArgumentException e) {
-      Assert.fail("Config file loading failed: " + e.getMessage());
-    }
+    assertThatCode(() -> new Main(LoggerFactory.getLogger(MainTest.class))
+            .run(new String[] {"--config-file", configFile.getAbsolutePath(), "help"}))
+        .doesNotThrowAnyException();
   }
 
   @Test
   public void testLocalPropertiesFile() throws Exception {
     String configFile = getClass().getResource("/test-config.properties").getPath();
-    ToolRunner.run(new Configuration(), new Main(LoggerFactory.getLogger(MainTest.class)), new String[] {
-      "--config-file", configFile, "version"
-    });
+    assertThatCode(() -> ToolRunner.run(
+            new Configuration(),
+            new Main(LoggerFactory.getLogger(MainTest.class)),
+            new String[] {"--config-file", configFile, "version"}))
+        .doesNotThrowAnyException();
   }
 
   @Test
   public void testLocalXmlFile() throws Exception {
     String configFile = getClass().getResource("/test-config.xml").getPath();
-    ToolRunner.run(new Configuration(), new Main(LoggerFactory.getLogger(MainTest.class)), new String[] {
-      "--config-file", configFile, "version"
-    });
+    assertThatCode(() -> ToolRunner.run(
+            new Configuration(),
+            new Main(LoggerFactory.getLogger(MainTest.class)),
+            new String[] {"--config-file", configFile, "version"}))
+        .doesNotThrowAnyException();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/AvroFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/AvroFileTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
@@ -47,7 +49,7 @@ public class AvroFileTest extends ParquetFileTest {
     command.overwrite = overwrite;
     command.setConf(new Configuration());
     int exitCode = command.run();
-    assert (exitCode == 0);
+    assertThat(exitCode).isZero();
     return outputFile;
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVSchemaCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVSchemaCommandTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CSVSchemaCommandTest extends CSVFileTest {
@@ -33,6 +34,6 @@ public class CSVSchemaCommandTest extends CSVFileTest {
     command.samplePaths = Arrays.asList(file.getAbsolutePath());
     command.recordName = "Test";
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.protobuf.Message;
@@ -35,7 +36,6 @@ import org.apache.parquet.proto.test.TestProtobuf;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CatCommandTest extends ParquetFileTest {
@@ -45,7 +45,7 @@ public class CatCommandTest extends ParquetFileTest {
     CatCommand command = new CatCommand(createLogger(), 0);
     command.sourceFiles = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -54,7 +54,7 @@ public class CatCommandTest extends ParquetFileTest {
     CatCommand command = new CatCommand(createLogger(), 0);
     command.sourceFiles = Arrays.asList(file.getAbsolutePath(), file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -64,7 +64,7 @@ public class CatCommandTest extends ParquetFileTest {
     command.sourceFiles = Arrays.asList(file.getAbsolutePath());
     command.columns = Arrays.asList(INT32_FIELD, INT64_FIELD);
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -89,7 +89,7 @@ public class CatCommandTest extends ParquetFileTest {
     cmd.setConf(new Configuration());
 
     int result = cmd.run();
-    Assert.assertEquals(0, result);
+    assertThat(result).isZero();
   }
 
   @Test
@@ -104,7 +104,7 @@ public class CatCommandTest extends ParquetFileTest {
     cmd.setConf(conf);
 
     int result = cmd.run();
-    Assert.assertEquals(0, result);
+    assertThat(result).isZero();
   }
 
   @Test
@@ -117,7 +117,7 @@ public class CatCommandTest extends ParquetFileTest {
     cmd.setConf(new Configuration());
 
     int result = cmd.run();
-    Assert.assertEquals(0, result);
+    assertThat(result).isZero();
   }
 
   private static void writeParquetWithHyphenatedFields(File file) throws IOException {

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CheckParquet251CommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CheckParquet251CommandTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CheckParquet251CommandTest extends ParquetFileTest {
@@ -32,6 +33,6 @@ public class CheckParquet251CommandTest extends ParquetFileTest {
     CheckParquet251Command command = new CheckParquet251Command(createLogger());
     command.files = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
@@ -21,8 +21,7 @@ package org.apache.parquet.cli.commands;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -36,7 +35,6 @@ import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ColumnSizeCommandTest extends ParquetFileTest {
@@ -51,17 +49,17 @@ public class ColumnSizeCommandTest extends ParquetFileTest {
     ColumnSizeCommand command = new ColumnSizeCommand(createLogger());
     command.target = file.getAbsolutePath();
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
   public void testColumnSize() throws Exception {
     String inputFile = createParquetFile();
     Map<String, Long> columnSizeInBytes = command.getColumnSizeInBytes(new Path(inputFile));
-    assertEquals(columnSizeInBytes.size(), 2);
-    assertTrue(columnSizeInBytes.get("DocId") > columnSizeInBytes.get("Num"));
+    assertThat(columnSizeInBytes).hasSize(2);
+    assertThat(columnSizeInBytes.get("DocId")).isGreaterThan(columnSizeInBytes.get("Num"));
     Map<String, Float> columnRatio = command.getColumnRatio(columnSizeInBytes);
-    assertTrue(columnRatio.get("DocId") > columnRatio.get("Num"));
+    assertThat(columnRatio.get("DocId")).isGreaterThan(columnRatio.get("Num"));
   }
 
   private String createParquetFile() throws IOException {

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ConvertCSVCommandTest extends CSVFileTest {
@@ -36,8 +36,8 @@ public class ConvertCSVCommandTest extends CSVFileTest {
     File output = new File(getTempFolder(), getClass().getSimpleName() + ".parquet");
     command.outputPath = output.getAbsolutePath();
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 
   @Test
@@ -48,8 +48,8 @@ public class ConvertCSVCommandTest extends CSVFileTest {
     File output = new File(getTempFolder(), getClass().getSimpleName() + ".parquet");
     command.outputPath = output.getAbsolutePath();
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 
   @Test
@@ -77,7 +77,7 @@ public class ConvertCSVCommandTest extends CSVFileTest {
     conf.set("parquet.avro.write-parquet-uuid", "true");
     conf.set("parquet.avro.write-old-list-structure", "false");
     command.setConf(conf);
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ConvertCommandTest extends AvroFileTest {
@@ -34,8 +35,8 @@ public class ConvertCommandTest extends AvroFileTest {
     File output = new File(getTempFolder(), "converted.avro");
     command.outputPath = output.getAbsolutePath();
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 
   @Test
@@ -51,8 +52,8 @@ public class ConvertCommandTest extends AvroFileTest {
     conf.set("test.property", "test.value");
     command.setConf(conf);
 
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 
   @Test
@@ -68,8 +69,8 @@ public class ConvertCommandTest extends AvroFileTest {
     conf.set("parquet.avro.write-old-list-structure", "false");
     command.setConf(conf);
 
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
 
     File output2 = new File(getTempFolder(), "converted_with_config_validation2.parquet");
     command.outputPath = output2.getAbsolutePath();
@@ -78,7 +79,7 @@ public class ConvertCommandTest extends AvroFileTest {
     conf2.set("parquet.avro.write-old-list-structure", "true");
     command.setConf(conf2);
 
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output2.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output2).exists();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetMetadataCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetMetadataCommandTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ParquetMetadataCommandTest extends ParquetFileTest {
@@ -32,6 +33,6 @@ public class ParquetMetadataCommandTest extends ParquetFileTest {
     ParquetMetadataCommand command = new ParquetMetadataCommand(createLogger());
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -26,7 +27,6 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class RewriteCommandTest extends ParquetFileTest {
@@ -38,8 +38,8 @@ public class RewriteCommandTest extends ParquetFileTest {
     File output = new File(getTempFolder(), "converted.parquet");
     command.output = output.getAbsolutePath();
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 
   @Test
@@ -68,8 +68,8 @@ public class RewriteCommandTest extends ParquetFileTest {
     command.setConf(new Configuration());
 
     Files.createFile(output.toPath());
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 
   @Test
@@ -82,8 +82,8 @@ public class RewriteCommandTest extends ParquetFileTest {
     command.codec = "GZIP";
     command.setConf(new Configuration());
 
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 
   @Test
@@ -96,7 +96,7 @@ public class RewriteCommandTest extends ParquetFileTest {
     command.codec = "gzip";
     command.setConf(new Configuration());
 
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ScanCommandTest extends ParquetFileTest {
@@ -34,7 +34,7 @@ public class ScanCommandTest extends ParquetFileTest {
     ScanCommand command = new ScanCommand(createLogger());
     command.sourceFiles = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -43,7 +43,7 @@ public class ScanCommandTest extends ParquetFileTest {
     ScanCommand command = new ScanCommand(createLogger());
     command.sourceFiles = Arrays.asList(file.getAbsolutePath(), file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/SchemaCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/SchemaCommandTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -26,7 +27,6 @@ import java.util.Arrays;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class SchemaCommandTest extends ParquetFileTest {
@@ -36,7 +36,7 @@ public class SchemaCommandTest extends ParquetFileTest {
     SchemaCommand command = new SchemaCommand(createLogger());
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -44,14 +44,14 @@ public class SchemaCommandTest extends ParquetFileTest {
     File inputFile = parquetFile();
     File outputFile = new File(getTempFolder(), getClass().getSimpleName() + ".avsc");
     FileUtils.touch(outputFile);
-    Assert.assertEquals(0, outputFile.length());
+    assertThat(outputFile.length()).isZero();
     SchemaCommand command = new SchemaCommand(createLogger());
     command.targets = Arrays.asList(inputFile.getAbsolutePath());
     command.outputPath = outputFile.getAbsolutePath();
     command.overwrite = true;
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(0 < outputFile.length());
+    assertThat(command.run()).isZero();
+    assertThat(outputFile.length()).isPositive();
   }
 
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowBloomFilterCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowBloomFilterCommandTest.java
@@ -21,6 +21,7 @@ package org.apache.parquet.cli.commands;
 
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,7 +45,6 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ShowBloomFilterCommandTest extends ParquetFileTest {
@@ -56,7 +56,7 @@ public class ShowBloomFilterCommandTest extends ParquetFileTest {
     command.columnPath = INT32_FIELD;
     command.testValues = Arrays.asList(new String[] {"1"});
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -75,7 +75,7 @@ public class ShowBloomFilterCommandTest extends ParquetFileTest {
         "02030405060708090a0b0c0d0e0f1011:name,email;0405060708090a0b0c0d0e0f10111213:phone");
     command.setConf(conf);
 
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
 
     ShowBloomFilterCommand emailCommand = new ShowBloomFilterCommand(createLogger());
     emailCommand.file = encryptedFile.getAbsolutePath();
@@ -83,7 +83,7 @@ public class ShowBloomFilterCommandTest extends ParquetFileTest {
     emailCommand.testValues = Arrays.asList(new String[] {"user1@test.com", "missing@test.com"});
     emailCommand.setConf(conf);
 
-    Assert.assertEquals(0, emailCommand.run());
+    assertThat(emailCommand.run()).isZero();
 
     ShowBloomFilterCommand phoneCommand = new ShowBloomFilterCommand(createLogger());
     phoneCommand.file = encryptedFile.getAbsolutePath();
@@ -91,7 +91,7 @@ public class ShowBloomFilterCommandTest extends ParquetFileTest {
     phoneCommand.testValues = Arrays.asList(new String[] {"555-0001", "555-9999"});
     phoneCommand.setConf(conf);
 
-    Assert.assertEquals(0, phoneCommand.run());
+    assertThat(phoneCommand.run()).isZero();
 
     encryptedFile.delete();
   }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowColumnIndexTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowColumnIndexTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ShowColumnIndexTest extends ParquetFileTest {
@@ -32,6 +33,6 @@ public class ShowColumnIndexTest extends ParquetFileTest {
     ShowColumnIndexCommand command = new ShowColumnIndexCommand(createLogger());
     command.files = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ShowDictionaryCommandTest extends ParquetFileTest {
@@ -33,7 +34,7 @@ public class ShowDictionaryCommandTest extends ParquetFileTest {
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.column = BINARY_FIELD;
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -44,7 +45,7 @@ public class ShowDictionaryCommandTest extends ParquetFileTest {
     // the 'double_field' column does not have dictionary encoding
     command.column = DOUBLE_FIELD;
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -54,6 +55,6 @@ public class ShowDictionaryCommandTest extends ParquetFileTest {
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.column = FIXED_LEN_BYTE_ARRAY_FIELD;
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowFooterCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowFooterCommandTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.parquet.cli.commands;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,9 +34,9 @@ public class ShowFooterCommandTest extends ParquetFileTest {
     command.target = file.getAbsolutePath();
     command.raw = false;
     command.setConf(new Configuration());
-    assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
 
     command.raw = true;
-    assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowGeospatialStatisticsCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowGeospatialStatisticsCommandTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ShowGeospatialStatisticsCommandTest extends ParquetFileTest {
@@ -32,6 +33,6 @@ public class ShowGeospatialStatisticsCommandTest extends ParquetFileTest {
     ShowGeospatialStatisticsCommand command = new ShowGeospatialStatisticsCommand(createLogger());
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowPagesCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowPagesCommandTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ShowPagesCommandTest extends ParquetFileTest {
@@ -32,6 +33,6 @@ public class ShowPagesCommandTest extends ParquetFileTest {
     ShowPagesCommand command = new ShowPagesCommand(createLogger());
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowSizeStatisticsCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowSizeStatisticsCommandTest.java
@@ -18,11 +18,12 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ShowSizeStatisticsCommandTest extends ParquetFileTest {
@@ -32,7 +33,7 @@ public class ShowSizeStatisticsCommandTest extends ParquetFileTest {
     ShowSizeStatisticsCommand command = new ShowSizeStatisticsCommand(createLogger());
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -42,7 +43,7 @@ public class ShowSizeStatisticsCommandTest extends ParquetFileTest {
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.columns = Arrays.asList(INT32_FIELD, INT64_FIELD);
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 
   @Test
@@ -52,6 +53,6 @@ public class ShowSizeStatisticsCommandTest extends ParquetFileTest {
     command.targets = Arrays.asList(file.getAbsolutePath());
     command.rowGroups = Arrays.asList(0);
     command.setConf(new Configuration());
-    Assert.assertEquals(0, command.run());
+    assertThat(command.run()).isZero();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowVersionCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowVersionCommandTest.java
@@ -18,9 +18,10 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Queue;
 import org.apache.parquet.Version;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.event.LoggingEvent;
@@ -34,10 +35,10 @@ public class ShowVersionCommandTest extends FileTest {
 
   private void testVersionCommand0(Logger console, Queue<? extends LoggingEvent> loggingEvents) {
     ShowVersionCommand command = new ShowVersionCommand(console);
-    Assert.assertEquals(0, command.run());
-    Assert.assertEquals(1, loggingEvents.size());
+    assertThat(command.run()).isZero();
+    assertThat(loggingEvents).hasSize(1);
     LoggingEvent loggingEvent = loggingEvents.remove();
-    Assert.assertEquals(Version.FULL_VERSION, loggingEvent.getMessage());
+    assertThat(loggingEvent.getMessage()).isEqualTo(Version.FULL_VERSION);
     loggingEvents.clear();
   }
 }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.beust.jcommander.JCommander;
@@ -28,7 +29,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -40,7 +40,7 @@ public class ToAvroCommandTest extends AvroFileTest {
   @Test
   public void testToAvroCommandFromParquet() throws IOException {
     File avroFile = toAvro(parquetFile());
-    Assert.assertTrue(avroFile.exists());
+    assertThat(avroFile).exists();
   }
 
   @Test
@@ -64,37 +64,37 @@ public class ToAvroCommandTest extends AvroFileTest {
         .build()
         .parse("--overwrite", jsonInputFile.getAbsolutePath(), "--output", avroOutputFile.getAbsolutePath());
 
-    assert (cmd.run() == 0);
+    assertThat(cmd.run()).isZero();
   }
 
   @Test
   public void testToAvroCommandWithGzipCompression() throws IOException {
     File avroFile = toAvro(parquetFile(), "GZIP");
-    Assert.assertTrue(avroFile.exists());
+    assertThat(avroFile).exists();
   }
 
   @Test
   public void testToAvroCommandWithSnappyCompression() throws IOException {
     File avroFile = toAvro(parquetFile(), "SNAPPY");
-    Assert.assertTrue(avroFile.exists());
+    assertThat(avroFile).exists();
   }
 
   @Test
   public void testToAvroCommandWithZstdCompression() throws IOException {
     File avroFile = toAvro(parquetFile(), "ZSTD");
-    Assert.assertTrue(avroFile.exists());
+    assertThat(avroFile).exists();
   }
 
   @Test
   public void testToAvroCommandWithBzip2Compression() throws IOException {
     File avroFile = toAvro(parquetFile(), "bzip2");
-    Assert.assertTrue(avroFile.exists());
+    assertThat(avroFile).exists();
   }
 
   @Test
   public void testToAvroCommandWithXzCompression() throws IOException {
     File avroFile = toAvro(parquetFile(), "xz");
-    Assert.assertTrue(avroFile.exists());
+    assertThat(avroFile).exists();
   }
 
   @Test
@@ -109,9 +109,9 @@ public class ToAvroCommandTest extends AvroFileTest {
   public void testToAvroCommandOverwriteExistentFile() throws IOException {
     File outputFile = new File(getTempFolder(), getClass().getSimpleName() + ".avro");
     FileUtils.touch(outputFile);
-    Assert.assertEquals(0, outputFile.length());
+    assertThat(outputFile.length()).isZero();
     File avroFile = toAvro(parquetFile(), outputFile, true);
-    Assert.assertTrue(0 < avroFile.length());
+    assertThat(avroFile.length()).isPositive();
   }
 
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/TransCompressionCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/TransCompressionCommandTest.java
@@ -18,10 +18,11 @@
  */
 package org.apache.parquet.cli.commands;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TransCompressionCommandTest extends ParquetFileTest {
@@ -37,8 +38,8 @@ public class TransCompressionCommandTest extends ParquetFileTest {
     command.codec = "ZSTD";
     command.setConf(new Configuration());
 
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 
   @Test
@@ -52,7 +53,7 @@ public class TransCompressionCommandTest extends ParquetFileTest {
     command.codec = "zstd";
     command.setConf(new Configuration());
 
-    Assert.assertEquals(0, command.run());
-    Assert.assertTrue(output.exists());
+    assertThat(command.run()).isZero();
+    assertThat(output).exists();
   }
 }

--- a/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking512VectorLE.java
+++ b/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking512VectorLE.java
@@ -110,7 +110,7 @@ public class TestByteBitPacking512VectorLE {
         directBuffer.put(byteOutput);
         directBuffer.flip();
         unpackValuesUsingVectorByteBuffer(bitWidth, directBuffer, output);
-        assertArrayEquals(expected, output);
+        assertThat(output).isEqualTo(expected);
         Arrays.fill(output, 0);
       });
     }
@@ -138,7 +138,7 @@ public class TestByteBitPacking512VectorLE {
         // Read-only heap ByteBuffer (hasArray() returns false)
         ByteBuffer readOnlyBuffer = ByteBuffer.wrap(byteOutput).asReadOnlyBuffer();
         unpackValuesUsingVectorByteBuffer(bitWidth, readOnlyBuffer, output);
-        assertArrayEquals(expected, output);
+        assertThat(output).isEqualTo(expected);
         Arrays.fill(output, 0);
       });
     }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Switching assertions from JUnit4-style Assert to AssertJ makes code easier to read and debug when tests fail.


### What changes are included in this PR?
This updates parquet-cli tests to use AssertJ checks, which provide more fluent assertions and more detailed information when assertions fails on CI.

The changes in this PR were done with the help of Claude but I manually reviewed every single LOC

### Are these changes tested?
yes, existing tests

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
