### PR TITLE
GH-3667: Close input readers when ParquetRewriter setup fails

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/rewrite/ParquetRewriter.java
@@ -87,6 +87,7 @@ import org.apache.parquet.schema.InvalidSchemaException;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+import org.apache.parquet.util.AutoCloseables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -336,7 +337,16 @@ public class ParquetRewriter implements Closeable {
             inputFile, ParquetReadOptions.builder(conf).build());
         inputFileReaders.add(reader);
       } catch (IOException e) {
-        throw new IllegalArgumentException("Failed to open input file: " + inputFile, e);
+        IllegalArgumentException failure =
+            new IllegalArgumentException("Failed to open input file: " + inputFile, e);
+        // Close the readers already opened so their input streams do not leak, aggregating any
+        // close failures as suppressed exceptions on the original failure.
+        try {
+          AutoCloseables.close(inputFileReaders);
+        } catch (Throwable t) {
+          failure.addSuppressed(t);
+        }
+        throw failure;
       }
     }
     return inputFileReaders;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -46,6 +46,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -88,6 +89,7 @@ import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.apache.parquet.hadoop.util.TestFileBuilder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.io.DelegatingSeekableInputStream;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.io.OutputFile;
@@ -770,6 +772,86 @@ public class ParquetRewriterTest {
             null, ImmutableMap.of("Name", "NameRenamed"), ImmutableMap.of("Name", MaskMode.NULLIFY)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot nullify and rename the same column");
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testInputFileReadersClosedWhenLaterInputFileFailsToOpen(RewriterTestParams params) throws Exception {
+    initTestState(params);
+    MessageType schema = new MessageType("schema", new PrimitiveType(OPTIONAL, INT64, "DocId"));
+    EncryptionTestFile file = new TestFileBuilder(conf, schema)
+        .withNumRecord(numRecord)
+        .withCodec("UNCOMPRESSED")
+        .withPageSize(ParquetProperties.DEFAULT_PAGE_SIZE)
+        .withWriterVersion(writerVersion)
+        .build();
+
+    CloseRecordingInputFile openable =
+        new CloseRecordingInputFile(HadoopInputFile.fromPath(new Path(file.getFileName()), conf));
+    InputFile failing = new InputFile() {
+      @Override
+      public long getLength() {
+        return 0;
+      }
+
+      @Override
+      public SeekableInputStream newStream() throws IOException {
+        throw new IOException("simulated open failure");
+      }
+    };
+
+    OutputFile output = HadoopOutputFile.fromPath(new Path(outputFile), conf);
+    RewriteOptions options =
+        new RewriteOptions.Builder(parquetConf, Arrays.asList(openable, failing), output).build();
+
+    assertThatThrownBy(() -> new ParquetRewriter(options))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Failed to open input file: " + failing);
+    assertThat(openable.isStreamClosed()).isTrue();
+  }
+
+  /**
+   * An {@link InputFile} that delegates to another one but records whether the {@link SeekableInputStream} it handed
+   * out was closed, so a test can assert that already-opened readers are released on a later failure.
+   */
+  private static class CloseRecordingInputFile implements InputFile {
+    private final InputFile delegate;
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+
+    CloseRecordingInputFile(InputFile delegate) {
+      this.delegate = delegate;
+    }
+
+    boolean isStreamClosed() {
+      return streamClosed.get();
+    }
+
+    @Override
+    public long getLength() throws IOException {
+      return delegate.getLength();
+    }
+
+    @Override
+    public SeekableInputStream newStream() throws IOException {
+      SeekableInputStream stream = delegate.newStream();
+      return new DelegatingSeekableInputStream(stream) {
+        @Override
+        public long getPos() throws IOException {
+          return stream.getPos();
+        }
+
+        @Override
+        public void seek(long newPos) throws IOException {
+          stream.seek(newPos);
+        }
+
+        @Override
+        public void close() throws IOException {
+          streamClosed.set(true);
+          super.close();
+        }
+      };
+    }
   }
 
   public void testMergeTwoFilesWithDifferentSchemaSetup(


### PR DESCRIPTION

### Rationale for this change

`ParquetRewriter.getFileReaders` opens a `TransParquetFileReader` for each input
file into a local list. If opening a later file throws `IOException`, it is
rethrown as `IllegalArgumentException` without closing the readers already opened
for the earlier files, so their `SeekableInputStream` handles leak. A single
corrupt, missing, or permission-denied file among several valid inputs can
therefore leak the input streams opened before the partial-open failure.

### What changes are included in this PR?

In `getFileReaders`, close the readers already opened before rethrowing, using
`org.apache.parquet.util.AutoCloseables.close(...)` so every reader is released
and any close failures are aggregated as suppressed exceptions on the original
`IllegalArgumentException`. This matches the existing cleanup idiom in the module.
The change is limited to the `catch (IOException)` block; the success path is
unchanged.

### Are these changes tested?

Yes. A new `ParquetRewriterTest` case
(`testInputFileReadersClosedWhenLaterInputFileFailsToOpen`) supplies a valid
input file (wrapped so it records whether the stream it hands out is closed)
followed by an `InputFile` whose `newStream()` throws, asserts that constructing
the `ParquetRewriter` throws `IllegalArgumentException`, and asserts the first
reader's stream was closed. It fails on the pre-fix code (the first stream is
left open) and passes with the fix. The full `ParquetRewriterTest` class passes
(`Tests run: 96, Failures: 0, Errors: 0`).

### Are there any user-facing changes?

No public API changes. On a partial-open failure while opening input files,
`ParquetRewriter` now closes the input streams it had already opened.

Closes #3667
