### PR TITLE
MINOR: Close output stream when ParquetFileWriter construction fails on encryption validation

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ParquetFileWriter.java
@@ -519,36 +519,44 @@ public class ParquetFileWriter implements AutoCloseable {
       return;
     }
 
-    if (null == encryptionProperties) {
-      encryptionProperties = encryptor.getEncryptionProperties();
-    }
+    try {
+      if (null == encryptionProperties) {
+        encryptionProperties = encryptor.getEncryptionProperties();
+      }
 
-    // Verify that every encrypted column is in file schema
-    Map<ColumnPath, ColumnEncryptionProperties> columnEncryptionProperties =
-        encryptionProperties.getEncryptedColumns();
-    if (null != columnEncryptionProperties) { // if null, every column in file schema will be encrypted with footer
-      // key
-      for (Map.Entry<ColumnPath, ColumnEncryptionProperties> entry : columnEncryptionProperties.entrySet()) {
-        String[] path = entry.getKey().toArray();
-        if (!schema.containsPath(path)) {
-          StringBuilder columnList = new StringBuilder();
-          columnList.append("[");
-          for (String[] columnPath : schema.getPaths()) {
-            columnList
-                .append(ColumnPath.get(columnPath).toDotString())
-                .append("], [");
+      // Verify that every encrypted column is in file schema
+      Map<ColumnPath, ColumnEncryptionProperties> columnEncryptionProperties =
+          encryptionProperties.getEncryptedColumns();
+      if (null != columnEncryptionProperties) { // if null, every column in file schema will be encrypted with
+        // footer
+        // key
+        for (Map.Entry<ColumnPath, ColumnEncryptionProperties> entry : columnEncryptionProperties.entrySet()) {
+          String[] path = entry.getKey().toArray();
+          if (!schema.containsPath(path)) {
+            StringBuilder columnList = new StringBuilder();
+            columnList.append("[");
+            for (String[] columnPath : schema.getPaths()) {
+              columnList
+                  .append(ColumnPath.get(columnPath).toDotString())
+                  .append("], [");
+            }
+            throw new ParquetCryptoRuntimeException("Encrypted column ["
+                + entry.getKey().toDotString() + "] not in file schema column list: "
+                + columnList.substring(0, columnList.length() - 3));
           }
-          throw new ParquetCryptoRuntimeException(
-              "Encrypted column [" + entry.getKey().toDotString() + "] not in file schema column list: "
-                  + columnList.substring(0, columnList.length() - 3));
         }
       }
-    }
 
-    if (null == encryptor) {
-      this.fileEncryptor = new InternalFileEncryptor(encryptionProperties);
-    } else {
-      this.fileEncryptor = encryptor;
+      if (null == encryptor) {
+        this.fileEncryptor = new InternalFileEncryptor(encryptionProperties);
+      } else {
+        this.fileEncryptor = encryptor;
+      }
+    } catch (Exception e) {
+      // If encryption setup throws in the constructor, the output stream opened above should be
+      // closed. Otherwise, there's no way to close it outside since the object is never returned.
+      out.close();
+      throw e;
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -76,6 +77,9 @@ import org.apache.parquet.column.statistics.BinaryStatistics;
 import org.apache.parquet.column.statistics.LongStatistics;
 import org.apache.parquet.column.values.bloomfilter.BlockSplitBloomFilter;
 import org.apache.parquet.column.values.bloomfilter.BloomFilter;
+import org.apache.parquet.crypto.ColumnEncryptionProperties;
+import org.apache.parquet.crypto.FileEncryptionProperties;
+import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.example.data.simple.SimpleGroup;
 import org.apache.parquet.format.Statistics;
@@ -84,6 +88,7 @@ import org.apache.parquet.hadoop.example.GroupReadSupport;
 import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.metadata.ConcatenatingKeyValueMetadataMergeStrategy;
 import org.apache.parquet.hadoop.metadata.FileMetaData;
@@ -98,7 +103,9 @@ import org.apache.parquet.internal.column.columnindex.BinaryTruncator;
 import org.apache.parquet.internal.column.columnindex.BoundaryOrder;
 import org.apache.parquet.internal.column.columnindex.ColumnIndex;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.ParquetEncodingException;
+import org.apache.parquet.io.PositionOutputStream;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
@@ -1441,6 +1448,89 @@ public class TestParquetFileWriter {
         merged.merge(new StrictKeyValueMetadataMergeStrategy()).getKeyValueMetaData();
     assertThat(mergedValues.get("a")).isEqualTo("b");
     assertThat(mergedValues.get("c")).isEqualTo("d");
+  }
+
+  @Test
+  public void testConstructorClosesStreamWhenEncryptedColumnMissing() throws Exception {
+    ColumnEncryptionProperties missingColumn = ColumnEncryptionProperties.builder("not_in_schema")
+        .withKey("0123456789012345".getBytes(StandardCharsets.UTF_8))
+        .build();
+    Map<ColumnPath, ColumnEncryptionProperties> encryptedColumns = new HashMap<>();
+    encryptedColumns.put(missingColumn.getPath(), missingColumn);
+    FileEncryptionProperties encryptionProperties = FileEncryptionProperties.builder(
+            "0123456789012345".getBytes(StandardCharsets.UTF_8))
+        .withEncryptedColumns(encryptedColumns)
+        .build();
+
+    RecordingOutputFile file = new RecordingOutputFile();
+    assertThatThrownBy(() -> new ParquetFileWriter(
+            file,
+            SCHEMA,
+            CREATE,
+            DEFAULT_BLOCK_SIZE,
+            MAX_PADDING_SIZE_DEFAULT,
+            ParquetProperties.DEFAULT_COLUMN_INDEX_TRUNCATE_LENGTH,
+            ParquetProperties.DEFAULT_STATISTICS_TRUNCATE_LENGTH,
+            ParquetProperties.DEFAULT_PAGE_WRITE_CHECKSUM_ENABLED,
+            encryptionProperties))
+        .isInstanceOf(ParquetCryptoRuntimeException.class)
+        .hasMessage("Encrypted column [not_in_schema] not in file schema column list: [a.b], [c.d]");
+
+    assertThat(file.isStreamClosed()).isTrue();
+  }
+
+  /**
+   * An {@link OutputFile} whose {@link PositionOutputStream} records whether it was closed, used to
+   * assert that a failed {@link ParquetFileWriter} construction does not leak the open stream.
+   */
+  private static class RecordingOutputFile implements OutputFile {
+
+    private final AtomicBoolean streamClosed = new AtomicBoolean(false);
+
+    boolean isStreamClosed() {
+      return streamClosed.get();
+    }
+
+    private PositionOutputStream newRecordingStream() {
+      return new PositionOutputStream() {
+        private long pos = 0;
+
+        @Override
+        public long getPos() {
+          return pos;
+        }
+
+        @Override
+        public void write(int b) {
+          pos++;
+        }
+
+        @Override
+        public void close() {
+          streamClosed.set(true);
+        }
+      };
+    }
+
+    @Override
+    public PositionOutputStream create(long blockSizeHint) {
+      return newRecordingStream();
+    }
+
+    @Override
+    public PositionOutputStream createOrOverwrite(long blockSizeHint) {
+      return newRecordingStream();
+    }
+
+    @Override
+    public boolean supportsBlockSize() {
+      return false;
+    }
+
+    @Override
+    public long defaultBlockSize() {
+      return 0;
+    }
   }
 
   private org.apache.parquet.column.statistics.Statistics<?> statsC1(Binary... values) {


### PR DESCRIPTION

### Rationale for this change

The shared private `ParquetFileWriter` constructor opens the output stream early
(`OutputFile.create` / `createOrOverwrite`), and only afterwards validates that
every column named in the encryption properties actually exists in the file
schema. When a configured encrypted column is missing, it throws
`ParquetCryptoRuntimeException`.

That validation runs after the stream is opened and is not guarded, so on the
throw the half-constructed writer is never returned to the caller. Its `close()`
is the only place that closes the stream, and it can never run, so the open
stream (and its underlying file/DFS handle and buffers) leaks. A service that
repeatedly constructs writers against a misconfigured encryption schema
accumulates leaked handles until exhaustion.

This is the same acquire-then-throw hazard the sibling `ParquetFileReader`
constructor already guards against by closing its stream before rethrowing, so
the writer should behave consistently.

### What changes are included in this PR?

- In `ParquetFileWriter`, wrap the encryption-setup and encrypted-column-in-schema
  validation block (which runs after `this.out` is assigned) in a
  `try { ... } catch (Exception e) { out.close(); throw e; }`. On any exception
  the already-opened stream is closed before the exception propagates, mirroring
  the existing guard in the `ParquetFileReader` constructor. The early return for
  the no-encryption case is left outside the guard (nothing to clean up there).
- Add a regression test, `testConstructorClosesStreamWhenEncryptedColumnMissing`,
  that constructs a writer with an encrypted column absent from the schema,
  asserts the expected `ParquetCryptoRuntimeException`, and asserts the stream was
  closed. It uses a small `RecordingOutputFile` whose `PositionOutputStream`
  flips an `AtomicBoolean` on `close()`, so it needs no disk I/O.

Two files change: `ParquetFileWriter.java` (the guard) and
`TestParquetFileWriter.java` (the test plus helper).

### Are these changes tested?

Yes.

- The new test is red without the source fix (the stream is left open) and green
  with it. It runs parameterized (vectored true/false), 2/2 passing.
- Regression sweep passes: `TestParquetFileWriter` (38), `TestParquetWriter`
  (19), `TestEncryptionOptions` (1), 0 failures / 0 errors.
- Spotless is clean on both changed files.

Commands used:

```
mvn -q -pl parquet-hadoop -am -DskipTests -Dspotless.check.skip=true install
mvn -pl parquet-hadoop -Dtest=TestParquetFileWriter#testConstructorClosesStreamWhenEncryptedColumnMissing test
mvn -pl parquet-hadoop -Dtest=TestParquetFileWriter,TestParquetWriter,TestEncryptionOptions test
```

### Are there any user-facing changes?

No. Behavior on the success path is unchanged; the only difference is that a
failed writer construction (invalid encrypted-column configuration) now releases
the output stream it opened instead of leaking it. No public API changes.

<!-- No GitHub issue filed; using MINOR: per the PR template. -->
