### PR TITLE
GH-3652: Use assertThat checks in parquet-hadoop tests

### DIFF
--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/DecryptionPropertiesFactoryTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/DecryptionPropertiesFactoryTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.parquet.crypto;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
@@ -36,12 +36,10 @@ public class DecryptionPropertiesFactoryTest {
     FileDecryptionProperties decryptionProperties =
         decryptionPropertiesFactory.getFileDecryptionProperties(conf, null);
 
-    assertArrayEquals(decryptionProperties.getFooterKey(), SampleDecryptionPropertiesFactory.FOOTER_KEY);
-    assertArrayEquals(
-        decryptionProperties.getColumnKey(SampleDecryptionPropertiesFactory.COL1),
-        SampleDecryptionPropertiesFactory.COL1_KEY);
-    assertArrayEquals(
-        decryptionProperties.getColumnKey(SampleDecryptionPropertiesFactory.COL2),
-        SampleDecryptionPropertiesFactory.COL2_KEY);
+    assertThat(decryptionProperties.getFooterKey()).isEqualTo(SampleDecryptionPropertiesFactory.FOOTER_KEY);
+    assertThat(decryptionProperties.getColumnKey(SampleDecryptionPropertiesFactory.COL1))
+        .isEqualTo(SampleDecryptionPropertiesFactory.COL1_KEY);
+    assertThat(decryptionProperties.getColumnKey(SampleDecryptionPropertiesFactory.COL2))
+        .isEqualTo(SampleDecryptionPropertiesFactory.COL2_KEY);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/EncryptionPropertiesFactoryTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/EncryptionPropertiesFactoryTest.java
@@ -19,8 +19,7 @@
 
 package org.apache.parquet.crypto;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.conf.ParquetConfiguration;
@@ -40,13 +39,11 @@ public class EncryptionPropertiesFactoryTest {
     FileEncryptionProperties encryptionProperties =
         encryptionPropertiesFactory.getFileEncryptionProperties(conf, null, null);
 
-    assertArrayEquals(encryptionProperties.getFooterKey(), SampleEncryptionPropertiesFactory.FOOTER_KEY);
-    assertEquals(
-        encryptionProperties.getColumnProperties(SampleEncryptionPropertiesFactory.COL1),
-        SampleEncryptionPropertiesFactory.COL1_ENCR_PROPERTIES);
-    assertEquals(
-        encryptionProperties.getColumnProperties(SampleEncryptionPropertiesFactory.COL2),
-        SampleEncryptionPropertiesFactory.COL2_ENCR_PROPERTIES);
+    assertThat(encryptionProperties.getFooterKey()).isEqualTo(SampleEncryptionPropertiesFactory.FOOTER_KEY);
+    assertThat(encryptionProperties.getColumnProperties(SampleEncryptionPropertiesFactory.COL1))
+        .isEqualTo(SampleEncryptionPropertiesFactory.COL1_ENCR_PROPERTIES);
+    assertThat(encryptionProperties.getColumnProperties(SampleEncryptionPropertiesFactory.COL2))
+        .isEqualTo(SampleEncryptionPropertiesFactory.COL2_ENCR_PROPERTIES);
   }
 
   @Test
@@ -60,12 +57,10 @@ public class EncryptionPropertiesFactoryTest {
     FileEncryptionProperties encryptionProperties = encryptionPropertiesFactory.getFileEncryptionProperties(
         ConfigurationUtil.createHadoopConfiguration(conf), null, null);
 
-    assertArrayEquals(encryptionProperties.getFooterKey(), SampleEncryptionPropertiesFactory.FOOTER_KEY);
-    assertEquals(
-        encryptionProperties.getColumnProperties(SampleEncryptionPropertiesFactory.COL1),
-        SampleEncryptionPropertiesFactory.COL1_ENCR_PROPERTIES);
-    assertEquals(
-        encryptionProperties.getColumnProperties(SampleEncryptionPropertiesFactory.COL2),
-        SampleEncryptionPropertiesFactory.COL2_ENCR_PROPERTIES);
+    assertThat(encryptionProperties.getFooterKey()).isEqualTo(SampleEncryptionPropertiesFactory.FOOTER_KEY);
+    assertThat(encryptionProperties.getColumnProperties(SampleEncryptionPropertiesFactory.COL1))
+        .isEqualTo(SampleEncryptionPropertiesFactory.COL1_ENCR_PROPERTIES);
+    assertThat(encryptionProperties.getColumnProperties(SampleEncryptionPropertiesFactory.COL2))
+        .isEqualTo(SampleEncryptionPropertiesFactory.COL2_ENCR_PROPERTIES);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/crypto/propertiesfactory/SchemaControlEncryptionTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/crypto/propertiesfactory/SchemaControlEncryptionTest.java
@@ -24,8 +24,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -172,14 +171,14 @@ public class SchemaControlEncryptionTest {
         .build();
     for (int i = 0; i < numRecord; i++) {
       Group group = reader.read();
-      assertEquals(testData.get("Name")[i], group.getBinary("Name", 0).toStringUsingUTF8());
-      assertEquals(testData.get("Age")[i], group.getLong("Age", 0));
+      assertThat(group.getBinary("Name", 0).toStringUsingUTF8()).isEqualTo(testData.get("Name")[i]);
+      assertThat(group.getLong("Age", 0)).isEqualTo(testData.get("Age")[i]);
 
       Group subGroup = group.getGroup("WebLinks", 0);
-      assertArrayEquals(
-          subGroup.getBinary("LinkedIn", 0).getBytes(), ((String) testData.get("LinkedIn")[i]).getBytes());
-      assertArrayEquals(
-          subGroup.getBinary("Twitter", 0).getBytes(), ((String) testData.get("Twitter")[i]).getBytes());
+      assertThat(((String) testData.get("LinkedIn")[i]).getBytes())
+          .isEqualTo(subGroup.getBinary("LinkedIn", 0).getBytes());
+      assertThat(((String) testData.get("Twitter")[i]).getBytes())
+          .isEqualTo(subGroup.getBinary("Twitter", 0).getBytes());
     }
     reader.close();
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/encodings/FileEncodingsIT.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/encodings/FileEncodingsIT.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.encodings;
 
-import static junit.framework.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -555,12 +555,11 @@ public class FileEncodingsIT {
     }
 
     public void validateNextValue(Object value) {
-      assertEquals(
-          String.format(
+      assertThat(value)
+          .as(String.format(
               "Value from page is different than expected, ROW_GROUP_ID=%d PAGE_ID=%d VALUE_POS=%d",
-              rowGroupID, pageID, currentPos),
-          expectedValues.get(currentPos++),
-          value);
+              rowGroupID, pageID, currentPos))
+          .isEqualTo(expectedValues.get(currentPos++));
     }
 
     public static void validateValuesForPage(

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/TestFiltersWithMissingColumns.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/TestFiltersWithMissingColumns.java
@@ -36,7 +36,7 @@ import static org.apache.parquet.io.api.Binary.fromString;
 import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -99,116 +99,110 @@ public class TestFiltersWithMissingColumns {
 
   @Test
   public void testNormalFilter() throws Exception {
-    assertEquals(500, countFilteredRecords(path, lt(longColumn("id"), 500L)));
+    assertThat(countFilteredRecords(path, lt(longColumn("id"), 500L))).isEqualTo(500);
   }
 
   @Test
   public void testSimpleMissingColumnFilter() throws Exception {
-    assertEquals(0, countFilteredRecords(path, lt(longColumn("missing"), 500L)));
+    assertThat(countFilteredRecords(path, lt(longColumn("missing"), 500L))).isEqualTo(0);
     Set<Long> values = new HashSet<>();
     values.add(1L);
     values.add(2L);
     values.add(5L);
-    assertEquals(0, countFilteredRecords(path, in(longColumn("missing"), values)));
-    assertEquals(1000, countFilteredRecords(path, notIn(longColumn("missing"), values)));
+    assertThat(countFilteredRecords(path, in(longColumn("missing"), values)))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, notIn(longColumn("missing"), values)))
+        .isEqualTo(1000);
   }
 
   @Test
   public void testAndMissingColumnFilter() throws Exception {
     // missing column filter is true
-    assertEquals(
-        500, countFilteredRecords(path, and(lt(longColumn("id"), 500L), eq(binaryColumn("missing"), null))));
-    assertEquals(
-        500,
-        countFilteredRecords(
-            path, and(lt(longColumn("id"), 500L), notEq(binaryColumn("missing"), fromString("any")))));
+    assertThat(countFilteredRecords(path, and(lt(longColumn("id"), 500L), eq(binaryColumn("missing"), null))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(
+            path, and(lt(longColumn("id"), 500L), notEq(binaryColumn("missing"), fromString("any")))))
+        .isEqualTo(500);
 
-    assertEquals(
-        500, countFilteredRecords(path, and(eq(binaryColumn("missing"), null), lt(longColumn("id"), 500L))));
-    assertEquals(
-        500,
-        countFilteredRecords(
-            path, and(notEq(binaryColumn("missing"), fromString("any")), lt(longColumn("id"), 500L))));
+    assertThat(countFilteredRecords(path, and(eq(binaryColumn("missing"), null), lt(longColumn("id"), 500L))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(
+            path, and(notEq(binaryColumn("missing"), fromString("any")), lt(longColumn("id"), 500L))))
+        .isEqualTo(500);
 
     // missing column filter is false
-    assertEquals(
-        0,
-        countFilteredRecords(
-            path, and(lt(longColumn("id"), 500L), eq(binaryColumn("missing"), fromString("any")))));
-    assertEquals(
-        0, countFilteredRecords(path, and(lt(longColumn("id"), 500L), notEq(binaryColumn("missing"), null))));
-    assertEquals(
-        0, countFilteredRecords(path, and(lt(longColumn("id"), 500L), lt(doubleColumn("missing"), 33.33))));
-    assertEquals(
-        0, countFilteredRecords(path, and(lt(longColumn("id"), 500L), ltEq(doubleColumn("missing"), 33.33))));
-    assertEquals(
-        0, countFilteredRecords(path, and(lt(longColumn("id"), 500L), gt(doubleColumn("missing"), 33.33))));
-    assertEquals(
-        0, countFilteredRecords(path, and(lt(longColumn("id"), 500L), gtEq(doubleColumn("missing"), 33.33))));
+    assertThat(countFilteredRecords(
+            path, and(lt(longColumn("id"), 500L), eq(binaryColumn("missing"), fromString("any")))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(lt(longColumn("id"), 500L), notEq(binaryColumn("missing"), null))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(lt(longColumn("id"), 500L), lt(doubleColumn("missing"), 33.33))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(lt(longColumn("id"), 500L), ltEq(doubleColumn("missing"), 33.33))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(lt(longColumn("id"), 500L), gt(doubleColumn("missing"), 33.33))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(lt(longColumn("id"), 500L), gtEq(doubleColumn("missing"), 33.33))))
+        .isEqualTo(0);
 
-    assertEquals(
-        0,
-        countFilteredRecords(
-            path, and(eq(binaryColumn("missing"), fromString("any")), lt(longColumn("id"), 500L))));
-    assertEquals(
-        0, countFilteredRecords(path, and(notEq(binaryColumn("missing"), null), lt(longColumn("id"), 500L))));
-    assertEquals(
-        0, countFilteredRecords(path, and(lt(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))));
-    assertEquals(
-        0, countFilteredRecords(path, and(ltEq(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))));
-    assertEquals(
-        0, countFilteredRecords(path, and(gt(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))));
-    assertEquals(
-        0, countFilteredRecords(path, and(gtEq(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))));
+    assertThat(countFilteredRecords(
+            path, and(eq(binaryColumn("missing"), fromString("any")), lt(longColumn("id"), 500L))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(notEq(binaryColumn("missing"), null), lt(longColumn("id"), 500L))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(lt(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(ltEq(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(gt(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))))
+        .isEqualTo(0);
+    assertThat(countFilteredRecords(path, and(gtEq(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))))
+        .isEqualTo(0);
   }
 
   @Test
   public void testOrMissingColumnFilter() throws Exception {
     // missing column filter is false
-    assertEquals(
-        500,
-        countFilteredRecords(
-            path, or(lt(longColumn("id"), 500L), eq(binaryColumn("missing"), fromString("any")))));
-    assertEquals(
-        500, countFilteredRecords(path, or(lt(longColumn("id"), 500L), notEq(binaryColumn("missing"), null))));
-    assertEquals(
-        500, countFilteredRecords(path, or(lt(longColumn("id"), 500L), lt(doubleColumn("missing"), 33.33))));
-    assertEquals(
-        500, countFilteredRecords(path, or(lt(longColumn("id"), 500L), ltEq(doubleColumn("missing"), 33.33))));
-    assertEquals(
-        500, countFilteredRecords(path, or(lt(longColumn("id"), 500L), gt(doubleColumn("missing"), 33.33))));
-    assertEquals(
-        500, countFilteredRecords(path, or(lt(longColumn("id"), 500L), gtEq(doubleColumn("missing"), 33.33))));
+    assertThat(countFilteredRecords(
+            path, or(lt(longColumn("id"), 500L), eq(binaryColumn("missing"), fromString("any")))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(lt(longColumn("id"), 500L), notEq(binaryColumn("missing"), null))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(lt(longColumn("id"), 500L), lt(doubleColumn("missing"), 33.33))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(lt(longColumn("id"), 500L), ltEq(doubleColumn("missing"), 33.33))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(lt(longColumn("id"), 500L), gt(doubleColumn("missing"), 33.33))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(lt(longColumn("id"), 500L), gtEq(doubleColumn("missing"), 33.33))))
+        .isEqualTo(500);
 
-    assertEquals(
-        500,
-        countFilteredRecords(
-            path, or(eq(binaryColumn("missing"), fromString("any")), lt(longColumn("id"), 500L))));
-    assertEquals(
-        500, countFilteredRecords(path, or(notEq(binaryColumn("missing"), null), lt(longColumn("id"), 500L))));
-    assertEquals(
-        500, countFilteredRecords(path, or(lt(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))));
-    assertEquals(
-        500, countFilteredRecords(path, or(ltEq(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))));
-    assertEquals(
-        500, countFilteredRecords(path, or(gt(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))));
-    assertEquals(
-        500, countFilteredRecords(path, or(gtEq(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))));
+    assertThat(countFilteredRecords(
+            path, or(eq(binaryColumn("missing"), fromString("any")), lt(longColumn("id"), 500L))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(notEq(binaryColumn("missing"), null), lt(longColumn("id"), 500L))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(lt(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(ltEq(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(gt(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))))
+        .isEqualTo(500);
+    assertThat(countFilteredRecords(path, or(gtEq(doubleColumn("missing"), 33.33), lt(longColumn("id"), 500L))))
+        .isEqualTo(500);
 
     // missing column filter is false
-    assertEquals(
-        1000, countFilteredRecords(path, or(lt(longColumn("id"), 500L), eq(binaryColumn("missing"), null))));
-    assertEquals(
-        1000,
-        countFilteredRecords(
-            path, or(lt(longColumn("id"), 500L), notEq(binaryColumn("missing"), fromString("any")))));
+    assertThat(countFilteredRecords(path, or(lt(longColumn("id"), 500L), eq(binaryColumn("missing"), null))))
+        .isEqualTo(1000);
+    assertThat(countFilteredRecords(
+            path, or(lt(longColumn("id"), 500L), notEq(binaryColumn("missing"), fromString("any")))))
+        .isEqualTo(1000);
 
-    assertEquals(
-        1000, countFilteredRecords(path, or(eq(binaryColumn("missing"), null), lt(longColumn("id"), 500L))));
-    assertEquals(
-        1000,
-        countFilteredRecords(
-            path, or(notEq(binaryColumn("missing"), fromString("any")), lt(longColumn("id"), 500L))));
+    assertThat(countFilteredRecords(path, or(eq(binaryColumn("missing"), null), lt(longColumn("id"), 500L))))
+        .isEqualTo(1000);
+    assertThat(countFilteredRecords(
+            path, or(notEq(binaryColumn("missing"), fromString("any")), lt(longColumn("id"), 500L))))
+        .isEqualTo(1000);
   }
 
   public static long countFilteredRecords(Path path, FilterPredicate pred) throws IOException {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/bloomfilterlevel/TestBloomFilterImpl.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/bloomfilterlevel/TestBloomFilterImpl.java
@@ -23,8 +23,7 @@ import static org.apache.parquet.filter2.predicate.FilterApi.doubleColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.eq;
 import static org.apache.parquet.filter2.predicate.FilterApi.floatColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.in;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.List;
@@ -59,12 +58,15 @@ public class TestBloomFilterImpl {
     ColumnChunkMetaData meta = columnMeta("double_column", PrimitiveTypeName.DOUBLE);
     BloomFilterReader reader = bloomFilterReader(meta, new BlockSplitBloomFilter(0));
 
-    assertTrue(BloomFilterImpl.canDrop(eq(column, 1.0D), List.of(meta), reader));
-    assertFalse(BloomFilterImpl.canDrop(eq(column, DOUBLE_NAN), List.of(meta), reader));
+    assertThat(BloomFilterImpl.canDrop(eq(column, 1.0D), List.of(meta), reader))
+        .isTrue();
+    assertThat(BloomFilterImpl.canDrop(eq(column, DOUBLE_NAN), List.of(meta), reader))
+        .isFalse();
 
     Set<Double> values = new HashSet<>();
     values.add(DOUBLE_NAN);
-    assertFalse(BloomFilterImpl.canDrop(in(column, values), List.of(meta), reader));
+    assertThat(BloomFilterImpl.canDrop(in(column, values), List.of(meta), reader))
+        .isFalse();
   }
 
   @Test
@@ -73,12 +75,15 @@ public class TestBloomFilterImpl {
     ColumnChunkMetaData meta = columnMeta("float_column", PrimitiveTypeName.FLOAT);
     BloomFilterReader reader = bloomFilterReader(meta, new BlockSplitBloomFilter(0));
 
-    assertTrue(BloomFilterImpl.canDrop(eq(column, 1.0F), List.of(meta), reader));
-    assertFalse(BloomFilterImpl.canDrop(eq(column, FLOAT_NAN), List.of(meta), reader));
+    assertThat(BloomFilterImpl.canDrop(eq(column, 1.0F), List.of(meta), reader))
+        .isTrue();
+    assertThat(BloomFilterImpl.canDrop(eq(column, FLOAT_NAN), List.of(meta), reader))
+        .isFalse();
 
     Set<Float> values = new HashSet<>();
     values.add(FLOAT_NAN);
-    assertFalse(BloomFilterImpl.canDrop(in(column, values), List.of(meta), reader));
+    assertThat(BloomFilterImpl.canDrop(in(column, values), List.of(meta), reader))
+        .isFalse();
   }
 
   @Test
@@ -91,11 +96,13 @@ public class TestBloomFilterImpl {
     ColumnChunkMetaData meta = columnMeta("float16_column", type);
     BloomFilterReader reader = bloomFilterReader(meta, new BlockSplitBloomFilter(0));
 
-    assertFalse(BloomFilterImpl.canDrop(eq(column, FLOAT16_NAN), List.of(meta), reader));
+    assertThat(BloomFilterImpl.canDrop(eq(column, FLOAT16_NAN), List.of(meta), reader))
+        .isFalse();
 
     Set<Binary> values = new HashSet<>();
     values.add(FLOAT16_NAN);
-    assertFalse(BloomFilterImpl.canDrop(in(column, values), List.of(meta), reader));
+    assertThat(BloomFilterImpl.canDrop(in(column, values), List.of(meta), reader))
+        .isFalse();
   }
 
   private static ColumnChunkMetaData columnMeta(String name, PrimitiveTypeName type) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/compat/TestRowGroupFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/compat/TestRowGroupFilter.java
@@ -24,7 +24,7 @@ import static org.apache.parquet.filter2.predicate.FilterApi.intColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.notEq;
 import static org.apache.parquet.filter2.predicate.FilterApi.notIn;
 import static org.apache.parquet.hadoop.TestInputFormat.makeBlockFromStats;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -87,36 +87,36 @@ public class TestRowGroupFilter {
     set1.add(10);
     set1.add(50);
     List<BlockMetaData> filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(in(foo, set1)), blocks, schema);
-    assertEquals(List.of(b1, b2, b5), filtered);
+    assertThat(filtered).containsExactly(b1, b2, b5);
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(notIn(foo, set1)), blocks, schema);
-    assertEquals(List.of(b1, b2, b3, b4, b5, b6), filtered);
+    assertThat(filtered).containsExactly(b1, b2, b3, b4, b5, b6);
 
     Set<Integer> set2 = new HashSet<>();
     set2.add(null);
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(in(foo, set2)), blocks, schema);
-    assertEquals(List.of(b1, b3, b4, b5, b6), filtered);
+    assertThat(filtered).containsExactly(b1, b3, b4, b5, b6);
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(notIn(foo, set2)), blocks, schema);
-    assertEquals(List.of(b1, b2, b3, b4, b5, b6), filtered);
+    assertThat(filtered).containsExactly(b1, b2, b3, b4, b5, b6);
 
     set2.add(8);
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(in(foo, set2)), blocks, schema);
-    assertEquals(List.of(b1, b2, b3, b4, b5, b6), filtered);
+    assertThat(filtered).containsExactly(b1, b2, b3, b4, b5, b6);
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(notIn(foo, set2)), blocks, schema);
-    assertEquals(List.of(b1, b2, b3, b4, b5, b6), filtered);
+    assertThat(filtered).containsExactly(b1, b2, b3, b4, b5, b6);
 
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(eq(foo, 50)), blocks, schema);
-    assertEquals(List.of(b1, b2, b5), filtered);
+    assertThat(filtered).containsExactly(b1, b2, b5);
 
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(notEq(foo, 50)), blocks, schema);
-    assertEquals(List.of(b1, b2, b3, b4, b5, b6), filtered);
+    assertThat(filtered).containsExactly(b1, b2, b3, b4, b5, b6);
 
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(eq(foo, null)), blocks, schema);
-    assertEquals(List.of(b1, b3, b4, b5, b6), filtered);
+    assertThat(filtered).containsExactly(b1, b3, b4, b5, b6);
 
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(notEq(foo, null)), blocks, schema);
-    assertEquals(List.of(b1, b2, b3, b5, b6), filtered);
+    assertThat(filtered).containsExactly(b1, b2, b3, b5, b6);
 
     filtered = RowGroupFilter.filterRowGroups(FilterCompat.get(eq(foo, 0)), blocks, schema);
-    assertEquals(List.of(b6), filtered);
+    assertThat(filtered).containsExactly(b6);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/dictionarylevel/DictionaryFilterTest.java
@@ -42,8 +42,7 @@ import static org.apache.parquet.filter2.predicate.FilterApi.or;
 import static org.apache.parquet.filter2.predicate.FilterApi.userDefined;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.GZIP;
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -305,7 +304,7 @@ public class DictionaryFilterTest {
   }
 
   @SuppressWarnings("deprecation")
-  private void testDictionaryEncodedColumnsV1() throws Exception {
+  private void testDictionaryEncodedColumnsV1() {
     Set<String> dictionaryEncodedColumns = new HashSet<String>(List.of(
         "binary_field",
         "single_value_field",
@@ -320,30 +319,30 @@ public class DictionaryFilterTest {
     for (ColumnChunkMetaData column : ccmd) {
       String name = column.getPath().toDotString();
       if (dictionaryEncodedColumns.contains(name)) {
-        assertTrue(
-            "Column should be dictionary encoded: " + name,
-            column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
-        assertFalse(
-            "Column should not have plain data pages" + name,
-            column.getEncodings().contains(Encoding.PLAIN));
+        assertThat(column.getEncodings())
+            .as("Column should be dictionary encoded: " + name)
+            .contains(Encoding.PLAIN_DICTIONARY);
+        assertThat(column.getEncodings())
+            .as("Column should not have plain data pages" + name)
+            .doesNotContain(Encoding.PLAIN);
       } else {
-        assertTrue(
-            "Column should have plain encoding: " + name,
-            column.getEncodings().contains(Encoding.PLAIN));
+        assertThat(column.getEncodings())
+            .as("Column should have plain encoding: " + name)
+            .contains(Encoding.PLAIN);
         if (name.startsWith("fallback")) {
-          assertTrue(
-              "Column should have some dictionary encoding: " + name,
-              column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
+          assertThat(column.getEncodings())
+              .as("Column should have some dictionary encoding: " + name)
+              .contains(Encoding.PLAIN_DICTIONARY);
         } else {
-          assertFalse(
-              "Column should have no dictionary encoding: " + name,
-              column.getEncodings().contains(Encoding.PLAIN_DICTIONARY));
+          assertThat(column.getEncodings())
+              .as("Column should have no dictionary encoding: " + name)
+              .doesNotContain(Encoding.PLAIN_DICTIONARY);
         }
       }
     }
   }
 
-  private void testDictionaryEncodedColumnsV2() throws Exception {
+  private void testDictionaryEncodedColumnsV2() {
     Set<String> dictionaryEncodedColumns = new HashSet<String>(List.of(
         "binary_field",
         "single_value_field",
@@ -360,26 +359,33 @@ public class DictionaryFilterTest {
       EncodingStats encStats = column.getEncodingStats();
       String name = column.getPath().toDotString();
       if (dictionaryEncodedColumns.contains(name)) {
-        assertTrue("Column should have dictionary pages: " + name, encStats.hasDictionaryPages());
-        assertTrue(
-            "Column should have dictionary encoded pages: " + name, encStats.hasDictionaryEncodedPages());
-        assertFalse(
-            "Column should not have non-dictionary encoded pages: " + name,
-            encStats.hasNonDictionaryEncodedPages());
+        assertThat(encStats.hasDictionaryPages())
+            .as("Column should have dictionary pages: " + name)
+            .isTrue();
+        assertThat(encStats.hasDictionaryEncodedPages())
+            .as("Column should have dictionary encoded pages: " + name)
+            .isTrue();
+        assertThat(encStats.hasNonDictionaryEncodedPages())
+            .as("Column should not have non-dictionary encoded pages: " + name)
+            .isFalse();
       } else {
-        assertTrue(
-            "Column should have non-dictionary encoded pages: " + name,
-            encStats.hasNonDictionaryEncodedPages());
+        assertThat(encStats.hasNonDictionaryEncodedPages())
+            .as("Column should have non-dictionary encoded pages: " + name)
+            .isTrue();
         if (name.startsWith("fallback")) {
-          assertTrue("Column should have dictionary pages: " + name, encStats.hasDictionaryPages());
-          assertTrue(
-              "Column should have dictionary encoded pages: " + name,
-              encStats.hasDictionaryEncodedPages());
+          assertThat(encStats.hasDictionaryPages())
+              .as("Column should have dictionary pages: " + name)
+              .isTrue();
+          assertThat(encStats.hasDictionaryEncodedPages())
+              .as("Column should have dictionary encoded pages: " + name)
+              .isTrue();
         } else {
-          assertFalse("Column should not have dictionary pages: " + name, encStats.hasDictionaryPages());
-          assertFalse(
-              "Column should not have dictionary encoded pages: " + name,
-              encStats.hasDictionaryEncodedPages());
+          assertThat(encStats.hasDictionaryPages())
+              .as("Column should not have dictionary pages: " + name)
+              .isFalse();
+          assertThat(encStats.hasDictionaryEncodedPages())
+              .as("Column should not have dictionary encoded pages: " + name)
+              .isFalse();
         }
       }
     }
@@ -390,12 +396,17 @@ public class DictionaryFilterTest {
     BinaryColumn b = binaryColumn("binary_field");
     FilterPredicate pred = eq(b, Binary.fromString("c"));
 
-    assertFalse("Should not drop block for lower case letters", canDrop(pred, ccmd, dictionaries));
+    assertThat(canDrop(pred, ccmd, dictionaries))
+        .as("Should not drop block for lower case letters")
+        .isFalse();
 
-    assertTrue(
-        "Should drop block for upper case letters", canDrop(eq(b, Binary.fromString("A")), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, Binary.fromString("A")), ccmd, dictionaries))
+        .as("Should drop block for upper case letters")
+        .isTrue();
 
-    assertFalse("Should not drop block for null", canDrop(eq(b, null), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, null), ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
   }
 
   @Test
@@ -404,12 +415,18 @@ public class DictionaryFilterTest {
 
     // Only V2 supports dictionary encoding for FIXED_LEN_BYTE_ARRAY values
     if (version == PARQUET_2_0) {
-      assertTrue("Should drop block for -2", canDrop(eq(b, toBinary("-2", 17)), ccmd, dictionaries));
+      assertThat(canDrop(eq(b, toBinary("-2", 17)), ccmd, dictionaries))
+          .as("Should drop block for -2")
+          .isTrue();
     }
 
-    assertFalse("Should not drop block for -1", canDrop(eq(b, toBinary("-1", 17)), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, toBinary("-1", 17)), ccmd, dictionaries))
+        .as("Should not drop block for -1")
+        .isFalse();
 
-    assertFalse("Should not drop block for null", canDrop(eq(b, null), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, null), ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
   }
 
   @Test
@@ -417,11 +434,17 @@ public class DictionaryFilterTest {
     BinaryColumn b = binaryColumn("int96_field");
 
     // INT96 ordering is undefined => no filtering shall be done
-    assertFalse("Should not drop block for -2", canDrop(eq(b, toBinary("-2", 12)), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, toBinary("-2", 12)), ccmd, dictionaries))
+        .as("Should not drop block for -2")
+        .isFalse();
 
-    assertFalse("Should not drop block for -1", canDrop(eq(b, toBinary("-1", 12)), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, toBinary("-1", 12)), ccmd, dictionaries))
+        .as("Should not drop block for -1")
+        .isFalse();
 
-    assertFalse("Should not drop block for null", canDrop(eq(b, null), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, null), ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
   }
 
   @Test
@@ -430,31 +453,33 @@ public class DictionaryFilterTest {
     BinaryColumn sharpAndNull = binaryColumn("optional_single_value_field");
     BinaryColumn b = binaryColumn("binary_field");
 
-    assertTrue(
-        "Should drop block with only the excluded value",
-        canDrop(notEq(sharp, Binary.fromString("sharp")), ccmd, dictionaries));
+    assertThat(canDrop(notEq(sharp, Binary.fromString("sharp")), ccmd, dictionaries))
+        .as("Should drop block with only the excluded value")
+        .isTrue();
 
-    assertFalse(
-        "Should not drop block with any other value",
-        canDrop(notEq(sharp, Binary.fromString("applause")), ccmd, dictionaries));
+    assertThat(canDrop(notEq(sharp, Binary.fromString("applause")), ccmd, dictionaries))
+        .as("Should not drop block with any other value")
+        .isFalse();
 
-    assertFalse(
-        "Should not drop block with only the excluded value and null",
-        canDrop(notEq(sharpAndNull, Binary.fromString("sharp")), ccmd, dictionaries));
+    assertThat(canDrop(notEq(sharpAndNull, Binary.fromString("sharp")), ccmd, dictionaries))
+        .as("Should not drop block with only the excluded value and null")
+        .isFalse();
 
-    assertFalse(
-        "Should not drop block with any other value",
-        canDrop(notEq(sharpAndNull, Binary.fromString("applause")), ccmd, dictionaries));
+    assertThat(canDrop(notEq(sharpAndNull, Binary.fromString("applause")), ccmd, dictionaries))
+        .as("Should not drop block with any other value")
+        .isFalse();
 
-    assertFalse(
-        "Should not drop block with a known value",
-        canDrop(notEq(b, Binary.fromString("x")), ccmd, dictionaries));
+    assertThat(canDrop(notEq(b, Binary.fromString("x")), ccmd, dictionaries))
+        .as("Should not drop block with a known value")
+        .isFalse();
 
-    assertFalse(
-        "Should not drop block with a known value",
-        canDrop(notEq(b, Binary.fromString("B")), ccmd, dictionaries));
+    assertThat(canDrop(notEq(b, Binary.fromString("B")), ccmd, dictionaries))
+        .as("Should not drop block with a known value")
+        .isFalse();
 
-    assertFalse("Should not drop block for null", canDrop(notEq(b, null), ccmd, dictionaries));
+    assertThat(canDrop(notEq(b, null), ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
   }
 
   @Test
@@ -465,11 +490,16 @@ public class DictionaryFilterTest {
       lowest = Math.min(lowest, value);
     }
 
-    assertTrue("Should drop: < lowest value", canDrop(lt(i32, lowest), ccmd, dictionaries));
-    assertFalse("Should not drop: < (lowest value + 1)", canDrop(lt(i32, lowest + 1), ccmd, dictionaries));
+    assertThat(canDrop(lt(i32, lowest), ccmd, dictionaries))
+        .as("Should drop: < lowest value")
+        .isTrue();
+    assertThat(canDrop(lt(i32, lowest + 1), ccmd, dictionaries))
+        .as("Should not drop: < (lowest value + 1)")
+        .isFalse();
 
-    assertFalse(
-        "Should not drop: contains matching values", canDrop(lt(i32, Integer.MAX_VALUE), ccmd, dictionaries));
+    assertThat(canDrop(lt(i32, Integer.MAX_VALUE), ccmd, dictionaries))
+        .as("Should not drop: contains matching values")
+        .isFalse();
   }
 
   @Test
@@ -478,10 +508,14 @@ public class DictionaryFilterTest {
 
     // Only V2 supports dictionary encoding for FIXED_LEN_BYTE_ARRAY values
     if (version == PARQUET_2_0) {
-      assertTrue("Should drop: < lowest value", canDrop(lt(fixed, DECIMAL_VALUES[0]), ccmd, dictionaries));
+      assertThat(canDrop(lt(fixed, DECIMAL_VALUES[0]), ccmd, dictionaries))
+          .as("Should drop: < lowest value")
+          .isTrue();
     }
 
-    assertFalse("Should not drop: < 2nd lowest value", canDrop(lt(fixed, DECIMAL_VALUES[1]), ccmd, dictionaries));
+    assertThat(canDrop(lt(fixed, DECIMAL_VALUES[1]), ccmd, dictionaries))
+        .as("Should not drop: < 2nd lowest value")
+        .isFalse();
   }
 
   @Test
@@ -492,11 +526,16 @@ public class DictionaryFilterTest {
       lowest = Math.min(lowest, value);
     }
 
-    assertTrue("Should drop: <= lowest - 1", canDrop(ltEq(i64, lowest - 1), ccmd, dictionaries));
-    assertFalse("Should not drop: <= lowest", canDrop(ltEq(i64, lowest), ccmd, dictionaries));
+    assertThat(canDrop(ltEq(i64, lowest - 1), ccmd, dictionaries))
+        .as("Should drop: <= lowest - 1")
+        .isTrue();
+    assertThat(canDrop(ltEq(i64, lowest), ccmd, dictionaries))
+        .as("Should not drop: <= lowest")
+        .isFalse();
 
-    assertFalse(
-        "Should not drop: contains matching values", canDrop(ltEq(i64, Long.MAX_VALUE), ccmd, dictionaries));
+    assertThat(canDrop(ltEq(i64, Long.MAX_VALUE), ccmd, dictionaries))
+        .as("Should not drop: contains matching values")
+        .isFalse();
   }
 
   @Test
@@ -507,10 +546,16 @@ public class DictionaryFilterTest {
       highest = Math.max(highest, toFloat(value));
     }
 
-    assertTrue("Should drop: > highest value", canDrop(gt(f, highest), ccmd, dictionaries));
-    assertFalse("Should not drop: > (highest value - 1.0)", canDrop(gt(f, highest - 1.0f), ccmd, dictionaries));
+    assertThat(canDrop(gt(f, highest), ccmd, dictionaries))
+        .as("Should drop: > highest value")
+        .isTrue();
+    assertThat(canDrop(gt(f, highest - 1.0f), ccmd, dictionaries))
+        .as("Should not drop: > (highest value - 1.0)")
+        .isFalse();
 
-    assertFalse("Should not drop: contains matching values", canDrop(gt(f, Float.MIN_VALUE), ccmd, dictionaries));
+    assertThat(canDrop(gt(f, Float.MIN_VALUE), ccmd, dictionaries))
+        .as("Should not drop: contains matching values")
+        .isFalse();
   }
 
   @Test
@@ -521,11 +566,16 @@ public class DictionaryFilterTest {
       highest = Math.max(highest, toDouble(value));
     }
 
-    assertTrue("Should drop: >= highest + 0.00000001", canDrop(gtEq(d, highest + 0.00000001), ccmd, dictionaries));
-    assertFalse("Should not drop: >= highest", canDrop(gtEq(d, highest), ccmd, dictionaries));
+    assertThat(canDrop(gtEq(d, highest + 0.00000001), ccmd, dictionaries))
+        .as("Should drop: >= highest + 0.00000001")
+        .isTrue();
+    assertThat(canDrop(gtEq(d, highest), ccmd, dictionaries))
+        .as("Should not drop: >= highest")
+        .isFalse();
 
-    assertFalse(
-        "Should not drop: contains matching values", canDrop(gtEq(d, Double.MIN_VALUE), ccmd, dictionaries));
+    assertThat(canDrop(gtEq(d, Double.MIN_VALUE), ccmd, dictionaries))
+        .as("Should not drop: contains matching values")
+        .isFalse();
   }
 
   @Test
@@ -536,41 +586,65 @@ public class DictionaryFilterTest {
     FloatColumn floatColumn = floatColumn("float_nan_field");
     BinaryColumn float16Column = binaryColumn("float16_nan_field");
 
-    assertFalse(canDrop(eq(doubleColumn, DOUBLE_NAN_A), nanColumns, nanDictionaries));
-    assertFalse(canDrop(eq(doubleColumn, DOUBLE_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notEq(doubleColumn, DOUBLE_NAN_A), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notEq(doubleColumn, DOUBLE_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(lt(doubleColumn, DOUBLE_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(gt(doubleColumn, DOUBLE_NAN_B), nanColumns, nanDictionaries));
+    assertThat(canDrop(eq(doubleColumn, DOUBLE_NAN_A), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(eq(doubleColumn, DOUBLE_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notEq(doubleColumn, DOUBLE_NAN_A), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notEq(doubleColumn, DOUBLE_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(lt(doubleColumn, DOUBLE_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(gt(doubleColumn, DOUBLE_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
 
-    assertFalse(canDrop(eq(floatColumn, FLOAT_NAN_A), nanColumns, nanDictionaries));
-    assertFalse(canDrop(eq(floatColumn, FLOAT_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notEq(floatColumn, FLOAT_NAN_A), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notEq(floatColumn, FLOAT_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(lt(floatColumn, FLOAT_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(gt(floatColumn, FLOAT_NAN_B), nanColumns, nanDictionaries));
+    assertThat(canDrop(eq(floatColumn, FLOAT_NAN_A), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(eq(floatColumn, FLOAT_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notEq(floatColumn, FLOAT_NAN_A), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notEq(floatColumn, FLOAT_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(lt(floatColumn, FLOAT_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(gt(floatColumn, FLOAT_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
 
     Set<Double> doubleSet = new HashSet<>();
     doubleSet.add(DOUBLE_NAN_B);
-    assertFalse(canDrop(in(doubleColumn, doubleSet), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notIn(doubleColumn, doubleSet), nanColumns, nanDictionaries));
+    assertThat(canDrop(in(doubleColumn, doubleSet), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notIn(doubleColumn, doubleSet), nanColumns, nanDictionaries))
+        .isFalse();
 
     Set<Float> floatSet = new HashSet<>();
     floatSet.add(FLOAT_NAN_B);
-    assertFalse(canDrop(in(floatColumn, floatSet), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notIn(floatColumn, floatSet), nanColumns, nanDictionaries));
+    assertThat(canDrop(in(floatColumn, floatSet), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notIn(floatColumn, floatSet), nanColumns, nanDictionaries))
+        .isFalse();
 
     Set<Binary> float16Set = new HashSet<>();
     float16Set.add(FLOAT16_NAN_B);
-    assertFalse(canDrop(in(float16Column, float16Set), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notIn(float16Column, float16Set), nanColumns, nanDictionaries));
+    assertThat(canDrop(in(float16Column, float16Set), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notIn(float16Column, float16Set), nanColumns, nanDictionaries))
+        .isFalse();
 
-    assertFalse(canDrop(eq(float16Column, FLOAT16_NAN_A), nanColumns, nanDictionaries));
-    assertFalse(canDrop(eq(float16Column, FLOAT16_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notEq(float16Column, FLOAT16_NAN_A), nanColumns, nanDictionaries));
-    assertFalse(canDrop(notEq(float16Column, FLOAT16_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(lt(float16Column, FLOAT16_NAN_B), nanColumns, nanDictionaries));
-    assertFalse(canDrop(gt(float16Column, FLOAT16_NAN_B), nanColumns, nanDictionaries));
+    assertThat(canDrop(eq(float16Column, FLOAT16_NAN_A), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(eq(float16Column, FLOAT16_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notEq(float16Column, FLOAT16_NAN_A), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(notEq(float16Column, FLOAT16_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(lt(float16Column, FLOAT16_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
+    assertThat(canDrop(gt(float16Column, FLOAT16_NAN_B), nanColumns, nanDictionaries))
+        .isFalse();
   }
 
   @Test
@@ -586,21 +660,33 @@ public class DictionaryFilterTest {
     FloatColumn floatColumn = floatColumn("float_nan_field");
     BinaryColumn float16Column = binaryColumn("float16_nan_field");
 
-    assertFalse(canDrop(gt(doubleColumn, 0.0D), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(gtEq(doubleColumn, 0.0D), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(lt(doubleColumn, 0.0D), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(ltEq(doubleColumn, 0.0D), nanColumns, dictionariesWithNaNs));
+    assertThat(canDrop(gt(doubleColumn, 0.0D), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, 0.0D), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(lt(doubleColumn, 0.0D), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, 0.0D), nanColumns, dictionariesWithNaNs))
+        .isFalse();
 
-    assertFalse(canDrop(gt(floatColumn, 0.0F), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(gtEq(floatColumn, 0.0F), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(lt(floatColumn, 0.0F), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(ltEq(floatColumn, 0.0F), nanColumns, dictionariesWithNaNs));
+    assertThat(canDrop(gt(floatColumn, 0.0F), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(gtEq(floatColumn, 0.0F), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(lt(floatColumn, 0.0F), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(ltEq(floatColumn, 0.0F), nanColumns, dictionariesWithNaNs))
+        .isFalse();
 
     Binary zero = Binary.fromConstantByteArray(new byte[] {0x00, 0x00});
-    assertFalse(canDrop(gt(float16Column, zero), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(gtEq(float16Column, zero), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(lt(float16Column, zero), nanColumns, dictionariesWithNaNs));
-    assertFalse(canDrop(ltEq(float16Column, zero), nanColumns, dictionariesWithNaNs));
+    assertThat(canDrop(gt(float16Column, zero), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(gtEq(float16Column, zero), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(lt(float16Column, zero), nanColumns, dictionariesWithNaNs))
+        .isFalse();
+    assertThat(canDrop(ltEq(float16Column, zero), nanColumns, dictionariesWithNaNs))
+        .isFalse();
   }
 
   private static List<ColumnChunkMetaData> nanColumns() {
@@ -729,8 +815,12 @@ public class DictionaryFilterTest {
     set1.add(Binary.fromString("E"));
     FilterPredicate predIn1 = in(b, set1);
     FilterPredicate predNotIn1 = notIn(b, set1);
-    assertFalse("Should not drop block", canDrop(predIn1, ccmd, dictionaries));
-    assertFalse("Should not drop block", canDrop(predNotIn1, ccmd, dictionaries));
+    assertThat(canDrop(predIn1, ccmd, dictionaries))
+        .as("Should not drop block")
+        .isFalse();
+    assertThat(canDrop(predNotIn1, ccmd, dictionaries))
+        .as("Should not drop block")
+        .isFalse();
 
     Set<Binary> set2 = new HashSet<>();
     for (int i = 0; i < 26; i++) {
@@ -739,8 +829,12 @@ public class DictionaryFilterTest {
     set2.add(Binary.fromString("A"));
     FilterPredicate predIn2 = in(b, set2);
     FilterPredicate predNotIn2 = notIn(b, set2);
-    assertFalse("Should not drop block", canDrop(predIn2, ccmd, dictionaries));
-    assertTrue("Should not drop block", canDrop(predNotIn2, ccmd, dictionaries));
+    assertThat(canDrop(predIn2, ccmd, dictionaries))
+        .as("Should not drop block")
+        .isFalse();
+    assertThat(canDrop(predNotIn2, ccmd, dictionaries))
+        .as("Should not drop block")
+        .isTrue();
 
     Set<Binary> set3 = new HashSet<>();
     set3.add(Binary.fromString("F"));
@@ -749,15 +843,21 @@ public class DictionaryFilterTest {
     set3.add(Binary.fromString("E"));
     FilterPredicate predIn3 = in(b, set3);
     FilterPredicate predNotIn3 = notIn(b, set3);
-    assertTrue("Should drop block", canDrop(predIn3, ccmd, dictionaries));
-    assertFalse("Should not drop block", canDrop(predNotIn3, ccmd, dictionaries));
+    assertThat(canDrop(predIn3, ccmd, dictionaries)).as("Should drop block").isTrue();
+    assertThat(canDrop(predNotIn3, ccmd, dictionaries))
+        .as("Should not drop block")
+        .isFalse();
 
     Set<Binary> set4 = new HashSet<>();
     set4.add(null);
     FilterPredicate predIn4 = in(b, set4);
     FilterPredicate predNotIn4 = notIn(b, set4);
-    assertFalse("Should not drop block for null", canDrop(predIn4, ccmd, dictionaries));
-    assertFalse("Should not drop block for null", canDrop(predNotIn4, ccmd, dictionaries));
+    assertThat(canDrop(predIn4, ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
+    assertThat(canDrop(predNotIn4, ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
 
     BinaryColumn sharpAndNull = binaryColumn("optional_single_value_field");
 
@@ -766,8 +866,12 @@ public class DictionaryFilterTest {
     set5.add(Binary.fromString("sharp"));
     FilterPredicate predNotIn5 = notIn(sharpAndNull, set5);
     FilterPredicate predIn5 = in(sharpAndNull, set5);
-    assertFalse("Should not drop block", canDrop(predNotIn5, ccmd, dictionaries));
-    assertFalse("Should not drop block", canDrop(predIn5, ccmd, dictionaries));
+    assertThat(canDrop(predNotIn5, ccmd, dictionaries))
+        .as("Should not drop block")
+        .isFalse();
+    assertThat(canDrop(predIn5, ccmd, dictionaries))
+        .as("Should not drop block")
+        .isFalse();
   }
 
   @Test
@@ -782,23 +886,35 @@ public class DictionaryFilterTest {
       set1.add(toBinary("12345", 17));
       FilterPredicate predIn1 = in(b, set1);
       FilterPredicate predNotIn1 = notIn(b, set1);
-      assertTrue("Should drop block for in (-2, -22, 12345)", canDrop(predIn1, ccmd, dictionaries));
-      assertFalse("Should not drop block for notIn (-2, -22, 12345)", canDrop(predNotIn1, ccmd, dictionaries));
+      assertThat(canDrop(predIn1, ccmd, dictionaries))
+          .as("Should drop block for in (-2, -22, 12345)")
+          .isTrue();
+      assertThat(canDrop(predNotIn1, ccmd, dictionaries))
+          .as("Should not drop block for notIn (-2, -22, 12345)")
+          .isFalse();
 
       Set<Binary> set2 = new HashSet<>();
       set2.add(toBinary("-1", 17));
       set2.add(toBinary("0", 17));
       set2.add(toBinary("12345", 17));
-      assertFalse("Should not drop block for in (-1, 0, 12345)", canDrop(in(b, set2), ccmd, dictionaries));
-      assertFalse("Should not drop block for in (-1, 0, 12345)", canDrop(notIn(b, set2), ccmd, dictionaries));
+      assertThat(canDrop(in(b, set2), ccmd, dictionaries))
+          .as("Should not drop block for in (-1, 0, 12345)")
+          .isFalse();
+      assertThat(canDrop(notIn(b, set2), ccmd, dictionaries))
+          .as("Should not drop block for in (-1, 0, 12345)")
+          .isFalse();
     }
 
     Set<Binary> set3 = new HashSet<>();
     set3.add(null);
     FilterPredicate predIn3 = in(b, set3);
     FilterPredicate predNotIn3 = notIn(b, set3);
-    assertFalse("Should not drop block for null", canDrop(predIn3, ccmd, dictionaries));
-    assertFalse("Should not drop block for null", canDrop(predNotIn3, ccmd, dictionaries));
+    assertThat(canDrop(predIn3, ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
+    assertThat(canDrop(predNotIn3, ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
   }
 
   @Test
@@ -812,8 +928,12 @@ public class DictionaryFilterTest {
     set1.add(toBinary("12345", 12));
     FilterPredicate predIn1 = in(b, set1);
     FilterPredicate predNotIn1 = notIn(b, set1);
-    assertFalse("Should not drop block for in (-2, -0, 12345)", canDrop(predIn1, ccmd, dictionaries));
-    assertFalse("Should not drop block for notIn (-2, -0, 12345)", canDrop(predNotIn1, ccmd, dictionaries));
+    assertThat(canDrop(predIn1, ccmd, dictionaries))
+        .as("Should not drop block for in (-2, -0, 12345)")
+        .isFalse();
+    assertThat(canDrop(predNotIn1, ccmd, dictionaries))
+        .as("Should not drop block for notIn (-2, -0, 12345)")
+        .isFalse();
 
     Set<Binary> set2 = new HashSet<>();
     set2.add(toBinary("-2", 17));
@@ -821,15 +941,23 @@ public class DictionaryFilterTest {
     set2.add(toBinary("-789", 17));
     FilterPredicate predIn2 = in(b, set2);
     FilterPredicate predNotIn2 = notIn(b, set2);
-    assertFalse("Should not drop block for in (-2, 12345, -789)", canDrop(predIn2, ccmd, dictionaries));
-    assertFalse("Should not drop block for notIn (-2, 12345, -789)", canDrop(predNotIn2, ccmd, dictionaries));
+    assertThat(canDrop(predIn2, ccmd, dictionaries))
+        .as("Should not drop block for in (-2, 12345, -789)")
+        .isFalse();
+    assertThat(canDrop(predNotIn2, ccmd, dictionaries))
+        .as("Should not drop block for notIn (-2, 12345, -789)")
+        .isFalse();
 
     Set<Binary> set3 = new HashSet<>();
     set3.add(null);
     FilterPredicate predIn3 = in(b, set3);
     FilterPredicate predNotIn3 = notIn(b, set3);
-    assertFalse("Should not drop block for null", canDrop(predIn3, ccmd, dictionaries));
-    assertFalse("Should not drop block for null", canDrop(predNotIn3, ccmd, dictionaries));
+    assertThat(canDrop(predIn3, ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
+    assertThat(canDrop(predNotIn3, ccmd, dictionaries))
+        .as("Should not drop block for null")
+        .isFalse();
   }
 
   @Test
@@ -844,10 +972,18 @@ public class DictionaryFilterTest {
     FilterPredicate x = eq(col, Binary.fromString("x"));
     FilterPredicate y = eq(col, Binary.fromString("y"));
 
-    assertTrue("Should drop when either predicate must be false", canDrop(and(B, y), ccmd, dictionaries));
-    assertTrue("Should drop when either predicate must be false", canDrop(and(x, C), ccmd, dictionaries));
-    assertTrue("Should drop when either predicate must be false", canDrop(and(B, C), ccmd, dictionaries));
-    assertFalse("Should not drop when either predicate could be true", canDrop(and(x, y), ccmd, dictionaries));
+    assertThat(canDrop(and(B, y), ccmd, dictionaries))
+        .as("Should drop when either predicate must be false")
+        .isTrue();
+    assertThat(canDrop(and(x, C), ccmd, dictionaries))
+        .as("Should drop when either predicate must be false")
+        .isTrue();
+    assertThat(canDrop(and(B, C), ccmd, dictionaries))
+        .as("Should drop when either predicate must be false")
+        .isTrue();
+    assertThat(canDrop(and(x, y), ccmd, dictionaries))
+        .as("Should not drop when either predicate could be true")
+        .isFalse();
   }
 
   @Test
@@ -862,10 +998,18 @@ public class DictionaryFilterTest {
     FilterPredicate x = eq(col, Binary.fromString("x"));
     FilterPredicate y = eq(col, Binary.fromString("y"));
 
-    assertFalse("Should not drop when one predicate could be true", canDrop(or(B, y), ccmd, dictionaries));
-    assertFalse("Should not drop when one predicate could be true", canDrop(or(x, C), ccmd, dictionaries));
-    assertTrue("Should drop when both predicates must be false", canDrop(or(B, C), ccmd, dictionaries));
-    assertFalse("Should not drop when one predicate could be true", canDrop(or(x, y), ccmd, dictionaries));
+    assertThat(canDrop(or(B, y), ccmd, dictionaries))
+        .as("Should not drop when one predicate could be true")
+        .isFalse();
+    assertThat(canDrop(or(x, C), ccmd, dictionaries))
+        .as("Should not drop when one predicate could be true")
+        .isFalse();
+    assertThat(canDrop(or(B, C), ccmd, dictionaries))
+        .as("Should drop when both predicates must be false")
+        .isTrue();
+    assertThat(canDrop(or(x, y), ccmd, dictionaries))
+        .as("Should not drop when one predicate could be true")
+        .isFalse();
   }
 
   @Test
@@ -873,13 +1017,13 @@ public class DictionaryFilterTest {
     InInt32UDP dropabble = new InInt32UDP(ImmutableSet.of(42));
     InInt32UDP undroppable = new InInt32UDP(ImmutableSet.of(205));
 
-    assertTrue(
-        "Should drop block for non-matching UDP",
-        canDrop(userDefined(intColumn("int32_field"), dropabble), ccmd, dictionaries));
+    assertThat(canDrop(userDefined(intColumn("int32_field"), dropabble), ccmd, dictionaries))
+        .as("Should drop block for non-matching UDP")
+        .isTrue();
 
-    assertFalse(
-        "Should not drop block for matching UDP",
-        canDrop(userDefined(intColumn("int32_field"), undroppable), ccmd, dictionaries));
+    assertThat(canDrop(userDefined(intColumn("int32_field"), undroppable), ccmd, dictionaries))
+        .as("Should not drop block for matching UDP")
+        .isFalse();
   }
 
   @Test
@@ -890,10 +1034,12 @@ public class DictionaryFilterTest {
     // A column with value 42 and 10% nulls
     IntColumn intColumnWithNulls = intColumn("optional_single_value_int32_field");
 
-    assertTrue("Should drop block", canDrop(userDefined(intColumnWithNulls, drop42DenyNulls), ccmd, dictionaries));
-    assertFalse(
-        "Should not drop block for null accepting udp",
-        canDrop(userDefined(intColumnWithNulls, drop42AcceptNulls), ccmd, dictionaries));
+    assertThat(canDrop(userDefined(intColumnWithNulls, drop42DenyNulls), ccmd, dictionaries))
+        .as("Should drop block")
+        .isTrue();
+    assertThat(canDrop(userDefined(intColumnWithNulls, drop42AcceptNulls), ccmd, dictionaries))
+        .as("Should not drop block for null accepting udp")
+        .isFalse();
   }
 
   @Test
@@ -909,12 +1055,17 @@ public class DictionaryFilterTest {
     FilterPredicate inverse2 =
         LogicalInverseRewriter.rewrite(not(userDefined(intColumn("int32_field"), completeMatch)));
 
-    assertFalse("Should not drop block for inverse of non-matching UDP", canDrop(inverse, ccmd, dictionaries));
+    assertThat(canDrop(inverse, ccmd, dictionaries))
+        .as("Should not drop block for inverse of non-matching UDP")
+        .isFalse();
 
-    assertFalse(
-        "Should not drop block for inverse of UDP with some matches", canDrop(inverse1, ccmd, dictionaries));
+    assertThat(canDrop(inverse1, ccmd, dictionaries))
+        .as("Should not drop block for inverse of UDP with some matches")
+        .isFalse();
 
-    assertTrue("Should drop block for inverse of UDP with all matches", canDrop(inverse2, ccmd, dictionaries));
+    assertThat(canDrop(inverse2, ccmd, dictionaries))
+        .as("Should drop block for inverse of UDP with all matches")
+        .isTrue();
   }
 
   @Test
@@ -922,23 +1073,29 @@ public class DictionaryFilterTest {
     IntColumn plain = intColumn("plain_int32_field");
     DictionaryPageReadStore dictionaryStore = mock(DictionaryPageReadStore.class);
 
-    assertFalse("Should never drop block using plain encoding", canDrop(eq(plain, -10), ccmd, dictionaryStore));
+    assertThat(canDrop(eq(plain, -10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse("Should never drop block using plain encoding", canDrop(lt(plain, -10), ccmd, dictionaryStore));
+    assertThat(canDrop(lt(plain, -10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse("Should never drop block using plain encoding", canDrop(ltEq(plain, -10), ccmd, dictionaryStore));
+    assertThat(canDrop(ltEq(plain, -10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse(
-        "Should never drop block using plain encoding",
-        canDrop(gt(plain, nElements + 10), ccmd, dictionaryStore));
+    assertThat(canDrop(gt(plain, nElements + 10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse(
-        "Should never drop block using plain encoding",
-        canDrop(gtEq(plain, nElements + 10), ccmd, dictionaryStore));
+    assertThat(canDrop(gtEq(plain, nElements + 10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse(
-        "Should never drop block using plain encoding",
-        canDrop(notEq(plain, nElements + 10), ccmd, dictionaryStore));
+    assertThat(canDrop(notEq(plain, nElements + 10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
     verifyNoInteractions(dictionaryStore);
   }
@@ -948,23 +1105,29 @@ public class DictionaryFilterTest {
     IntColumn plain = intColumn("fallback_binary_field");
     DictionaryPageReadStore dictionaryStore = mock(DictionaryPageReadStore.class);
 
-    assertFalse("Should never drop block using plain encoding", canDrop(eq(plain, -10), ccmd, dictionaryStore));
+    assertThat(canDrop(eq(plain, -10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse("Should never drop block using plain encoding", canDrop(lt(plain, -10), ccmd, dictionaryStore));
+    assertThat(canDrop(lt(plain, -10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse("Should never drop block using plain encoding", canDrop(ltEq(plain, -10), ccmd, dictionaryStore));
+    assertThat(canDrop(ltEq(plain, -10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse(
-        "Should never drop block using plain encoding",
-        canDrop(gt(plain, nElements + 10), ccmd, dictionaryStore));
+    assertThat(canDrop(gt(plain, nElements + 10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse(
-        "Should never drop block using plain encoding",
-        canDrop(gtEq(plain, nElements + 10), ccmd, dictionaryStore));
+    assertThat(canDrop(gtEq(plain, nElements + 10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
-    assertFalse(
-        "Should never drop block using plain encoding",
-        canDrop(notEq(plain, nElements + 10), ccmd, dictionaryStore));
+    assertThat(canDrop(notEq(plain, nElements + 10), ccmd, dictionaryStore))
+        .as("Should never drop block using plain encoding")
+        .isFalse();
 
     verifyNoInteractions(dictionaryStore);
   }
@@ -973,57 +1136,62 @@ public class DictionaryFilterTest {
   public void testEqMissingColumn() throws Exception {
     BinaryColumn b = binaryColumn("missing_column");
 
-    assertTrue(
-        "Should drop block for non-null query", canDrop(eq(b, Binary.fromString("any")), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, Binary.fromString("any")), ccmd, dictionaries))
+        .as("Should drop block for non-null query")
+        .isTrue();
 
-    assertFalse("Should not drop block null query", canDrop(eq(b, null), ccmd, dictionaries));
+    assertThat(canDrop(eq(b, null), ccmd, dictionaries))
+        .as("Should not drop block null query")
+        .isFalse();
   }
 
   @Test
   public void testNotEqMissingColumn() throws Exception {
     BinaryColumn b = binaryColumn("missing_column");
 
-    assertFalse(
-        "Should not drop block for non-null query",
-        canDrop(notEq(b, Binary.fromString("any")), ccmd, dictionaries));
+    assertThat(canDrop(notEq(b, Binary.fromString("any")), ccmd, dictionaries))
+        .as("Should not drop block for non-null query")
+        .isFalse();
 
-    assertTrue("Should not drop block null query", canDrop(notEq(b, null), ccmd, dictionaries));
+    assertThat(canDrop(notEq(b, null), ccmd, dictionaries))
+        .as("Should not drop block null query")
+        .isTrue();
   }
 
   @Test
   public void testLtMissingColumn() throws Exception {
     BinaryColumn b = binaryColumn("missing_column");
 
-    assertTrue(
-        "Should drop block for any non-null query",
-        canDrop(lt(b, Binary.fromString("any")), ccmd, dictionaries));
+    assertThat(canDrop(lt(b, Binary.fromString("any")), ccmd, dictionaries))
+        .as("Should drop block for any non-null query")
+        .isTrue();
   }
 
   @Test
   public void testLtEqMissingColumn() throws Exception {
     BinaryColumn b = binaryColumn("missing_column");
 
-    assertTrue(
-        "Should drop block for any non-null query",
-        canDrop(ltEq(b, Binary.fromString("any")), ccmd, dictionaries));
+    assertThat(canDrop(ltEq(b, Binary.fromString("any")), ccmd, dictionaries))
+        .as("Should drop block for any non-null query")
+        .isTrue();
   }
 
   @Test
   public void testGtMissingColumn() throws Exception {
     BinaryColumn b = binaryColumn("missing_column");
 
-    assertTrue(
-        "Should drop block for any non-null query",
-        canDrop(gt(b, Binary.fromString("any")), ccmd, dictionaries));
+    assertThat(canDrop(gt(b, Binary.fromString("any")), ccmd, dictionaries))
+        .as("Should drop block for any non-null query")
+        .isTrue();
   }
 
   @Test
   public void testGtEqMissingColumn() throws Exception {
     BinaryColumn b = binaryColumn("missing_column");
 
-    assertTrue(
-        "Should drop block for any non-null query",
-        canDrop(gtEq(b, Binary.fromString("any")), ccmd, dictionaries));
+    assertThat(canDrop(gtEq(b, Binary.fromString("any")), ccmd, dictionaries))
+        .as("Should drop block for any non-null query")
+        .isTrue();
   }
 
   @Test
@@ -1032,12 +1200,12 @@ public class DictionaryFilterTest {
     InInt32UDP nullAccepting = new InInt32UDP(Sets.newHashSet((Integer) null));
     IntColumn fake = intColumn("missing_column");
 
-    assertTrue(
-        "Should drop block for null rejecting udp",
-        canDrop(userDefined(fake, nullRejecting), ccmd, dictionaries));
-    assertFalse(
-        "Should not drop block for null accepting udp",
-        canDrop(userDefined(fake, nullAccepting), ccmd, dictionaries));
+    assertThat(canDrop(userDefined(fake, nullRejecting), ccmd, dictionaries))
+        .as("Should drop block for null rejecting udp")
+        .isTrue();
+    assertThat(canDrop(userDefined(fake, nullAccepting), ccmd, dictionaries))
+        .as("Should not drop block for null accepting udp")
+        .isFalse();
   }
 
   @Test
@@ -1046,12 +1214,12 @@ public class DictionaryFilterTest {
     InInt32UDP nullAccepting = new InInt32UDP(Sets.newHashSet((Integer) null));
     IntColumn fake = intColumn("missing_column");
 
-    assertTrue(
-        "Should drop block for null accepting udp",
-        canDrop(LogicalInverseRewriter.rewrite(not(userDefined(fake, nullAccepting))), ccmd, dictionaries));
-    assertFalse(
-        "Should not drop block for null rejecting udp",
-        canDrop(LogicalInverseRewriter.rewrite(not(userDefined(fake, nullRejecting))), ccmd, dictionaries));
+    assertThat(canDrop(LogicalInverseRewriter.rewrite(not(userDefined(fake, nullAccepting))), ccmd, dictionaries))
+        .as("Should drop block for null accepting udp")
+        .isTrue();
+    assertThat(canDrop(LogicalInverseRewriter.rewrite(not(userDefined(fake, nullRejecting))), ccmd, dictionaries))
+        .as("Should not drop block for null rejecting udp")
+        .isFalse();
   }
 
   @Test
@@ -1066,10 +1234,18 @@ public class DictionaryFilterTest {
     Operators.Contains<Binary> x = contains(eq(col, Binary.fromString("x")));
     Operators.Contains<Binary> y = contains(eq(col, Binary.fromString("y")));
 
-    assertTrue("Should drop when either predicate must be false", canDrop(and(B, y), ccmd, dictionaries));
-    assertTrue("Should drop when either predicate must be false", canDrop(and(x, C), ccmd, dictionaries));
-    assertTrue("Should drop when either predicate must be false", canDrop(and(B, C), ccmd, dictionaries));
-    assertFalse("Should not drop when either predicate could be true", canDrop(and(x, y), ccmd, dictionaries));
+    assertThat(canDrop(and(B, y), ccmd, dictionaries))
+        .as("Should drop when either predicate must be false")
+        .isTrue();
+    assertThat(canDrop(and(x, C), ccmd, dictionaries))
+        .as("Should drop when either predicate must be false")
+        .isTrue();
+    assertThat(canDrop(and(B, C), ccmd, dictionaries))
+        .as("Should drop when either predicate must be false")
+        .isTrue();
+    assertThat(canDrop(and(x, y), ccmd, dictionaries))
+        .as("Should not drop when either predicate could be true")
+        .isFalse();
   }
 
   @Test
@@ -1084,10 +1260,18 @@ public class DictionaryFilterTest {
     Operators.Contains<Binary> x = contains(eq(col, Binary.fromString("x")));
     Operators.Contains<Binary> y = contains(eq(col, Binary.fromString("y")));
 
-    assertFalse("Should not drop when one predicate could be true", canDrop(or(B, y), ccmd, dictionaries));
-    assertFalse("Should not drop when one predicate could be true", canDrop(or(x, C), ccmd, dictionaries));
-    assertTrue("Should drop when both predicates must be false", canDrop(or(B, C), ccmd, dictionaries));
-    assertFalse("Should not drop when one predicate could be true", canDrop(or(x, y), ccmd, dictionaries));
+    assertThat(canDrop(or(B, y), ccmd, dictionaries))
+        .as("Should not drop when one predicate could be true")
+        .isFalse();
+    assertThat(canDrop(or(x, C), ccmd, dictionaries))
+        .as("Should not drop when one predicate could be true")
+        .isFalse();
+    assertThat(canDrop(or(B, C), ccmd, dictionaries))
+        .as("Should drop when both predicates must be false")
+        .isTrue();
+    assertThat(canDrop(or(x, y), ccmd, dictionaries))
+        .as("Should not drop when one predicate could be true")
+        .isFalse();
   }
 
   private static final class InInt32UDP extends UserDefinedPredicate<Integer> implements Serializable {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/PhoneBookWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/PhoneBookWriter.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.filter2.recordlevel;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -424,7 +424,9 @@ public class PhoneBookWriter {
         User u = userFromGroup(group);
         users.add(u);
         if (validateRowIndexes) {
-          assertEquals("Row index should be equal to User id", u.id, reader.getCurrentRowIndex());
+          assertThat(reader.getCurrentRowIndex())
+              .as("Row index should be equal to User id")
+              .isEqualTo(u.id);
         }
       }
       return users;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/TestRecordLevelFilters.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/recordlevel/TestRecordLevelFilters.java
@@ -34,7 +34,7 @@ import static org.apache.parquet.filter2.predicate.FilterApi.notEq;
 import static org.apache.parquet.filter2.predicate.FilterApi.notIn;
 import static org.apache.parquet.filter2.predicate.FilterApi.or;
 import static org.apache.parquet.filter2.predicate.FilterApi.userDefined;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -149,11 +149,13 @@ public class TestRecordLevelFilters {
 
   private static void assertFilter(List<Group> found, UserFilter f) {
     List<Group> expected = getExpected(f);
-    assertEquals(expected.size(), found.size());
+    assertThat(found).hasSameSizeAs(expected);
     Iterator<Group> expectedIter = expected.iterator();
     Iterator<Group> foundIter = found.iterator();
     while (expectedIter.hasNext()) {
-      assertEquals(expectedIter.next().toString(), foundIter.next().toString());
+      assertThat(foundIter.next())
+          .asString()
+          .isEqualTo(expectedIter.next().toString());
     }
   }
 
@@ -164,9 +166,9 @@ public class TestRecordLevelFilters {
   private static void assertPredicate(File file, FilterPredicate predicate, long... expectedIds) throws IOException {
     List<Group> found = PhoneBookWriter.readFile(file, FilterCompat.get(predicate));
 
-    assertEquals(expectedIds.length, found.size());
+    assertThat(found).hasSameSizeAs(expectedIds);
     for (int i = 0; i < expectedIds.length; i++) {
-      assertEquals(expectedIds[i], found.get(i).getLong("id", 0));
+      assertThat(found.get(i).getLong("id", 0)).isEqualTo(expectedIds[i]);
     }
   }
 
@@ -217,7 +219,7 @@ public class TestRecordLevelFilters {
     FilterPredicate pred = eq(name, Binary.fromString("no matches"));
 
     List<Group> found = PhoneBookWriter.readFile(phonebookFile, FilterCompat.get(pred));
-    assertEquals(new ArrayList<Group>(), found);
+    assertThat(found).isEmpty();
   }
 
   @Test
@@ -245,10 +247,10 @@ public class TestRecordLevelFilters {
 
     // validate that all the values returned by the reader fulfills the filter and there are no values left out,
     // i.e. "thing1", "thing2" and from "p100" to "p199" and nothing else.
-    assertEquals(expectedNames.get(0), ((Group) (found.get(0))).getString("name", 0));
-    assertEquals(expectedNames.get(1), ((Group) (found.get(1))).getString("name", 0));
+    assertThat(((Group) (found.get(0))).getString("name", 0)).isEqualTo(expectedNames.get(0));
+    assertThat(((Group) (found.get(1))).getString("name", 0)).isEqualTo(expectedNames.get(1));
     for (int i = 2; i < 102; i++) {
-      assertEquals(expectedNames.get(i), ((Group) (found.get(i))).getString("name", 0));
+      assertThat(((Group) (found.get(i))).getString("name", 0)).isEqualTo(expectedNames.get(i));
     }
     assert (found.size() == 102);
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/filter2/statisticslevel/TestStatisticsFilter.java
@@ -38,10 +38,7 @@ import static org.apache.parquet.filter2.predicate.FilterApi.userDefined;
 import static org.apache.parquet.filter2.statisticslevel.StatisticsFilter.canDrop;
 import static org.apache.parquet.io.api.Binary.fromString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashSet;
 import java.util.List;
@@ -141,17 +138,17 @@ public class TestStatisticsFilter {
 
   @Test
   public void testEqNonNull() {
-    assertTrue(canDrop(eq(intColumn, 9), columnMetas));
-    assertFalse(canDrop(eq(intColumn, 10), columnMetas));
-    assertFalse(canDrop(eq(intColumn, 100), columnMetas));
-    assertTrue(canDrop(eq(intColumn, 101), columnMetas));
+    assertThat(canDrop(eq(intColumn, 9), columnMetas)).isTrue();
+    assertThat(canDrop(eq(intColumn, 10), columnMetas)).isFalse();
+    assertThat(canDrop(eq(intColumn, 100), columnMetas)).isFalse();
+    assertThat(canDrop(eq(intColumn, 101), columnMetas)).isTrue();
 
     // drop columns of all nulls when looking for non-null value
-    assertTrue(canDrop(eq(intColumn, 0), nullColumnMetas));
-    assertTrue(canDrop(eq(missingColumn, fromString("any")), columnMetas));
+    assertThat(canDrop(eq(intColumn, 0), nullColumnMetas)).isTrue();
+    assertThat(canDrop(eq(missingColumn, fromString("any")), columnMetas)).isTrue();
 
-    assertFalse(canDrop(eq(intColumn, 50), missingMinMaxColumnMetas));
-    assertFalse(canDrop(eq(doubleColumn, 50.0), missingMinMaxColumnMetas));
+    assertThat(canDrop(eq(intColumn, 50), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(eq(doubleColumn, 50.0), missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
@@ -164,47 +161,53 @@ public class TestStatisticsFilter {
     statsSomeNulls.setMinMax(10, 100);
     statsSomeNulls.setNumNulls(3);
 
-    assertTrue(canDrop(
-        eq(intColumn, null),
-        List.of(getIntColumnMeta(statsNoNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            eq(intColumn, null),
+            List.of(getIntColumnMeta(statsNoNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertFalse(canDrop(
-        eq(intColumn, null),
-        List.of(getIntColumnMeta(statsSomeNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            eq(intColumn, null),
+            List.of(getIntColumnMeta(statsSomeNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(eq(missingColumn, null), columnMetas));
+    assertThat(canDrop(eq(missingColumn, null), columnMetas)).isFalse();
 
-    assertFalse(canDrop(eq(intColumn, null), missingMinMaxColumnMetas));
-    assertFalse(canDrop(eq(doubleColumn, null), missingMinMaxColumnMetas));
+    assertThat(canDrop(eq(intColumn, null), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(eq(doubleColumn, null), missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
   public void testNotEqNonNull() {
-    assertFalse(canDrop(notEq(intColumn, 9), columnMetas));
-    assertFalse(canDrop(notEq(intColumn, 10), columnMetas));
-    assertFalse(canDrop(notEq(intColumn, 100), columnMetas));
-    assertFalse(canDrop(notEq(intColumn, 101), columnMetas));
+    assertThat(canDrop(notEq(intColumn, 9), columnMetas)).isFalse();
+    assertThat(canDrop(notEq(intColumn, 10), columnMetas)).isFalse();
+    assertThat(canDrop(notEq(intColumn, 100), columnMetas)).isFalse();
+    assertThat(canDrop(notEq(intColumn, 101), columnMetas)).isFalse();
 
     IntStatistics allSevens = new IntStatistics();
     allSevens.setMinMax(7, 7);
-    assertTrue(canDrop(
-        notEq(intColumn, 7),
-        List.of(getIntColumnMeta(allSevens, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            notEq(intColumn, 7),
+            List.of(getIntColumnMeta(allSevens, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
     allSevens.setNumNulls(100L);
-    assertFalse(canDrop(
-        notEq(intColumn, 7),
-        List.of(getIntColumnMeta(allSevens, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            notEq(intColumn, 7),
+            List.of(getIntColumnMeta(allSevens, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
     allSevens.setNumNulls(177L);
-    assertFalse(canDrop(
-        notEq(intColumn, 7),
-        List.of(getIntColumnMeta(allSevens, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            notEq(intColumn, 7),
+            List.of(getIntColumnMeta(allSevens, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(notEq(missingColumn, fromString("any")), columnMetas));
+    assertThat(canDrop(notEq(missingColumn, fromString("any")), columnMetas))
+        .isFalse();
 
-    assertFalse(canDrop(notEq(intColumn, 50), missingMinMaxColumnMetas));
-    assertFalse(canDrop(notEq(doubleColumn, 50.0), missingMinMaxColumnMetas));
+    assertThat(canDrop(notEq(intColumn, 50), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(notEq(doubleColumn, 50.0), missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
@@ -221,86 +224,89 @@ public class TestStatisticsFilter {
     statsAllNulls.setMinMax(0, 0);
     statsAllNulls.setNumNulls(177);
 
-    assertFalse(canDrop(
-        notEq(intColumn, null),
-        List.of(getIntColumnMeta(statsNoNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            notEq(intColumn, null),
+            List.of(getIntColumnMeta(statsNoNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(
-        notEq(intColumn, null),
-        List.of(getIntColumnMeta(statsSomeNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            notEq(intColumn, null),
+            List.of(getIntColumnMeta(statsSomeNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertTrue(canDrop(
-        notEq(intColumn, null),
-        List.of(getIntColumnMeta(statsAllNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            notEq(intColumn, null),
+            List.of(getIntColumnMeta(statsAllNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertTrue(canDrop(notEq(missingColumn, null), columnMetas));
+    assertThat(canDrop(notEq(missingColumn, null), columnMetas)).isTrue();
 
-    assertFalse(canDrop(notEq(intColumn, null), missingMinMaxColumnMetas));
-    assertFalse(canDrop(notEq(doubleColumn, null), missingMinMaxColumnMetas));
+    assertThat(canDrop(notEq(intColumn, null), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(notEq(doubleColumn, null), missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
   public void testLt() {
-    assertTrue(canDrop(lt(intColumn, 9), columnMetas));
-    assertTrue(canDrop(lt(intColumn, 10), columnMetas));
-    assertFalse(canDrop(lt(intColumn, 100), columnMetas));
-    assertFalse(canDrop(lt(intColumn, 101), columnMetas));
+    assertThat(canDrop(lt(intColumn, 9), columnMetas)).isTrue();
+    assertThat(canDrop(lt(intColumn, 10), columnMetas)).isTrue();
+    assertThat(canDrop(lt(intColumn, 100), columnMetas)).isFalse();
+    assertThat(canDrop(lt(intColumn, 101), columnMetas)).isFalse();
 
-    assertTrue(canDrop(lt(intColumn, 0), nullColumnMetas));
-    assertTrue(canDrop(lt(intColumn, 7), nullColumnMetas));
+    assertThat(canDrop(lt(intColumn, 0), nullColumnMetas)).isTrue();
+    assertThat(canDrop(lt(intColumn, 7), nullColumnMetas)).isTrue();
 
-    assertTrue(canDrop(lt(missingColumn, fromString("any")), columnMetas));
+    assertThat(canDrop(lt(missingColumn, fromString("any")), columnMetas)).isTrue();
 
-    assertFalse(canDrop(lt(intColumn, 0), missingMinMaxColumnMetas));
-    assertFalse(canDrop(lt(doubleColumn, 0.0), missingMinMaxColumnMetas));
+    assertThat(canDrop(lt(intColumn, 0), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, 0.0), missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
   public void testLtEq() {
-    assertTrue(canDrop(ltEq(intColumn, 9), columnMetas));
-    assertFalse(canDrop(ltEq(intColumn, 10), columnMetas));
-    assertFalse(canDrop(ltEq(intColumn, 100), columnMetas));
-    assertFalse(canDrop(ltEq(intColumn, 101), columnMetas));
+    assertThat(canDrop(ltEq(intColumn, 9), columnMetas)).isTrue();
+    assertThat(canDrop(ltEq(intColumn, 10), columnMetas)).isFalse();
+    assertThat(canDrop(ltEq(intColumn, 100), columnMetas)).isFalse();
+    assertThat(canDrop(ltEq(intColumn, 101), columnMetas)).isFalse();
 
-    assertTrue(canDrop(ltEq(intColumn, 0), nullColumnMetas));
-    assertTrue(canDrop(ltEq(intColumn, 7), nullColumnMetas));
+    assertThat(canDrop(ltEq(intColumn, 0), nullColumnMetas)).isTrue();
+    assertThat(canDrop(ltEq(intColumn, 7), nullColumnMetas)).isTrue();
 
-    assertTrue(canDrop(ltEq(missingColumn, fromString("any")), columnMetas));
+    assertThat(canDrop(ltEq(missingColumn, fromString("any")), columnMetas)).isTrue();
 
-    assertFalse(canDrop(ltEq(intColumn, -1), missingMinMaxColumnMetas));
-    assertFalse(canDrop(ltEq(doubleColumn, -0.1), missingMinMaxColumnMetas));
+    assertThat(canDrop(ltEq(intColumn, -1), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, -0.1), missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
   public void testGt() {
-    assertFalse(canDrop(gt(intColumn, 9), columnMetas));
-    assertFalse(canDrop(gt(intColumn, 10), columnMetas));
-    assertTrue(canDrop(gt(intColumn, 100), columnMetas));
-    assertTrue(canDrop(gt(intColumn, 101), columnMetas));
+    assertThat(canDrop(gt(intColumn, 9), columnMetas)).isFalse();
+    assertThat(canDrop(gt(intColumn, 10), columnMetas)).isFalse();
+    assertThat(canDrop(gt(intColumn, 100), columnMetas)).isTrue();
+    assertThat(canDrop(gt(intColumn, 101), columnMetas)).isTrue();
 
-    assertTrue(canDrop(gt(intColumn, 0), nullColumnMetas));
-    assertTrue(canDrop(gt(intColumn, 7), nullColumnMetas));
+    assertThat(canDrop(gt(intColumn, 0), nullColumnMetas)).isTrue();
+    assertThat(canDrop(gt(intColumn, 7), nullColumnMetas)).isTrue();
 
-    assertTrue(canDrop(gt(missingColumn, fromString("any")), columnMetas));
+    assertThat(canDrop(gt(missingColumn, fromString("any")), columnMetas)).isTrue();
 
-    assertFalse(canDrop(gt(intColumn, 0), missingMinMaxColumnMetas));
-    assertFalse(canDrop(gt(doubleColumn, 0.0), missingMinMaxColumnMetas));
+    assertThat(canDrop(gt(intColumn, 0), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, 0.0), missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
   public void testGtEq() {
-    assertFalse(canDrop(gtEq(intColumn, 9), columnMetas));
-    assertFalse(canDrop(gtEq(intColumn, 10), columnMetas));
-    assertFalse(canDrop(gtEq(intColumn, 100), columnMetas));
-    assertTrue(canDrop(gtEq(intColumn, 101), columnMetas));
+    assertThat(canDrop(gtEq(intColumn, 9), columnMetas)).isFalse();
+    assertThat(canDrop(gtEq(intColumn, 10), columnMetas)).isFalse();
+    assertThat(canDrop(gtEq(intColumn, 100), columnMetas)).isFalse();
+    assertThat(canDrop(gtEq(intColumn, 101), columnMetas)).isTrue();
 
-    assertTrue(canDrop(gtEq(intColumn, 0), nullColumnMetas));
-    assertTrue(canDrop(gtEq(intColumn, 7), nullColumnMetas));
+    assertThat(canDrop(gtEq(intColumn, 0), nullColumnMetas)).isTrue();
+    assertThat(canDrop(gtEq(intColumn, 7), nullColumnMetas)).isTrue();
 
-    assertTrue(canDrop(gtEq(missingColumn, fromString("any")), columnMetas));
+    assertThat(canDrop(gtEq(missingColumn, fromString("any")), columnMetas)).isTrue();
 
-    assertFalse(canDrop(gtEq(intColumn, 1), missingMinMaxColumnMetas));
-    assertFalse(canDrop(gtEq(doubleColumn, 0.1), missingMinMaxColumnMetas));
+    assertThat(canDrop(gtEq(intColumn, 1), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, 0.1), missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
@@ -311,8 +317,8 @@ public class TestStatisticsFilter {
     values1.add(15);
     values1.add(17);
     values1.add(19);
-    assertFalse(canDrop(in(intColumn, values1), columnMetas));
-    assertFalse(canDrop(notIn(intColumn, values1), columnMetas));
+    assertThat(canDrop(in(intColumn, values1), columnMetas)).isFalse();
+    assertThat(canDrop(notIn(intColumn, values1), columnMetas)).isFalse();
 
     Set<Integer> values2 = new HashSet<>();
     values2.add(109);
@@ -320,8 +326,8 @@ public class TestStatisticsFilter {
     values2.add(5);
     values2.add(117);
     values2.add(101);
-    assertFalse(canDrop(in(intColumn, values2), columnMetas));
-    assertFalse(canDrop(notIn(intColumn, values2), columnMetas));
+    assertThat(canDrop(in(intColumn, values2), columnMetas)).isFalse();
+    assertThat(canDrop(notIn(intColumn, values2), columnMetas)).isFalse();
 
     Set<Integer> values3 = new HashSet<>();
     values3.add(1);
@@ -329,14 +335,14 @@ public class TestStatisticsFilter {
     values3.add(5);
     values3.add(7);
     values3.add(10);
-    assertFalse(canDrop(in(intColumn, values3), columnMetas));
-    assertFalse(canDrop(notIn(intColumn, values3), columnMetas));
+    assertThat(canDrop(in(intColumn, values3), columnMetas)).isFalse();
+    assertThat(canDrop(notIn(intColumn, values3), columnMetas)).isFalse();
 
     Set<Integer> values4 = new HashSet<>();
     values4.add(50);
     values4.add(60);
-    assertFalse(canDrop(in(intColumn, values4), missingMinMaxColumnMetas));
-    assertFalse(canDrop(notIn(intColumn, values4), missingMinMaxColumnMetas));
+    assertThat(canDrop(in(intColumn, values4), missingMinMaxColumnMetas)).isFalse();
+    assertThat(canDrop(notIn(intColumn, values4), missingMinMaxColumnMetas)).isFalse();
 
     Set<Double> values5 = new HashSet<>();
     values5.add(1.0);
@@ -344,24 +350,24 @@ public class TestStatisticsFilter {
     values5.add(95.0);
     values5.add(107.0);
     values5.add(99.0);
-    assertFalse(canDrop(in(doubleColumn, values5), columnMetas));
-    assertFalse(canDrop(notIn(doubleColumn, values5), columnMetas));
+    assertThat(canDrop(in(doubleColumn, values5), columnMetas)).isFalse();
+    assertThat(canDrop(notIn(doubleColumn, values5), columnMetas)).isFalse();
 
     Set<Binary> values6 = new HashSet<>();
     values6.add(Binary.fromString("test1"));
     values6.add(Binary.fromString("test2"));
-    assertTrue(canDrop(in(missingColumn, values6), columnMetas));
-    assertFalse(canDrop(notIn(missingColumn, values6), columnMetas));
+    assertThat(canDrop(in(missingColumn, values6), columnMetas)).isTrue();
+    assertThat(canDrop(notIn(missingColumn, values6), columnMetas)).isFalse();
 
     Set<Integer> values7 = new HashSet<>();
     values7.add(null);
-    assertFalse(canDrop(in(intColumn, values7), nullColumnMetas));
-    assertFalse(canDrop(notIn(intColumn, values7), nullColumnMetas));
+    assertThat(canDrop(in(intColumn, values7), nullColumnMetas)).isFalse();
+    assertThat(canDrop(notIn(intColumn, values7), nullColumnMetas)).isFalse();
 
     Set<Binary> values8 = new HashSet<>();
     values8.add(null);
-    assertFalse(canDrop(in(missingColumn, values8), columnMetas));
-    assertFalse(canDrop(notIn(missingColumn, values8), columnMetas));
+    assertThat(canDrop(in(missingColumn, values8), columnMetas)).isFalse();
+    assertThat(canDrop(notIn(missingColumn, values8), columnMetas)).isFalse();
 
     IntStatistics statsNoNulls = new IntStatistics();
     statsNoNulls.setMinMax(10, 100);
@@ -373,21 +379,25 @@ public class TestStatisticsFilter {
 
     Set<Integer> values9 = new HashSet<>();
     values9.add(null);
-    assertTrue(canDrop(
-        in(intColumn, values9),
-        List.of(getIntColumnMeta(statsNoNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            in(intColumn, values9),
+            List.of(getIntColumnMeta(statsNoNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertFalse(canDrop(
-        notIn(intColumn, values9),
-        List.of(getIntColumnMeta(statsNoNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            notIn(intColumn, values9),
+            List.of(getIntColumnMeta(statsNoNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(
-        in(intColumn, values9),
-        List.of(getIntColumnMeta(statsSomeNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            in(intColumn, values9),
+            List.of(getIntColumnMeta(statsSomeNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(
-        notIn(intColumn, values9),
-        List.of(getIntColumnMeta(statsSomeNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            notIn(intColumn, values9),
+            List.of(getIntColumnMeta(statsSomeNulls, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
   }
 
   @Test
@@ -431,54 +441,55 @@ public class TestStatisticsFilter {
 
   @Test
   public void testContainsEqNonNull() {
-    assertTrue(canDrop(contains(eq(intColumn, 9)), columnMetas));
-    assertFalse(canDrop(contains(eq(intColumn, 10)), columnMetas));
-    assertFalse(canDrop(contains(eq(intColumn, 100)), columnMetas));
-    assertTrue(canDrop(contains(eq(intColumn, 101)), columnMetas));
+    assertThat(canDrop(contains(eq(intColumn, 9)), columnMetas)).isTrue();
+    assertThat(canDrop(contains(eq(intColumn, 10)), columnMetas)).isFalse();
+    assertThat(canDrop(contains(eq(intColumn, 100)), columnMetas)).isFalse();
+    assertThat(canDrop(contains(eq(intColumn, 101)), columnMetas)).isTrue();
 
     // drop columns of all nulls when looking for non-null value
-    assertTrue(canDrop(contains(eq(intColumn, 0)), nullColumnMetas));
-    assertFalse(canDrop(contains(eq(intColumn, 50)), missingMinMaxColumnMetas));
+    assertThat(canDrop(contains(eq(intColumn, 0)), nullColumnMetas)).isTrue();
+    assertThat(canDrop(contains(eq(intColumn, 50)), missingMinMaxColumnMetas))
+        .isFalse();
   }
 
   @Test
   public void testContainsAnd() {
     Operators.Contains<Integer> yes = contains(eq(intColumn, 9));
     Operators.Contains<Double> no = contains(eq(doubleColumn, 50D));
-    assertTrue(canDrop(and(yes, yes), columnMetas));
-    assertTrue(canDrop(and(yes, no), columnMetas));
-    assertTrue(canDrop(and(no, yes), columnMetas));
-    assertFalse(canDrop(and(no, no), columnMetas));
+    assertThat(canDrop(and(yes, yes), columnMetas)).isTrue();
+    assertThat(canDrop(and(yes, no), columnMetas)).isTrue();
+    assertThat(canDrop(and(no, yes), columnMetas)).isTrue();
+    assertThat(canDrop(and(no, no), columnMetas)).isFalse();
   }
 
   @Test
   public void testContainsOr() {
     Operators.Contains<Integer> yes = contains(eq(intColumn, 9));
     Operators.Contains<Double> no = contains(eq(doubleColumn, 50D));
-    assertTrue(canDrop(or(yes, yes), columnMetas));
-    assertFalse(canDrop(or(yes, no), columnMetas));
-    assertFalse(canDrop(or(no, yes), columnMetas));
-    assertFalse(canDrop(or(no, no), columnMetas));
+    assertThat(canDrop(or(yes, yes), columnMetas)).isTrue();
+    assertThat(canDrop(or(yes, no), columnMetas)).isFalse();
+    assertThat(canDrop(or(no, yes), columnMetas)).isFalse();
+    assertThat(canDrop(or(no, no), columnMetas)).isFalse();
   }
 
   @Test
   public void testAnd() {
     FilterPredicate yes = eq(intColumn, 9);
     FilterPredicate no = eq(doubleColumn, 50D);
-    assertTrue(canDrop(and(yes, yes), columnMetas));
-    assertTrue(canDrop(and(yes, no), columnMetas));
-    assertTrue(canDrop(and(no, yes), columnMetas));
-    assertFalse(canDrop(and(no, no), columnMetas));
+    assertThat(canDrop(and(yes, yes), columnMetas)).isTrue();
+    assertThat(canDrop(and(yes, no), columnMetas)).isTrue();
+    assertThat(canDrop(and(no, yes), columnMetas)).isTrue();
+    assertThat(canDrop(and(no, no), columnMetas)).isFalse();
   }
 
   @Test
   public void testOr() {
     FilterPredicate yes = eq(intColumn, 9);
     FilterPredicate no = eq(doubleColumn, 50D);
-    assertTrue(canDrop(or(yes, yes), columnMetas));
-    assertFalse(canDrop(or(yes, no), columnMetas));
-    assertFalse(canDrop(or(no, yes), columnMetas));
-    assertFalse(canDrop(or(no, no), columnMetas));
+    assertThat(canDrop(or(yes, yes), columnMetas)).isTrue();
+    assertThat(canDrop(or(yes, no), columnMetas)).isFalse();
+    assertThat(canDrop(or(no, yes), columnMetas)).isFalse();
+    assertThat(canDrop(or(no, no), columnMetas)).isFalse();
   }
 
   public static class SevensAndEightsUdp extends UserDefinedPredicate<Integer> {
@@ -556,67 +567,89 @@ public class TestStatisticsFilter {
     IntStatistics neither = new IntStatistics();
     neither.setMinMax(1, 2);
 
-    assertTrue(canDrop(pred, List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(pred, List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertFalse(canDrop(pred, List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(pred, List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(pred, List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(pred, List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(invPred, List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(invPred, List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertTrue(canDrop(invPred, List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(invPred, List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertFalse(canDrop(invPred, List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(invPred, List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
     // udpDropMissingColumn drops null column.
-    assertTrue(canDrop(
-        udpDropMissingColumn, List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            udpDropMissingColumn,
+            List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertTrue(canDrop(
-        udpDropMissingColumn, List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            udpDropMissingColumn,
+            List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertTrue(canDrop(
-        udpDropMissingColumn,
-        List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            udpDropMissingColumn,
+            List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
     // invUdpDropMissingColumn (i.e., not(udpDropMissingColumn)) keeps null column.
-    assertFalse(canDrop(
-        invUdpDropMissingColumn,
-        List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            invUdpDropMissingColumn,
+            List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(
-        invUdpDropMissingColumn,
-        List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            invUdpDropMissingColumn,
+            List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(
-        invUdpDropMissingColumn,
-        List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            invUdpDropMissingColumn,
+            List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
     // udpKeepMissingColumn keeps null column.
-    assertFalse(canDrop(
-        udpKeepMissingColumn, List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            udpKeepMissingColumn,
+            List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(
-        udpKeepMissingColumn, List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            udpKeepMissingColumn,
+            List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
-    assertFalse(canDrop(
-        udpKeepMissingColumn,
-        List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            udpKeepMissingColumn,
+            List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isFalse();
 
     // invUdpKeepMissingColumn (i.e., not(udpKeepMissingColumn)) drops null column.
-    assertTrue(canDrop(
-        invUdpKeepMissingColumn,
-        List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            invUdpKeepMissingColumn,
+            List.of(getIntColumnMeta(seven, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertTrue(canDrop(
-        invUdpKeepMissingColumn,
-        List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            invUdpKeepMissingColumn,
+            List.of(getIntColumnMeta(eight, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertTrue(canDrop(
-        invUdpKeepMissingColumn,
-        List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))));
+    assertThat(canDrop(
+            invUdpKeepMissingColumn,
+            List.of(getIntColumnMeta(neither, 177L), getDoubleColumnMeta(doubleStats, 177L))))
+        .isTrue();
 
-    assertFalse(canDrop(allPositivePred, missingMinMaxColumnMetas));
+    assertThat(canDrop(allPositivePred, missingMinMaxColumnMetas)).isFalse();
   }
 
   @Test
@@ -626,15 +659,11 @@ public class TestStatisticsFilter {
 
     FilterPredicate pred = and(not(eq(doubleColumn, 12.0)), eq(intColumn, 17));
 
-    try {
-      canDrop(pred, columnMetas);
-      fail("This should throw");
-    } catch (IllegalArgumentException e) {
-      assertEquals(
-          "This predicate contains a not! Did you forget to run this predicate through LogicalInverseRewriter?"
-              + " not(eq(double.column, 12.0))",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> canDrop(pred, columnMetas))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "This predicate contains a not! Did you forget to run this predicate through LogicalInverseRewriter?"
+                + " not(eq(double.column, 12.0))");
   }
 
   private static final FloatColumn floatCol = floatColumn("float.column");
@@ -682,21 +711,23 @@ public class TestStatisticsFilter {
     List<ColumnChunkMetaData> metas =
         List.of(getIntColumnMeta(intStats, 177L), getDoubleColumnMeta(allNanStats, 177L));
 
-    assertTrue(canDrop(eq(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(notEq(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(lt(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(gt(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, 5.0), metas));
-    assertTrue(canDrop(in(doubleColumn, new HashSet<>(List.of(5.0))), metas));
+    assertThat(canDrop(eq(doubleColumn, 5.0), metas)).isTrue();
+    assertThat(canDrop(notEq(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(in(doubleColumn, new HashSet<>(List.of(5.0))), metas))
+        .isTrue();
 
-    assertFalse(canDrop(eq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(notEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(lt(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(gt(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(in(doubleColumn, new HashSet<>(List.of(Double.NaN))), metas));
+    assertThat(canDrop(eq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(notEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(in(doubleColumn, new HashSet<>(List.of(Double.NaN))), metas))
+        .isFalse();
   }
 
   @Test
@@ -711,15 +742,16 @@ public class TestStatisticsFilter {
         List.of(getIntColumnMeta(intStats, 177L), getDoubleColumnMeta(mixedStats, 177L));
 
     // Non-NaN literal within range: cannot drop
-    assertFalse(canDrop(eq(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(notEq(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(lt(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(gt(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(in(doubleColumn, new HashSet<>(List.of(50.0))), metas));
-    assertFalse(canDrop(lt(doubleColumn, 0.0), metas));
-    assertFalse(canDrop(gt(doubleColumn, 200.0), metas));
+    assertThat(canDrop(eq(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(notEq(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(in(doubleColumn, new HashSet<>(List.of(50.0))), metas))
+        .isFalse();
+    assertThat(canDrop(lt(doubleColumn, 0.0), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, 200.0), metas)).isFalse();
 
     DoubleStatistics mixedEqualStats = new DoubleStatistics();
     mixedEqualStats.setMinMax(5.0, 5.0);
@@ -727,16 +759,17 @@ public class TestStatisticsFilter {
     mixedEqualStats.incrementNanCount(1);
     List<ColumnChunkMetaData> mixedEqualMetas =
         List.of(getIntColumnMeta(intStats, 177L), getDoubleColumnMeta(mixedEqualStats, 177L));
-    assertFalse(canDrop(notEq(doubleColumn, 5.0), mixedEqualMetas));
+    assertThat(canDrop(notEq(doubleColumn, 5.0), mixedEqualMetas)).isFalse();
 
     // NaN literal: NaN values are present so cannot drop
-    assertFalse(canDrop(eq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(notEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(lt(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(gt(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(in(doubleColumn, new HashSet<>(List.of(Double.NaN))), metas));
+    assertThat(canDrop(eq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(notEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(in(doubleColumn, new HashSet<>(List.of(Double.NaN))), metas))
+        .isFalse();
   }
 
   @Test
@@ -752,12 +785,12 @@ public class TestStatisticsFilter {
     List<ColumnChunkMetaData> metas =
         List.of(getIntColumnMeta(intStats, 177L), getDoubleColumnMeta(statsWithUnknownNaNs, 177L));
 
-    assertFalse(canDrop(eq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(notEq(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(lt(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(gt(doubleColumn, 200.0), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, 200.0), metas));
+    assertThat(canDrop(eq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(notEq(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, 200.0), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, 200.0), metas)).isFalse();
   }
 
   @Test
@@ -771,21 +804,23 @@ public class TestStatisticsFilter {
     List<ColumnChunkMetaData> metas =
         List.of(getIntColumnMeta(intStats, 177L), getDoubleColumnMeta(zeroNanStats, 177L));
 
-    assertFalse(canDrop(eq(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(notEq(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(lt(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(gt(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, 50.0), metas));
-    assertFalse(canDrop(in(doubleColumn, new HashSet<>(List.of(50.0))), metas));
+    assertThat(canDrop(eq(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(notEq(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, 50.0), metas)).isFalse();
+    assertThat(canDrop(in(doubleColumn, new HashSet<>(List.of(50.0))), metas))
+        .isFalse();
 
-    assertTrue(canDrop(eq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(notEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(lt(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(gt(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(in(doubleColumn, new HashSet<>(List.of(Double.NaN))), metas));
+    assertThat(canDrop(eq(doubleColumn, Double.NaN), metas)).isTrue();
+    assertThat(canDrop(notEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(in(doubleColumn, new HashSet<>(List.of(Double.NaN))), metas))
+        .isFalse();
   }
 
   @Test
@@ -803,21 +838,23 @@ public class TestStatisticsFilter {
     List<ColumnChunkMetaData> metas =
         List.of(getIntColumnMeta(intStats, 177L), getDoubleColumnMetaWithType(ieee754Type, allNanStats, 177L));
 
-    assertTrue(canDrop(eq(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(notEq(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(lt(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(gt(doubleColumn, 5.0), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, 5.0), metas));
-    assertTrue(canDrop(in(doubleColumn, new HashSet<>(List.of(5.0))), metas));
+    assertThat(canDrop(eq(doubleColumn, 5.0), metas)).isTrue();
+    assertThat(canDrop(notEq(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, 5.0), metas)).isFalse();
+    assertThat(canDrop(in(doubleColumn, new HashSet<>(List.of(5.0))), metas))
+        .isTrue();
 
-    assertFalse(canDrop(eq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(notEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(lt(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(ltEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(gt(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(gtEq(doubleColumn, Double.NaN), metas));
-    assertFalse(canDrop(in(doubleColumn, new HashSet<>(List.of(Double.NaN))), metas));
+    assertThat(canDrop(eq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(notEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(lt(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(ltEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(gt(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(gtEq(doubleColumn, Double.NaN), metas)).isFalse();
+    assertThat(canDrop(in(doubleColumn, new HashSet<>(List.of(Double.NaN))), metas))
+        .isFalse();
   }
 
   // ========================= Float NaN Tests =========================
@@ -832,21 +869,22 @@ public class TestStatisticsFilter {
     List<ColumnChunkMetaData> metas =
         List.of(getIntColumnMeta(intStats, 177L), getFloatColumnMeta(allNanStats, 177L));
 
-    assertTrue(canDrop(eq(floatCol, 5.0f), metas));
-    assertFalse(canDrop(notEq(floatCol, 5.0f), metas));
-    assertFalse(canDrop(lt(floatCol, 5.0f), metas));
-    assertFalse(canDrop(ltEq(floatCol, 5.0f), metas));
-    assertFalse(canDrop(gt(floatCol, 5.0f), metas));
-    assertFalse(canDrop(gtEq(floatCol, 5.0f), metas));
-    assertTrue(canDrop(in(floatCol, new HashSet<>(List.of(5.0f))), metas));
+    assertThat(canDrop(eq(floatCol, 5.0f), metas)).isTrue();
+    assertThat(canDrop(notEq(floatCol, 5.0f), metas)).isFalse();
+    assertThat(canDrop(lt(floatCol, 5.0f), metas)).isFalse();
+    assertThat(canDrop(ltEq(floatCol, 5.0f), metas)).isFalse();
+    assertThat(canDrop(gt(floatCol, 5.0f), metas)).isFalse();
+    assertThat(canDrop(gtEq(floatCol, 5.0f), metas)).isFalse();
+    assertThat(canDrop(in(floatCol, new HashSet<>(List.of(5.0f))), metas)).isTrue();
 
-    assertFalse(canDrop(eq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(notEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(lt(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(ltEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(gt(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(gtEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(in(floatCol, new HashSet<>(List.of(Float.NaN))), metas));
+    assertThat(canDrop(eq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(notEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(lt(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(ltEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(gt(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(gtEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(in(floatCol, new HashSet<>(List.of(Float.NaN))), metas))
+        .isFalse();
   }
 
   @Test
@@ -860,15 +898,15 @@ public class TestStatisticsFilter {
     List<ColumnChunkMetaData> metas =
         List.of(getIntColumnMeta(intStats, 177L), getFloatColumnMeta(mixedStats, 177L));
 
-    assertFalse(canDrop(eq(floatCol, 50.0f), metas));
-    assertFalse(canDrop(notEq(floatCol, 50.0f), metas));
-    assertFalse(canDrop(lt(floatCol, 50.0f), metas));
-    assertFalse(canDrop(ltEq(floatCol, 50.0f), metas));
-    assertFalse(canDrop(gt(floatCol, 50.0f), metas));
-    assertFalse(canDrop(gtEq(floatCol, 50.0f), metas));
-    assertFalse(canDrop(in(floatCol, new HashSet<>(List.of(50.0f))), metas));
-    assertFalse(canDrop(lt(floatCol, 0.0f), metas));
-    assertFalse(canDrop(gt(floatCol, 200.0f), metas));
+    assertThat(canDrop(eq(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(notEq(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(lt(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(ltEq(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(gt(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(gtEq(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(in(floatCol, new HashSet<>(List.of(50.0f))), metas)).isFalse();
+    assertThat(canDrop(lt(floatCol, 0.0f), metas)).isFalse();
+    assertThat(canDrop(gt(floatCol, 200.0f), metas)).isFalse();
 
     FloatStatistics mixedEqualStats = new FloatStatistics();
     mixedEqualStats.setMinMax(5.0f, 5.0f);
@@ -876,15 +914,16 @@ public class TestStatisticsFilter {
     mixedEqualStats.incrementNanCount(1);
     List<ColumnChunkMetaData> mixedEqualMetas =
         List.of(getIntColumnMeta(intStats, 177L), getFloatColumnMeta(mixedEqualStats, 177L));
-    assertFalse(canDrop(notEq(floatCol, 5.0f), mixedEqualMetas));
+    assertThat(canDrop(notEq(floatCol, 5.0f), mixedEqualMetas)).isFalse();
 
-    assertFalse(canDrop(eq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(notEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(lt(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(ltEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(gt(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(gtEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(in(floatCol, new HashSet<>(List.of(Float.NaN))), metas));
+    assertThat(canDrop(eq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(notEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(lt(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(ltEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(gt(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(gtEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(in(floatCol, new HashSet<>(List.of(Float.NaN))), metas))
+        .isFalse();
   }
 
   @Test
@@ -898,21 +937,22 @@ public class TestStatisticsFilter {
     List<ColumnChunkMetaData> metas =
         List.of(getIntColumnMeta(intStats, 177L), getFloatColumnMeta(zeroNanStats, 177L));
 
-    assertFalse(canDrop(eq(floatCol, 50.0f), metas));
-    assertFalse(canDrop(notEq(floatCol, 50.0f), metas));
-    assertFalse(canDrop(lt(floatCol, 50.0f), metas));
-    assertFalse(canDrop(ltEq(floatCol, 50.0f), metas));
-    assertFalse(canDrop(gt(floatCol, 50.0f), metas));
-    assertFalse(canDrop(gtEq(floatCol, 50.0f), metas));
-    assertFalse(canDrop(in(floatCol, new HashSet<>(List.of(50.0f))), metas));
+    assertThat(canDrop(eq(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(notEq(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(lt(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(ltEq(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(gt(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(gtEq(floatCol, 50.0f), metas)).isFalse();
+    assertThat(canDrop(in(floatCol, new HashSet<>(List.of(50.0f))), metas)).isFalse();
 
-    assertTrue(canDrop(eq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(notEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(lt(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(ltEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(gt(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(gtEq(floatCol, Float.NaN), metas));
-    assertFalse(canDrop(in(floatCol, new HashSet<>(List.of(Float.NaN))), metas));
+    assertThat(canDrop(eq(floatCol, Float.NaN), metas)).isTrue();
+    assertThat(canDrop(notEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(lt(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(ltEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(gt(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(gtEq(floatCol, Float.NaN), metas)).isFalse();
+    assertThat(canDrop(in(floatCol, new HashSet<>(List.of(Float.NaN))), metas))
+        .isFalse();
   }
 
   // ========================= Float16 NaN Tests =========================
@@ -958,21 +998,23 @@ public class TestStatisticsFilter {
     ColumnChunkMetaData float16Meta = getFloat16ColumnMeta(allNanStats, 177L);
     List<ColumnChunkMetaData> metas = List.of(getIntColumnMeta(intStats, 177L), float16Meta);
 
-    assertTrue(canDrop(eq(float16Column, FLOAT16_ONE), metas));
-    assertFalse(canDrop(notEq(float16Column, FLOAT16_ONE), metas));
-    assertFalse(canDrop(lt(float16Column, FLOAT16_ONE), metas));
-    assertFalse(canDrop(ltEq(float16Column, FLOAT16_ONE), metas));
-    assertFalse(canDrop(gt(float16Column, FLOAT16_ONE), metas));
-    assertFalse(canDrop(gtEq(float16Column, FLOAT16_ONE), metas));
-    assertTrue(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_ONE))), metas));
+    assertThat(canDrop(eq(float16Column, FLOAT16_ONE), metas)).isTrue();
+    assertThat(canDrop(notEq(float16Column, FLOAT16_ONE), metas)).isFalse();
+    assertThat(canDrop(lt(float16Column, FLOAT16_ONE), metas)).isFalse();
+    assertThat(canDrop(ltEq(float16Column, FLOAT16_ONE), metas)).isFalse();
+    assertThat(canDrop(gt(float16Column, FLOAT16_ONE), metas)).isFalse();
+    assertThat(canDrop(gtEq(float16Column, FLOAT16_ONE), metas)).isFalse();
+    assertThat(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_ONE))), metas))
+        .isTrue();
 
-    assertFalse(canDrop(eq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(notEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(lt(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(ltEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(gt(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(gtEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_NAN))), metas));
+    assertThat(canDrop(eq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(notEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(lt(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(ltEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(gt(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(gtEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_NAN))), metas))
+        .isFalse();
   }
 
   @Test
@@ -989,21 +1031,23 @@ public class TestStatisticsFilter {
     ColumnChunkMetaData float16Meta = getFloat16ColumnMeta(mixedStats, 177L);
     List<ColumnChunkMetaData> metas = List.of(getIntColumnMeta(intStats, 177L), float16Meta);
 
-    assertFalse(canDrop(eq(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(notEq(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(lt(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(ltEq(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(gt(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(gtEq(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_FIFTY))), metas));
+    assertThat(canDrop(eq(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(notEq(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(lt(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(ltEq(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(gt(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(gtEq(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_FIFTY))), metas))
+        .isFalse();
 
-    assertFalse(canDrop(eq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(notEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(lt(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(ltEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(gt(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(gtEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_NAN))), metas));
+    assertThat(canDrop(eq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(notEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(lt(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(ltEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(gt(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(gtEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_NAN))), metas))
+        .isFalse();
   }
 
   @Test
@@ -1020,20 +1064,22 @@ public class TestStatisticsFilter {
     ColumnChunkMetaData float16Meta = getFloat16ColumnMeta(zeroNanStats, 177L);
     List<ColumnChunkMetaData> metas = List.of(getIntColumnMeta(intStats, 177L), float16Meta);
 
-    assertFalse(canDrop(eq(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(notEq(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(lt(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(ltEq(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(gt(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(gtEq(float16Column, FLOAT16_FIFTY), metas));
-    assertFalse(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_FIFTY))), metas));
+    assertThat(canDrop(eq(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(notEq(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(lt(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(ltEq(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(gt(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(gtEq(float16Column, FLOAT16_FIFTY), metas)).isFalse();
+    assertThat(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_FIFTY))), metas))
+        .isFalse();
 
-    assertTrue(canDrop(eq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(notEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(lt(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(ltEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(gt(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(gtEq(float16Column, FLOAT16_NAN), metas));
-    assertFalse(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_NAN))), metas));
+    assertThat(canDrop(eq(float16Column, FLOAT16_NAN), metas)).isTrue();
+    assertThat(canDrop(notEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(lt(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(ltEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(gt(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(gtEq(float16Column, FLOAT16_NAN), metas)).isFalse();
+    assertThat(canDrop(in(float16Column, new HashSet<>(List.of(FLOAT16_NAN))), metas))
+        .isFalse();
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -43,13 +43,10 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.timestampType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.uuidType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.variantType;
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.data.Offset.offset;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -139,7 +136,6 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.Repetition;
 import org.apache.parquet.schema.Types;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -163,7 +159,7 @@ public class TestParquetMetadataConverter {
     PageHeader pageHeader = new PageHeader(type, uncSize, compSize);
     writePageHeader(pageHeader, out);
     PageHeader readPageHeader = readPageHeader(new ByteArrayInputStream(out.toByteArray()));
-    assertEquals(pageHeader, readPageHeader);
+    assertThat(readPageHeader).isEqualTo(pageHeader);
   }
 
   @Test
@@ -171,7 +167,7 @@ public class TestParquetMetadataConverter {
     ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
     List<SchemaElement> parquetSchema = parquetMetadataConverter.toParquetSchema(Paper.schema);
     MessageType schema = parquetMetadataConverter.fromParquetSchema(parquetSchema, null);
-    assertEquals(Paper.schema, schema);
+    assertThat(schema).isEqualTo(Paper.schema);
   }
 
   @Test
@@ -207,7 +203,7 @@ public class TestParquetMetadataConverter {
             .setLogicalType(LogicalType.DECIMAL(new DecimalType(2, 9)))
             .setPrecision(9)
             .setScale(2));
-    Assert.assertEquals(expected, schemaElements);
+    assertThat(schemaElements).isEqualTo(expected);
   }
 
   @Test
@@ -228,7 +224,7 @@ public class TestParquetMetadataConverter {
 
     // Flag should be true
     fmd1.row_groups.forEach(rowGroup -> rowGroup.columns.forEach(column -> {
-      assertTrue(column.meta_data.isSetDictionary_page_offset());
+      assertThat(column.meta_data.isSetDictionary_page_offset()).isTrue();
     }));
 
     ByteArrayOutputStream metaDataOutputStream = new ByteArrayOutputStream();
@@ -242,7 +238,7 @@ public class TestParquetMetadataConverter {
     long dicOffsetConverted =
         parquetMetaDataConverted.getBlocks().get(0).getColumns().get(0).getDictionaryPageOffset();
 
-    Assert.assertEquals(dicOffsetOriginal, dicOffsetConverted);
+    assertThat(dicOffsetConverted).isEqualTo(dicOffsetOriginal);
   }
 
   @Test
@@ -254,7 +250,7 @@ public class TestParquetMetadataConverter {
 
     // Flag should be false
     fmd1.row_groups.forEach(rowGroup -> rowGroup.columns.forEach(column -> {
-      assertFalse(column.meta_data.isSetDictionary_page_offset());
+      assertThat(column.meta_data.isSetDictionary_page_offset()).isFalse();
     }));
 
     ByteArrayOutputStream metaDataOutputStream = new ByteArrayOutputStream();
@@ -265,7 +261,7 @@ public class TestParquetMetadataConverter {
 
     long dicOffsetConverted = pmd2.getBlocks().get(0).getColumns().get(0).getDictionaryPageOffset();
 
-    Assert.assertEquals(0, dicOffsetConverted);
+    assertThat(dicOffsetConverted).isEqualTo(0);
   }
 
   @Test
@@ -275,22 +271,37 @@ public class TestParquetMetadataConverter {
 
     // Without bloom filter offset
     FileMetaData footer = converter.toParquetMetadata(1, origMetaData);
-    assertFalse(
-        footer.getRow_groups().get(0).getColumns().get(0).getMeta_data().isSetBloom_filter_offset());
+    assertThat(footer.getRow_groups()
+            .get(0)
+            .getColumns()
+            .get(0)
+            .getMeta_data()
+            .isSetBloom_filter_offset())
+        .isFalse();
     ParquetMetadata convertedMetaData = converter.fromParquetMetadata(footer);
-    assertTrue(convertedMetaData.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset() < 0);
+    assertThat(convertedMetaData.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset())
+        .isNegative();
 
     // With bloom filter offset
     origMetaData.getBlocks().get(0).getColumns().get(0).setBloomFilterOffset(1234);
     footer = converter.toParquetMetadata(1, origMetaData);
-    assertTrue(
-        footer.getRow_groups().get(0).getColumns().get(0).getMeta_data().isSetBloom_filter_offset());
-    assertEquals(
-        1234,
-        footer.getRow_groups().get(0).getColumns().get(0).getMeta_data().getBloom_filter_offset());
+    assertThat(footer.getRow_groups()
+            .get(0)
+            .getColumns()
+            .get(0)
+            .getMeta_data()
+            .isSetBloom_filter_offset())
+        .isTrue();
+    assertThat(footer.getRow_groups()
+            .get(0)
+            .getColumns()
+            .get(0)
+            .getMeta_data()
+            .getBloom_filter_offset())
+        .isEqualTo(1234);
     convertedMetaData = converter.fromParquetMetadata(footer);
-    assertEquals(
-        1234, convertedMetaData.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset());
+    assertThat(convertedMetaData.getBlocks().get(0).getColumns().get(0).getBloomFilterOffset())
+        .isEqualTo(1234);
   }
 
   @Test
@@ -300,22 +311,37 @@ public class TestParquetMetadataConverter {
 
     // Without bloom filter length
     FileMetaData footer = converter.toParquetMetadata(1, origMetaData);
-    assertFalse(
-        footer.getRow_groups().get(0).getColumns().get(0).getMeta_data().isSetBloom_filter_length());
+    assertThat(footer.getRow_groups()
+            .get(0)
+            .getColumns()
+            .get(0)
+            .getMeta_data()
+            .isSetBloom_filter_length())
+        .isFalse();
     ParquetMetadata convertedMetaData = converter.fromParquetMetadata(footer);
-    assertTrue(convertedMetaData.getBlocks().get(0).getColumns().get(0).getBloomFilterLength() < 0);
+    assertThat(convertedMetaData.getBlocks().get(0).getColumns().get(0).getBloomFilterLength())
+        .isNegative();
 
     // With bloom filter length
     origMetaData.getBlocks().get(0).getColumns().get(0).setBloomFilterLength(1024);
     footer = converter.toParquetMetadata(1, origMetaData);
-    assertTrue(
-        footer.getRow_groups().get(0).getColumns().get(0).getMeta_data().isSetBloom_filter_length());
-    assertEquals(
-        1024,
-        footer.getRow_groups().get(0).getColumns().get(0).getMeta_data().getBloom_filter_length());
+    assertThat(footer.getRow_groups()
+            .get(0)
+            .getColumns()
+            .get(0)
+            .getMeta_data()
+            .isSetBloom_filter_length())
+        .isTrue();
+    assertThat(footer.getRow_groups()
+            .get(0)
+            .getColumns()
+            .get(0)
+            .getMeta_data()
+            .getBloom_filter_length())
+        .isEqualTo(1024);
     convertedMetaData = converter.fromParquetMetadata(footer);
-    assertEquals(
-        1024, convertedMetaData.getBlocks().get(0).getColumns().get(0).getBloomFilterLength());
+    assertThat(convertedMetaData.getBlocks().get(0).getColumns().get(0).getBloomFilterLength())
+        .isEqualTo(1024);
   }
 
   @Test
@@ -333,7 +359,7 @@ public class TestParquetMetadataConverter {
     // where converted_types are written to the metadata, but logicalType is missing
     parquetSchema.get(1).setLogicalType(null);
     MessageType schema = parquetMetadataConverter.fromParquetSchema(parquetSchema, null);
-    assertEquals(expected, schema);
+    assertThat(schema).isEqualTo(expected);
   }
 
   @Test
@@ -356,7 +382,7 @@ public class TestParquetMetadataConverter {
     // Set converted type field to a different type to verify that in case of mismatch, it overrides logical type
     parquetSchema.get(1).setConverted_type(ConvertedType.JSON);
     MessageType actual = parquetMetadataConverter.fromParquetSchema(parquetSchema, null);
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -402,117 +428,121 @@ public class TestParquetMetadataConverter {
         .named("Message");
     List<SchemaElement> parquetSchema = parquetMetadataConverter.toParquetSchema(expected);
     MessageType schema = parquetMetadataConverter.fromParquetSchema(parquetSchema, null);
-    assertEquals(expected, schema);
+    assertThat(schema).isEqualTo(expected);
   }
 
   @Test
   public void testLogicalToConvertedTypeConversion() {
     ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
 
-    assertEquals(ConvertedType.UTF8, parquetMetadataConverter.convertToConvertedType(stringType()));
-    assertEquals(ConvertedType.ENUM, parquetMetadataConverter.convertToConvertedType(enumType()));
+    assertThat(parquetMetadataConverter.convertToConvertedType(stringType()))
+        .isEqualTo(ConvertedType.UTF8);
+    assertThat(parquetMetadataConverter.convertToConvertedType(enumType())).isEqualTo(ConvertedType.ENUM);
 
-    assertEquals(ConvertedType.INT_8, parquetMetadataConverter.convertToConvertedType(intType(8, true)));
-    assertEquals(ConvertedType.INT_16, parquetMetadataConverter.convertToConvertedType(intType(16, true)));
-    assertEquals(ConvertedType.INT_32, parquetMetadataConverter.convertToConvertedType(intType(32, true)));
-    assertEquals(ConvertedType.INT_64, parquetMetadataConverter.convertToConvertedType(intType(64, true)));
-    assertEquals(ConvertedType.UINT_8, parquetMetadataConverter.convertToConvertedType(intType(8, false)));
-    assertEquals(ConvertedType.UINT_16, parquetMetadataConverter.convertToConvertedType(intType(16, false)));
-    assertEquals(ConvertedType.UINT_32, parquetMetadataConverter.convertToConvertedType(intType(32, false)));
-    assertEquals(ConvertedType.UINT_64, parquetMetadataConverter.convertToConvertedType(intType(64, false)));
-    assertEquals(ConvertedType.DECIMAL, parquetMetadataConverter.convertToConvertedType(decimalType(8, 16)));
+    assertThat(parquetMetadataConverter.convertToConvertedType(intType(8, true)))
+        .isEqualTo(ConvertedType.INT_8);
+    assertThat(parquetMetadataConverter.convertToConvertedType(intType(16, true)))
+        .isEqualTo(ConvertedType.INT_16);
+    assertThat(parquetMetadataConverter.convertToConvertedType(intType(32, true)))
+        .isEqualTo(ConvertedType.INT_32);
+    assertThat(parquetMetadataConverter.convertToConvertedType(intType(64, true)))
+        .isEqualTo(ConvertedType.INT_64);
+    assertThat(parquetMetadataConverter.convertToConvertedType(intType(8, false)))
+        .isEqualTo(ConvertedType.UINT_8);
+    assertThat(parquetMetadataConverter.convertToConvertedType(intType(16, false)))
+        .isEqualTo(ConvertedType.UINT_16);
+    assertThat(parquetMetadataConverter.convertToConvertedType(intType(32, false)))
+        .isEqualTo(ConvertedType.UINT_32);
+    assertThat(parquetMetadataConverter.convertToConvertedType(intType(64, false)))
+        .isEqualTo(ConvertedType.UINT_64);
+    assertThat(parquetMetadataConverter.convertToConvertedType(decimalType(8, 16)))
+        .isEqualTo(ConvertedType.DECIMAL);
 
-    assertEquals(
-        ConvertedType.TIMESTAMP_MILLIS,
-        parquetMetadataConverter.convertToConvertedType(timestampType(true, MILLIS)));
-    assertEquals(
-        ConvertedType.TIMESTAMP_MICROS,
-        parquetMetadataConverter.convertToConvertedType(timestampType(true, MICROS)));
-    assertNull(parquetMetadataConverter.convertToConvertedType(timestampType(true, NANOS)));
-    assertEquals(
-        ConvertedType.TIMESTAMP_MILLIS,
-        parquetMetadataConverter.convertToConvertedType(timestampType(false, MILLIS)));
-    assertEquals(
-        ConvertedType.TIMESTAMP_MICROS,
-        parquetMetadataConverter.convertToConvertedType(timestampType(false, MICROS)));
-    assertNull(parquetMetadataConverter.convertToConvertedType(timestampType(false, NANOS)));
+    assertThat(parquetMetadataConverter.convertToConvertedType(timestampType(true, MILLIS)))
+        .isEqualTo(ConvertedType.TIMESTAMP_MILLIS);
+    assertThat(parquetMetadataConverter.convertToConvertedType(timestampType(true, MICROS)))
+        .isEqualTo(ConvertedType.TIMESTAMP_MICROS);
+    assertThat(parquetMetadataConverter.convertToConvertedType(timestampType(true, NANOS)))
+        .isNull();
+    assertThat(parquetMetadataConverter.convertToConvertedType(timestampType(false, MILLIS)))
+        .isEqualTo(ConvertedType.TIMESTAMP_MILLIS);
+    assertThat(parquetMetadataConverter.convertToConvertedType(timestampType(false, MICROS)))
+        .isEqualTo(ConvertedType.TIMESTAMP_MICROS);
+    assertThat(parquetMetadataConverter.convertToConvertedType(timestampType(false, NANOS)))
+        .isNull();
 
-    assertEquals(
-        ConvertedType.TIME_MILLIS, parquetMetadataConverter.convertToConvertedType(timeType(true, MILLIS)));
-    assertEquals(
-        ConvertedType.TIME_MICROS, parquetMetadataConverter.convertToConvertedType(timeType(true, MICROS)));
-    assertNull(parquetMetadataConverter.convertToConvertedType(timeType(true, NANOS)));
-    assertEquals(
-        ConvertedType.TIME_MILLIS, parquetMetadataConverter.convertToConvertedType(timeType(false, MILLIS)));
-    assertEquals(
-        ConvertedType.TIME_MICROS, parquetMetadataConverter.convertToConvertedType(timeType(false, MICROS)));
-    assertNull(parquetMetadataConverter.convertToConvertedType(timeType(false, NANOS)));
+    assertThat(parquetMetadataConverter.convertToConvertedType(timeType(true, MILLIS)))
+        .isEqualTo(ConvertedType.TIME_MILLIS);
+    assertThat(parquetMetadataConverter.convertToConvertedType(timeType(true, MICROS)))
+        .isEqualTo(ConvertedType.TIME_MICROS);
+    assertThat(parquetMetadataConverter.convertToConvertedType(timeType(true, NANOS)))
+        .isNull();
+    assertThat(parquetMetadataConverter.convertToConvertedType(timeType(false, MILLIS)))
+        .isEqualTo(ConvertedType.TIME_MILLIS);
+    assertThat(parquetMetadataConverter.convertToConvertedType(timeType(false, MICROS)))
+        .isEqualTo(ConvertedType.TIME_MICROS);
+    assertThat(parquetMetadataConverter.convertToConvertedType(timeType(false, NANOS)))
+        .isNull();
 
-    assertEquals(ConvertedType.DATE, parquetMetadataConverter.convertToConvertedType(dateType()));
+    assertThat(parquetMetadataConverter.convertToConvertedType(dateType())).isEqualTo(ConvertedType.DATE);
 
-    assertEquals(
-        ConvertedType.INTERVAL,
-        parquetMetadataConverter.convertToConvertedType(
-            LogicalTypeAnnotation.IntervalLogicalTypeAnnotation.getInstance()));
-    assertEquals(ConvertedType.JSON, parquetMetadataConverter.convertToConvertedType(jsonType()));
-    assertEquals(ConvertedType.BSON, parquetMetadataConverter.convertToConvertedType(bsonType()));
+    assertThat(parquetMetadataConverter.convertToConvertedType(
+            LogicalTypeAnnotation.IntervalLogicalTypeAnnotation.getInstance()))
+        .isEqualTo(ConvertedType.INTERVAL);
+    assertThat(parquetMetadataConverter.convertToConvertedType(jsonType())).isEqualTo(ConvertedType.JSON);
+    assertThat(parquetMetadataConverter.convertToConvertedType(bsonType())).isEqualTo(ConvertedType.BSON);
 
-    assertNull(parquetMetadataConverter.convertToConvertedType(uuidType()));
+    assertThat(parquetMetadataConverter.convertToConvertedType(uuidType())).isNull();
 
-    assertEquals(ConvertedType.LIST, parquetMetadataConverter.convertToConvertedType(listType()));
-    assertEquals(ConvertedType.MAP, parquetMetadataConverter.convertToConvertedType(mapType()));
-    assertEquals(
-        ConvertedType.MAP_KEY_VALUE,
-        parquetMetadataConverter.convertToConvertedType(
-            LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance()));
+    assertThat(parquetMetadataConverter.convertToConvertedType(listType())).isEqualTo(ConvertedType.LIST);
+    assertThat(parquetMetadataConverter.convertToConvertedType(mapType())).isEqualTo(ConvertedType.MAP);
+    assertThat(parquetMetadataConverter.convertToConvertedType(
+            LogicalTypeAnnotation.MapKeyValueTypeAnnotation.getInstance()))
+        .isEqualTo(ConvertedType.MAP_KEY_VALUE);
   }
 
   @Test
   public void testEnumEquivalence() {
     ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
     for (org.apache.parquet.column.Encoding encoding : org.apache.parquet.column.Encoding.values()) {
-      assertEquals(
-          encoding, parquetMetadataConverter.getEncoding(parquetMetadataConverter.getEncoding(encoding)));
+      assertThat(parquetMetadataConverter.getEncoding(parquetMetadataConverter.getEncoding(encoding)))
+          .isEqualTo(encoding);
     }
     for (org.apache.parquet.format.Encoding encoding : org.apache.parquet.format.Encoding.values()) {
-      assertEquals(
-          encoding, parquetMetadataConverter.getEncoding(parquetMetadataConverter.getEncoding(encoding)));
+      assertThat(parquetMetadataConverter.getEncoding(parquetMetadataConverter.getEncoding(encoding)))
+          .isEqualTo(encoding);
     }
     for (Repetition repetition : Repetition.values()) {
-      assertEquals(
-          repetition,
-          parquetMetadataConverter.fromParquetRepetition(
-              parquetMetadataConverter.toParquetRepetition(repetition)));
+      assertThat(parquetMetadataConverter.fromParquetRepetition(
+              parquetMetadataConverter.toParquetRepetition(repetition)))
+          .isEqualTo(repetition);
     }
     for (FieldRepetitionType repetition : FieldRepetitionType.values()) {
-      assertEquals(
-          repetition,
-          parquetMetadataConverter.toParquetRepetition(
-              parquetMetadataConverter.fromParquetRepetition(repetition)));
+      assertThat(parquetMetadataConverter.toParquetRepetition(
+              parquetMetadataConverter.fromParquetRepetition(repetition)))
+          .isEqualTo(repetition);
     }
     for (PrimitiveTypeName primitiveTypeName : PrimitiveTypeName.values()) {
-      assertEquals(
-          primitiveTypeName,
-          parquetMetadataConverter.getPrimitive(parquetMetadataConverter.getType(primitiveTypeName)));
+      assertThat(parquetMetadataConverter.getPrimitive(parquetMetadataConverter.getType(primitiveTypeName)))
+          .isEqualTo(primitiveTypeName);
     }
     for (Type type : Type.values()) {
-      assertEquals(type, parquetMetadataConverter.getType(parquetMetadataConverter.getPrimitive(type)));
+      assertThat(parquetMetadataConverter.getType(parquetMetadataConverter.getPrimitive(type)))
+          .isEqualTo(type);
     }
     for (OriginalType original : OriginalType.values()) {
-      assertEquals(
-          original,
-          parquetMetadataConverter
+      assertThat(parquetMetadataConverter
               .getLogicalTypeAnnotation(
                   parquetMetadataConverter.convertToConvertedType(
                       LogicalTypeAnnotation.fromOriginalType(original, null)),
                   null)
-              .toOriginalType());
+              .toOriginalType())
+          .isEqualTo(original);
     }
     for (ConvertedType converted : ConvertedType.values()) {
-      assertEquals(
-          converted,
-          parquetMetadataConverter.convertToConvertedType(
-              parquetMetadataConverter.getLogicalTypeAnnotation(converted, null)));
+      assertThat(parquetMetadataConverter.convertToConvertedType(
+              parquetMetadataConverter.getLogicalTypeAnnotation(converted, null)))
+          .isEqualTo(converted);
     }
   }
 
@@ -554,11 +584,11 @@ public class TestParquetMetadataConverter {
   }
 
   private void verifyMD(FileMetaData md, long... offsets) {
-    assertEquals(offsets.length, md.row_groups.size());
+    assertThat(md.row_groups).hasSameSizeAs(offsets);
     for (int i = 0; i < offsets.length; i++) {
       long offset = offsets[i];
       RowGroup rowGroup = md.getRow_groups().get(i);
-      assertEquals(offset, getOffset(rowGroup));
+      assertThat(getOffset(rowGroup)).isEqualTo(offset);
     }
   }
 
@@ -575,16 +605,13 @@ public class TestParquetMetadataConverter {
       FileMetaData filtered = filter(md, start, start + splitWidth);
       for (RowGroup rg : filtered.getRow_groups()) {
         long o = getOffset(rg);
-        if (offsetsFound.contains(o)) {
-          fail("found the offset twice: " + o);
-        } else {
-          offsetsFound.add(o);
-        }
+        assertThat(offsetsFound).as("found the offset twice: " + o).doesNotContain(o);
+        offsetsFound.add(o);
       }
     }
-    if (offsetsFound.size() != md.row_groups.size()) {
-      fail("missing row groups, " + "found: " + offsetsFound + "\nexpected " + md.getRow_groups());
-    }
+    assertThat(offsetsFound)
+        .as("found: " + offsetsFound + "\nexpected " + md.getRow_groups())
+        .hasSize(md.getRow_groups().size());
   }
 
   private long fileSize(FileMetaData md) {
@@ -701,11 +728,10 @@ public class TestParquetMetadataConverter {
   @Test
   public void testMetadataToJson() {
     ParquetMetadata metadata = new ParquetMetadata(null, null);
-    assertEquals("{\"fileMetaData\":null,\"blocks\":null}", ParquetMetadata.toJSON(metadata));
-    assertEquals(
-        ("{\n" + "  \"fileMetaData\" : null,\n" + "  \"blocks\" : null\n" + "}")
-            .replace("\n", System.lineSeparator()),
-        ParquetMetadata.toPrettyJSON(metadata));
+    assertThat(ParquetMetadata.toJSON(metadata)).isEqualTo("{\"fileMetaData\":null,\"blocks\":null}");
+    assertThat(ParquetMetadata.toPrettyJSON(metadata))
+        .isEqualTo(("{\n" + "  \"fileMetaData\" : null,\n" + "  \"blocks\" : null\n" + "}")
+            .replace("\n", System.lineSeparator()));
   }
 
   private ColumnChunkMetaData createColumnChunkMetaData() {
@@ -745,18 +771,18 @@ public class TestParquetMetadataConverter {
         parquetMetadataConverter.fromFormatEncodings(formatEncodingsCopy2);
 
     // make sure they are all semantically equal
-    assertEquals(expected, res1);
-    assertEquals(expected, res2);
-    assertEquals(expected, res3);
+    assertThat(res1).isEqualTo(expected);
+    assertThat(res2).isEqualTo(expected);
+    assertThat(res3).isEqualTo(expected);
 
     // make sure res1, res2, and res3 are actually the same cached object
-    assertSame(res1, res2);
-    assertSame(res1, res3);
+    assertThat(res2).isSameAs(res1);
+    assertThat(res3).isSameAs(res1);
 
     // make sure they are all unmodifiable (UnmodifiableSet is not public, so we have to compare on class name)
-    assertEquals("java.util.Collections$UnmodifiableSet", res1.getClass().getName());
-    assertEquals("java.util.Collections$UnmodifiableSet", res2.getClass().getName());
-    assertEquals("java.util.Collections$UnmodifiableSet", res3.getClass().getName());
+    assertThat(res1.getClass().getName()).isEqualTo("java.util.Collections$UnmodifiableSet");
+    assertThat(res2.getClass().getName()).isEqualTo("java.util.Collections$UnmodifiableSet");
+    assertThat(res3.getClass().getName()).isEqualTo("java.util.Collections$UnmodifiableSet");
   }
 
   @Test
@@ -770,8 +796,8 @@ public class TestParquetMetadataConverter {
     List<org.apache.parquet.format.Encoding> formatEncodings =
         parquetMetadataConverter.toFormatEncodings(columnEncodings);
     for (int i = 1; i < formatEncodings.size(); i++) {
-      assertTrue(formatEncodings.get(i - 1).ordinal()
-          < formatEncodings.get(i).ordinal());
+      assertThat(formatEncodings.get(i - 1).ordinal())
+          .isLessThan(formatEncodings.get(i).ordinal());
     }
   }
 
@@ -794,29 +820,37 @@ public class TestParquetMetadataConverter {
     stats.updateStats(Binary.fromConstantByteArray(min));
     stats.updateStats(Binary.fromConstantByteArray(max));
     long totalLen = min.length + max.length;
-    Assert.assertFalse("Should not be smaller than min + max size", stats.isSmallerThan(totalLen));
-    Assert.assertTrue("Should be smaller than min + max size + 1", stats.isSmallerThan(totalLen + 1));
+    assertThat(stats.isSmallerThan(totalLen))
+        .as("Should not be smaller than min + max size")
+        .isFalse();
+    assertThat(stats.isSmallerThan(totalLen + 1))
+        .as("Should be smaller than min + max size + 1")
+        .isTrue();
 
     org.apache.parquet.format.Statistics formatStats = helper.toParquetStatistics(stats);
 
-    assertFalse("Min should not be set", formatStats.isSetMin());
-    assertFalse("Max should not be set", formatStats.isSetMax());
+    assertThat(formatStats.isSetMin()).as("Min should not be set").isFalse();
+    assertThat(formatStats.isSetMax()).as("Max should not be set").isFalse();
     if (helper == StatsHelper.V2) {
-      Assert.assertArrayEquals("Min_value should match", min, formatStats.getMin_value());
-      Assert.assertArrayEquals("Max_value should match", max, formatStats.getMax_value());
+      assertThat(formatStats.getMin_value()).as("Min_value should match").isEqualTo(min);
+      assertThat(formatStats.getMax_value()).as("Max_value should match").isEqualTo(max);
     }
-    Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
+    assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
 
     // min/max are not written because the values are too large, but null count is always written
     stats.setMinMaxFromBytes(max, max);
 
     formatStats = helper.toParquetStatistics(stats);
 
-    Assert.assertFalse("Min should not be set", formatStats.isSetMin());
-    Assert.assertFalse("Max should not be set", formatStats.isSetMax());
-    Assert.assertFalse("Min_value should not be set", formatStats.isSetMin_value());
-    Assert.assertFalse("Max_value should not be set", formatStats.isSetMax_value());
-    Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
+    assertThat(formatStats.isSetMin()).as("Min should not be set").isFalse();
+    assertThat(formatStats.isSetMax()).as("Max should not be set").isFalse();
+    assertThat(formatStats.isSetMin_value())
+        .as("Min_value should not be set")
+        .isFalse();
+    assertThat(formatStats.isSetMax_value())
+        .as("Max_value should not be set")
+        .isFalse();
+    assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
 
     Statistics roundTripStats = ParquetMetadataConverter.fromParquetStatisticsInternal(
         Version.FULL_VERSION,
@@ -824,8 +858,12 @@ public class TestParquetMetadataConverter {
         new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.BINARY, ""),
         ParquetMetadataConverter.SortOrder.SIGNED);
 
-    Assert.assertFalse("Round-trip stats should not be empty (null count is set)", roundTripStats.isEmpty());
-    Assert.assertEquals("Round-trip null count should match", 3004, roundTripStats.getNumNulls());
+    assertThat(roundTripStats.isEmpty())
+        .as("Round-trip stats should not be empty (null count is set)")
+        .isFalse();
+    assertThat(roundTripStats.getNumNulls())
+        .as("Round-trip null count should match")
+        .isEqualTo(3004);
   }
 
   @Test
@@ -842,12 +880,9 @@ public class TestParquetMetadataConverter {
 
     int[] invalidLengths = {-1, 0, Integer.MAX_VALUE + 1};
     for (int len : invalidLengths) {
-      try {
-        testBinaryStatsWithTruncation(len, 80, 20);
-        Assert.fail("Expected IllegalArgumentException but didn't happen");
-      } catch (IllegalArgumentException e) {
-        // expected, nothing to do
-      }
+      assertThatThrownBy(() -> testBinaryStatsWithTruncation(len, 80, 20))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("Truncate length should be greater than 0");
     }
   }
 
@@ -862,20 +897,20 @@ public class TestParquetMetadataConverter {
     org.apache.parquet.format.Statistics formatStats = metadataConverter.toParquetStatistics(stats);
 
     if (minLen + maxLen >= ParquetMetadataConverter.MAX_STATS_SIZE) {
-      assertNull(formatStats.getMin_value());
-      assertNull(formatStats.getMax_value());
+      assertThat(formatStats.getMin_value()).isNull();
+      assertThat(formatStats.getMax_value()).isNull();
     } else {
       String minString = new String(min, Charset.forName("UTF-8"));
       String minStatString = new String(formatStats.getMin_value(), Charset.forName("UTF-8"));
-      assertTrue(minStatString.compareTo(minString) <= 0);
+      assertThat(minStatString.compareTo(minString)).isLessThanOrEqualTo(0);
       String maxString = new String(max, Charset.forName("UTF-8"));
       String maxStatString = new String(formatStats.getMax_value(), Charset.forName("UTF-8"));
-      assertTrue(maxStatString.compareTo(maxString) >= 0);
+      assertThat(maxStatString.compareTo(maxString)).isGreaterThanOrEqualTo(0);
     }
   }
 
   private static String generateRandomString(String prefix, int length) {
-    assertTrue(prefix.length() <= length);
+    assertThat(prefix.length()).isLessThanOrEqualTo(length);
     StringBuilder sb = new StringBuilder(length);
     sb.append(prefix);
     for (int i = 0; i < length - prefix.length(); i++) {
@@ -907,9 +942,13 @@ public class TestParquetMetadataConverter {
 
     org.apache.parquet.format.Statistics formatStats = helper.toParquetStatistics(stats);
 
-    Assert.assertEquals("Min should match", min, BytesUtils.bytesToInt(formatStats.getMin()));
-    Assert.assertEquals("Max should match", max, BytesUtils.bytesToInt(formatStats.getMax()));
-    Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
+    assertThat(BytesUtils.bytesToInt(formatStats.getMin()))
+        .as("Min should match")
+        .isEqualTo(min);
+    assertThat(BytesUtils.bytesToInt(formatStats.getMax()))
+        .as("Max should match")
+        .isEqualTo(max);
+    assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
   }
 
   @Test
@@ -933,9 +972,13 @@ public class TestParquetMetadataConverter {
 
     org.apache.parquet.format.Statistics formatStats = helper.toParquetStatistics(stats);
 
-    Assert.assertEquals("Min should match", min, BytesUtils.bytesToLong(formatStats.getMin()));
-    Assert.assertEquals("Max should match", max, BytesUtils.bytesToLong(formatStats.getMax()));
-    Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
+    assertThat(BytesUtils.bytesToLong(formatStats.getMin()))
+        .as("Min should match")
+        .isEqualTo(min);
+    assertThat(BytesUtils.bytesToLong(formatStats.getMax()))
+        .as("Max should match")
+        .isEqualTo(max);
+    assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
   }
 
   @Test
@@ -959,11 +1002,13 @@ public class TestParquetMetadataConverter {
 
     org.apache.parquet.format.Statistics formatStats = helper.toParquetStatistics(stats);
 
-    Assert.assertEquals(
-        "Min should match", min, Float.intBitsToFloat(BytesUtils.bytesToInt(formatStats.getMin())), 0.000001);
-    Assert.assertEquals(
-        "Max should match", max, Float.intBitsToFloat(BytesUtils.bytesToInt(formatStats.getMax())), 0.000001);
-    Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
+    assertThat(Float.intBitsToFloat(BytesUtils.bytesToInt(formatStats.getMin())))
+        .as("Min should match")
+        .isCloseTo(min, offset(0.000001f));
+    assertThat(Float.intBitsToFloat(BytesUtils.bytesToInt(formatStats.getMax())))
+        .as("Max should match")
+        .isCloseTo(max, offset(0.000001f));
+    assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
   }
 
   @Test
@@ -987,17 +1032,13 @@ public class TestParquetMetadataConverter {
 
     org.apache.parquet.format.Statistics formatStats = helper.toParquetStatistics(stats);
 
-    Assert.assertEquals(
-        "Min should match",
-        min,
-        Double.longBitsToDouble(BytesUtils.bytesToLong(formatStats.getMin())),
-        0.000001);
-    Assert.assertEquals(
-        "Max should match",
-        max,
-        Double.longBitsToDouble(BytesUtils.bytesToLong(formatStats.getMax())),
-        0.000001);
-    Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
+    assertThat(Double.longBitsToDouble(BytesUtils.bytesToLong(formatStats.getMin())))
+        .as("Min should match")
+        .isCloseTo(min, offset(0.000001));
+    assertThat(Double.longBitsToDouble(BytesUtils.bytesToLong(formatStats.getMax())))
+        .as("Max should match")
+        .isCloseTo(max, offset(0.000001));
+    assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
   }
 
   @Test
@@ -1021,9 +1062,13 @@ public class TestParquetMetadataConverter {
 
     org.apache.parquet.format.Statistics formatStats = helper.toParquetStatistics(stats);
 
-    Assert.assertEquals("Min should match", min, BytesUtils.bytesToBool(formatStats.getMin()));
-    Assert.assertEquals("Max should match", max, BytesUtils.bytesToBool(formatStats.getMax()));
-    Assert.assertEquals("Num nulls should match", 3004, formatStats.getNull_count());
+    assertThat(BytesUtils.bytesToBool(formatStats.getMin()))
+        .as("Min should match")
+        .isEqualTo(min);
+    assertThat(BytesUtils.bytesToBool(formatStats.getMax()))
+        .as("Max should match")
+        .isEqualTo(max);
+    assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
   }
 
   @Test
@@ -1041,9 +1086,15 @@ public class TestParquetMetadataConverter {
     Statistics convertedStats = converter.fromParquetStatistics(
         Version.FULL_VERSION, StatsHelper.V1.toParquetStatistics(stats), binaryType);
 
-    Assert.assertFalse("Stats should not include min/max: " + convertedStats, convertedStats.hasNonNullValue());
-    Assert.assertTrue("Stats should have null count: " + convertedStats, convertedStats.isNumNullsSet());
-    Assert.assertEquals("Stats should have 3 nulls: " + convertedStats, 3L, convertedStats.getNumNulls());
+    assertThat(convertedStats.hasNonNullValue())
+        .as("Stats should not include min/max: " + convertedStats)
+        .isFalse();
+    assertThat(convertedStats.isNumNullsSet())
+        .as("Stats should have null count: " + convertedStats)
+        .isTrue();
+    assertThat(convertedStats.getNumNulls())
+        .as("Stats should have 3 nulls: " + convertedStats)
+        .isEqualTo(3L);
   }
 
   @Test
@@ -1070,9 +1121,12 @@ public class TestParquetMetadataConverter {
     Statistics convertedStats = converter.fromParquetStatistics(
         Version.FULL_VERSION, ParquetMetadataConverter.toParquetStatistics(stats), binaryType);
 
-    Assert.assertFalse("Stats should not be empty: " + convertedStats, convertedStats.isEmpty());
-    Assert.assertArrayEquals(
-        "min == max: " + convertedStats, convertedStats.getMaxBytes(), convertedStats.getMinBytes());
+    assertThat(convertedStats.isEmpty())
+        .as("Stats should not be empty: " + convertedStats)
+        .isFalse();
+    assertThat(convertedStats.getMinBytes())
+        .as("min == max: " + convertedStats)
+        .isEqualTo(convertedStats.getMaxBytes());
   }
 
   @Test
@@ -1103,16 +1157,20 @@ public class TestParquetMetadataConverter {
     Statistics convertedStats =
         converter.fromParquetStatistics(Version.FULL_VERSION, helper.toParquetStatistics(stats), binaryType);
 
-    Assert.assertFalse("Stats should not be empty", convertedStats.isEmpty());
-    Assert.assertTrue(convertedStats.isNumNullsSet());
-    Assert.assertEquals("Should have 3 nulls", 3, convertedStats.getNumNulls());
+    assertThat(convertedStats.isEmpty()).as("Stats should not be empty").isFalse();
+    assertThat(convertedStats.isNumNullsSet()).isTrue();
+    assertThat(convertedStats.getNumNulls()).as("Should have 3 nulls").isEqualTo(3);
     if (helper == StatsHelper.V1) {
-      assertFalse("Min-max should be null for V1 stats", convertedStats.hasNonNullValue());
+      assertThat(convertedStats.hasNonNullValue())
+          .as("Min-max should be null for V1 stats")
+          .isFalse();
     } else {
-      Assert.assertEquals(
-          "Should have correct min (unsigned sort)", Binary.fromString("A"), convertedStats.genericGetMin());
-      Assert.assertEquals(
-          "Should have correct max (unsigned sort)", Binary.fromString("z"), convertedStats.genericGetMax());
+      assertThat(convertedStats.genericGetMin())
+          .as("Should have correct min (unsigned sort)")
+          .isEqualTo(Binary.fromString("A"));
+      assertThat(convertedStats.genericGetMax())
+          .as("Should have correct max (unsigned sort)")
+          .isEqualTo(Binary.fromString("z"));
     }
   }
 
@@ -1125,8 +1183,8 @@ public class TestParquetMetadataConverter {
     stats.updateStats(toBinary(0xff, 0x7b));
     String expectedMinStr = "6.097555E-5";
     String expectedMaxStr = "65504.0";
-    assertEquals(expectedMinStr, stats.minAsString());
-    assertEquals(expectedMaxStr, stats.maxAsString());
+    assertThat(stats.minAsString()).isEqualTo(expectedMinStr);
+    assertThat(stats.maxAsString()).isEqualTo(expectedMaxStr);
   }
 
   private Binary toBinary(int... bytes) {
@@ -1144,29 +1202,29 @@ public class TestParquetMetadataConverter {
 
     org.apache.parquet.format.Statistics formatStats = new org.apache.parquet.format.Statistics();
     Statistics<?> stats = converter.fromParquetStatistics(Version.FULL_VERSION, formatStats, type);
-    assertFalse(stats.isNumNullsSet());
-    assertFalse(stats.hasNonNullValue());
-    assertTrue(stats.isEmpty());
-    assertEquals(-1, stats.getNumNulls());
+    assertThat(stats.isNumNullsSet()).isFalse();
+    assertThat(stats.hasNonNullValue()).isFalse();
+    assertThat(stats.isEmpty()).isTrue();
+    assertThat(stats.getNumNulls()).isEqualTo(-1);
 
     formatStats.clear();
     formatStats.setMin(BytesUtils.intToBytes(-100));
     formatStats.setMax(BytesUtils.intToBytes(100));
     stats = converter.fromParquetStatistics(Version.FULL_VERSION, formatStats, type);
-    assertFalse(stats.isNumNullsSet());
-    assertTrue(stats.hasNonNullValue());
-    assertFalse(stats.isEmpty());
-    assertEquals(-1, stats.getNumNulls());
-    assertEquals(-100, stats.genericGetMin());
-    assertEquals(100, stats.genericGetMax());
+    assertThat(stats.isNumNullsSet()).isFalse();
+    assertThat(stats.hasNonNullValue()).isTrue();
+    assertThat(stats.isEmpty()).isFalse();
+    assertThat(stats.getNumNulls()).isEqualTo(-1);
+    assertThat(stats.genericGetMin()).isEqualTo(-100);
+    assertThat(stats.genericGetMax()).isEqualTo(100);
 
     formatStats.clear();
     formatStats.setNull_count(2000);
     stats = converter.fromParquetStatistics(Version.FULL_VERSION, formatStats, type);
-    assertTrue(stats.isNumNullsSet());
-    assertFalse(stats.hasNonNullValue());
-    assertFalse(stats.isEmpty());
-    assertEquals(2000, stats.getNumNulls());
+    assertThat(stats.isNumNullsSet()).isTrue();
+    assertThat(stats.hasNonNullValue()).isFalse();
+    assertThat(stats.isEmpty()).isFalse();
+    assertThat(stats.getNumNulls()).isEqualTo(2000);
   }
 
   @Test
@@ -1187,10 +1245,10 @@ public class TestParquetMetadataConverter {
   private void testSkippedV2Stats(PrimitiveType type, Object min, Object max) {
     Statistics<?> stats = createStats(type, min, max);
     org.apache.parquet.format.Statistics statistics = ParquetMetadataConverter.toParquetStatistics(stats);
-    assertFalse(statistics.isSetMin());
-    assertFalse(statistics.isSetMax());
-    assertFalse(statistics.isSetMin_value());
-    assertFalse(statistics.isSetMax_value());
+    assertThat(statistics.isSetMin()).isFalse();
+    assertThat(statistics.isSetMax()).isFalse();
+    assertThat(statistics.isSetMin_value()).isFalse();
+    assertThat(statistics.isSetMax_value()).isFalse();
   }
 
   @Test
@@ -1225,10 +1283,10 @@ public class TestParquetMetadataConverter {
   private void testV2OnlyStats(PrimitiveType type, Object min, Object max) {
     Statistics<?> stats = createStats(type, min, max);
     org.apache.parquet.format.Statistics statistics = ParquetMetadataConverter.toParquetStatistics(stats);
-    assertFalse(statistics.isSetMin());
-    assertFalse(statistics.isSetMax());
-    assertEquals(ByteBuffer.wrap(stats.getMinBytes()), statistics.min_value);
-    assertEquals(ByteBuffer.wrap(stats.getMaxBytes()), statistics.max_value);
+    assertThat(statistics.isSetMin()).isFalse();
+    assertThat(statistics.isSetMax()).isFalse();
+    assertThat(statistics.min_value).isEqualTo(ByteBuffer.wrap(stats.getMinBytes()));
+    assertThat(statistics.max_value).isEqualTo(ByteBuffer.wrap(stats.getMaxBytes()));
   }
 
   @Test
@@ -1267,10 +1325,10 @@ public class TestParquetMetadataConverter {
   private void testV2StatsEqualMinMax(PrimitiveType type, Object min, Object max) {
     Statistics<?> stats = createStats(type, min, max);
     org.apache.parquet.format.Statistics statistics = ParquetMetadataConverter.toParquetStatistics(stats);
-    assertEquals(ByteBuffer.wrap(stats.getMinBytes()), statistics.min);
-    assertEquals(ByteBuffer.wrap(stats.getMaxBytes()), statistics.max);
-    assertEquals(ByteBuffer.wrap(stats.getMinBytes()), statistics.min_value);
-    assertEquals(ByteBuffer.wrap(stats.getMaxBytes()), statistics.max_value);
+    assertThat(statistics.min).isEqualTo(ByteBuffer.wrap(stats.getMinBytes()));
+    assertThat(statistics.max).isEqualTo(ByteBuffer.wrap(stats.getMaxBytes()));
+    assertThat(statistics.min_value).isEqualTo(ByteBuffer.wrap(stats.getMinBytes()));
+    assertThat(statistics.max_value).isEqualTo(ByteBuffer.wrap(stats.getMaxBytes()));
   }
 
   private static <T> Statistics<?> createStats(PrimitiveType type, T min, T max) {
@@ -1290,8 +1348,8 @@ public class TestParquetMetadataConverter {
     Statistics<?> stats = Statistics.createStats(type);
     stats.updateStats(max);
     stats.updateStats(min);
-    assertEquals(min, stats.genericGetMin());
-    assertEquals(max, stats.genericGetMax());
+    assertThat(stats.genericGetMin()).isEqualTo(min);
+    assertThat(stats.genericGetMax()).isEqualTo(max);
     return stats;
   }
 
@@ -1299,8 +1357,8 @@ public class TestParquetMetadataConverter {
     Statistics<?> stats = Statistics.createStats(type);
     stats.updateStats(max);
     stats.updateStats(min);
-    assertEquals(min, stats.genericGetMin());
-    assertEquals(max, stats.genericGetMax());
+    assertThat(stats.genericGetMin()).isEqualTo(min);
+    assertThat(stats.genericGetMax()).isEqualTo(max);
     return stats;
   }
 
@@ -1310,8 +1368,8 @@ public class TestParquetMetadataConverter {
     Binary maxBinary = FixedBinaryTestUtils.getFixedBinary(type, max);
     stats.updateStats(maxBinary);
     stats.updateStats(minBinary);
-    assertEquals(minBinary, stats.genericGetMin());
-    assertEquals(maxBinary, stats.genericGetMax());
+    assertThat(stats.genericGetMin()).isEqualTo(minBinary);
+    assertThat(stats.genericGetMax()).isEqualTo(maxBinary);
     return stats;
   }
 
@@ -1397,9 +1455,9 @@ public class TestParquetMetadataConverter {
     FileMetaData formatMetadata = converter.toParquetMetadata(1, metadata);
 
     List<org.apache.parquet.format.ColumnOrder> columnOrders = formatMetadata.getColumn_orders();
-    assertEquals(3, columnOrders.size());
+    assertThat(columnOrders).hasSize(3);
     for (org.apache.parquet.format.ColumnOrder columnOrder : columnOrders) {
-      assertTrue(columnOrder.isSetTYPE_ORDER());
+      assertThat(columnOrder.isSetTYPE_ORDER()).isTrue();
     }
 
     // Simulate that thrift got a union type that is not in the generated code
@@ -1409,11 +1467,10 @@ public class TestParquetMetadataConverter {
     MessageType resultSchema =
         converter.fromParquetMetadata(formatMetadata).getFileMetaData().getSchema();
     List<ColumnDescriptor> columns = resultSchema.getColumns();
-    assertEquals(3, columns.size());
-    assertEquals(
-        ColumnOrder.typeDefined(), columns.get(0).getPrimitiveType().columnOrder());
-    assertEquals(ColumnOrder.undefined(), columns.get(1).getPrimitiveType().columnOrder());
-    assertEquals(ColumnOrder.undefined(), columns.get(2).getPrimitiveType().columnOrder());
+    assertThat(columns).hasSize(3);
+    assertThat(columns.get(0).getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.typeDefined());
+    assertThat(columns.get(1).getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.undefined());
+    assertThat(columns.get(2).getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.undefined());
   }
 
   @Test
@@ -1424,19 +1481,19 @@ public class TestParquetMetadataConverter {
       builder.add(22000, 12000, 100, withSizeStats ? Optional.of(22L) : Optional.empty());
       OffsetIndex offsetIndex = ParquetMetadataConverter.fromParquetOffsetIndex(
           ParquetMetadataConverter.toParquetOffsetIndex(builder.build(100000)));
-      assertEquals(2, offsetIndex.getPageCount());
-      assertEquals(101000, offsetIndex.getOffset(0));
-      assertEquals(10000, offsetIndex.getCompressedPageSize(0));
-      assertEquals(0, offsetIndex.getFirstRowIndex(0));
-      assertEquals(122000, offsetIndex.getOffset(1));
-      assertEquals(12000, offsetIndex.getCompressedPageSize(1));
-      assertEquals(100, offsetIndex.getFirstRowIndex(1));
+      assertThat(offsetIndex.getPageCount()).isEqualTo(2);
+      assertThat(offsetIndex.getOffset(0)).isEqualTo(101000);
+      assertThat(offsetIndex.getCompressedPageSize(0)).isEqualTo(10000);
+      assertThat(offsetIndex.getFirstRowIndex(0)).isEqualTo(0);
+      assertThat(offsetIndex.getOffset(1)).isEqualTo(122000);
+      assertThat(offsetIndex.getCompressedPageSize(1)).isEqualTo(12000);
+      assertThat(offsetIndex.getFirstRowIndex(1)).isEqualTo(100);
       if (withSizeStats) {
-        assertEquals(Optional.of(11L), offsetIndex.getUnencodedByteArrayDataBytes(0));
-        assertEquals(Optional.of(22L), offsetIndex.getUnencodedByteArrayDataBytes(1));
+        assertThat(offsetIndex.getUnencodedByteArrayDataBytes(0)).isEqualTo(Optional.of(11L));
+        assertThat(offsetIndex.getUnencodedByteArrayDataBytes(1)).isEqualTo(Optional.of(22L));
       } else {
-        assertFalse(offsetIndex.getUnencodedByteArrayDataBytes(0).isPresent());
-        assertFalse(offsetIndex.getUnencodedByteArrayDataBytes(1).isPresent());
+        assertThat(offsetIndex.getUnencodedByteArrayDataBytes(0)).isEmpty();
+        assertThat(offsetIndex.getUnencodedByteArrayDataBytes(1)).isEmpty();
       }
     }
   }
@@ -1467,43 +1524,43 @@ public class TestParquetMetadataConverter {
       org.apache.parquet.format.ColumnIndex parquetColumnIndex =
           ParquetMetadataConverter.toParquetColumnIndex(type, builder.build());
       ColumnIndex columnIndex = ParquetMetadataConverter.fromParquetColumnIndex(type, parquetColumnIndex);
-      assertEquals(BoundaryOrder.ASCENDING, columnIndex.getBoundaryOrder());
-      assertTrue(List.of(false, true, false).equals(columnIndex.getNullPages()));
-      assertTrue(List.of(16l, 111l, 0l).equals(columnIndex.getNullCounts()));
-      assertTrue(List.of(
-              ByteBuffer.wrap(BytesUtils.longToBytes(-100l)),
+      assertThat(columnIndex.getBoundaryOrder()).isEqualTo(BoundaryOrder.ASCENDING);
+      assertThat(columnIndex.getNullPages()).containsExactly(false, true, false);
+      assertThat(columnIndex.getNullCounts()).containsExactly(16L, 111L, 0L);
+      assertThat(columnIndex.getMinValues())
+          .containsExactly(
+              ByteBuffer.wrap(BytesUtils.longToBytes(-100L)),
               ByteBuffer.allocate(0),
-              ByteBuffer.wrap(BytesUtils.longToBytes(200l)))
-          .equals(columnIndex.getMinValues()));
-      assertTrue(List.of(
-              ByteBuffer.wrap(BytesUtils.longToBytes(100l)),
+              ByteBuffer.wrap(BytesUtils.longToBytes(200L)));
+      assertThat(columnIndex.getMaxValues())
+          .containsExactly(
+              ByteBuffer.wrap(BytesUtils.longToBytes(100L)),
               ByteBuffer.allocate(0),
-              ByteBuffer.wrap(BytesUtils.longToBytes(500l)))
-          .equals(columnIndex.getMaxValues()));
+              ByteBuffer.wrap(BytesUtils.longToBytes(500L)));
 
-      assertNull(
-          "Should handle null column index",
-          ParquetMetadataConverter.toParquetColumnIndex(
-              Types.required(PrimitiveTypeName.INT32).named("test_int32"), null));
-      assertNull(
-          "Should ignore unsupported types",
-          ParquetMetadataConverter.toParquetColumnIndex(
-              Types.required(PrimitiveTypeName.INT96).named("test_int96"), columnIndex));
-      assertNull(
-          "Should ignore unsupported types",
-          ParquetMetadataConverter.fromParquetColumnIndex(
+      assertThat(ParquetMetadataConverter.toParquetColumnIndex(
+              Types.required(PrimitiveTypeName.INT32).named("test_int32"), null))
+          .as("Should handle null column index")
+          .isNull();
+      assertThat(ParquetMetadataConverter.toParquetColumnIndex(
+              Types.required(PrimitiveTypeName.INT96).named("test_int96"), columnIndex))
+          .as("Should ignore unsupported types")
+          .isNull();
+      assertThat(ParquetMetadataConverter.fromParquetColumnIndex(
               Types.required(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
                   .length(12)
                   .as(OriginalType.INTERVAL)
                   .named("test_interval"),
-              parquetColumnIndex));
+              parquetColumnIndex))
+          .as("Should ignore unsupported types")
+          .isNull();
 
       if (withSizeStats) {
-        assertEquals(LongArrayList.of(1, 2, 3, 4, 5, 6), columnIndex.getRepetitionLevelHistogram());
-        assertEquals(LongArrayList.of(6, 5, 4, 3, 2, 1), columnIndex.getDefinitionLevelHistogram());
+        assertThat(columnIndex.getRepetitionLevelHistogram()).containsExactly(1L, 2L, 3L, 4L, 5L, 6L);
+        assertThat(columnIndex.getDefinitionLevelHistogram()).containsExactly(6L, 5L, 4L, 3L, 2L, 1L);
       } else {
-        assertEquals(LongArrayList.of(), columnIndex.getRepetitionLevelHistogram());
-        assertEquals(LongArrayList.of(), columnIndex.getDefinitionLevelHistogram());
+        assertThat(columnIndex.getRepetitionLevelHistogram()).isEmpty();
+        assertThat(columnIndex.getDefinitionLevelHistogram()).isEmpty();
       }
     }
   }
@@ -1526,41 +1583,37 @@ public class TestParquetMetadataConverter {
         .named("Message");
 
     List<SchemaElement> parquetSchema = parquetMetadataConverter.toParquetSchema(expected);
-    assertEquals(5, parquetSchema.size());
-    assertEquals(new SchemaElement("Message").setNum_children(1), parquetSchema.get(0));
-    assertEquals(
-        new SchemaElement("testMap")
+    assertThat(parquetSchema).hasSize(5);
+    assertThat(parquetSchema.get(0)).isEqualTo(new SchemaElement("Message").setNum_children(1));
+    assertThat(parquetSchema.get(1))
+        .isEqualTo(new SchemaElement("testMap")
             .setRepetition_type(FieldRepetitionType.REQUIRED)
             .setNum_children(1)
             .setConverted_type(ConvertedType.MAP)
-            .setLogicalType(LogicalType.MAP(new MapType())),
-        parquetSchema.get(1));
+            .setLogicalType(LogicalType.MAP(new MapType())));
     // PARQUET-1879 ensure that LogicalType is not written (null) but ConvertedType is MAP_KEY_VALUE for
     // backwards-compatibility
-    assertEquals(
-        new SchemaElement("key_value")
+    assertThat(parquetSchema.get(2))
+        .isEqualTo(new SchemaElement("key_value")
             .setRepetition_type(FieldRepetitionType.REPEATED)
             .setNum_children(2)
             .setConverted_type(ConvertedType.MAP_KEY_VALUE)
-            .setLogicalType(null),
-        parquetSchema.get(2));
-    assertEquals(
-        new SchemaElement("key")
+            .setLogicalType(null));
+    assertThat(parquetSchema.get(3))
+        .isEqualTo(new SchemaElement("key")
             .setType(Type.BYTE_ARRAY)
             .setRepetition_type(FieldRepetitionType.REQUIRED)
             .setConverted_type(ConvertedType.UTF8)
-            .setLogicalType(LogicalType.STRING(new StringType())),
-        parquetSchema.get(3));
-    assertEquals(
-        new SchemaElement("value")
+            .setLogicalType(LogicalType.STRING(new StringType())));
+    assertThat(parquetSchema.get(4))
+        .isEqualTo(new SchemaElement("value")
             .setType(Type.INT32)
             .setRepetition_type(FieldRepetitionType.REQUIRED)
             .setConverted_type(null)
-            .setLogicalType(null),
-        parquetSchema.get(4));
+            .setLogicalType(null));
 
     MessageType schema = parquetMetadataConverter.fromParquetSchema(parquetSchema, null);
-    assertEquals(expected, schema);
+    assertThat(schema).isEqualTo(expected);
   }
 
   @Test
@@ -1629,10 +1682,11 @@ public class TestParquetMetadataConverter {
     ParquetMetadataConverter parquetMetadataConverter = new ParquetMetadataConverter();
     List<SchemaElement> parquetSchema = parquetMetadataConverter.toParquetSchema(expected);
     MessageType schema = parquetMetadataConverter.fromParquetSchema(parquetSchema, null);
-    assertEquals(expected, schema);
+    assertThat(schema).isEqualTo(expected);
     LogicalTypeAnnotation logicalType = schema.getType("v").getLogicalTypeAnnotation();
-    assertEquals(LogicalTypeAnnotation.variantType(specVersion), logicalType);
-    assertEquals(specVersion, ((LogicalTypeAnnotation.VariantLogicalTypeAnnotation) logicalType).getSpecVersion());
+    assertThat(logicalType).isEqualTo(LogicalTypeAnnotation.variantType(specVersion));
+    assertThat(((LogicalTypeAnnotation.VariantLogicalTypeAnnotation) logicalType).getSpecVersion())
+        .isEqualTo(specVersion);
   }
 
   private void verifyMapMessageType(final MessageType messageType, final String keyValueName) throws IOException {
@@ -1656,16 +1710,17 @@ public class TestParquetMetadataConverter {
         ParquetReader.builder(new GroupReadSupport(), file).build()) {
       Group group = reader.read();
 
-      assertNotNull(group);
+      assertThat(group).isNotNull();
 
       Group testMap = group.getGroup("testMap", 0);
-      assertNotNull(testMap);
-      assertEquals(5, testMap.getFieldRepetitionCount(keyValueName));
+      assertThat(testMap).isNotNull();
+      assertThat(testMap.getFieldRepetitionCount(keyValueName)).isEqualTo(5);
 
       for (int index = 0; index < 5; index++) {
-        assertEquals(
-            "key" + index, testMap.getGroup(keyValueName, index).getString("key", 0));
-        assertEquals(100L + index, testMap.getGroup(keyValueName, index).getLong("value", 0));
+        assertThat(testMap.getGroup(keyValueName, index).getString("key", 0))
+            .isEqualTo("key" + index);
+        assertThat(testMap.getGroup(keyValueName, index).getLong("value", 0))
+            .isEqualTo(100L + index);
       }
     }
   }
@@ -1679,10 +1734,10 @@ public class TestParquetMetadataConverter {
         ParquetMetadataConverter.toParquetSizeStatistics(
             new SizeStatistics(type, 1024, repLevelHistogram, defLevelHistogram)),
         type);
-    assertEquals(type, sizeStatistics.getType());
-    assertEquals(Optional.of(1024L), sizeStatistics.getUnencodedByteArrayDataBytes());
-    assertEquals(repLevelHistogram, sizeStatistics.getRepetitionLevelHistogram());
-    assertEquals(defLevelHistogram, sizeStatistics.getDefinitionLevelHistogram());
+    assertThat(sizeStatistics.getType()).isEqualTo(type);
+    assertThat(sizeStatistics.getUnencodedByteArrayDataBytes()).isEqualTo(Optional.of(1024L));
+    assertThat(sizeStatistics.getRepetitionLevelHistogram()).containsExactlyElementsOf(repLevelHistogram);
+    assertThat(sizeStatistics.getDefinitionLevelHistogram()).containsExactlyElementsOf(defLevelHistogram);
   }
 
   @Test
@@ -1701,12 +1756,13 @@ public class TestParquetMetadataConverter {
     MessageType actual = parquetMetadataConverter.fromParquetSchema(parquetSchema, null);
 
     // Verify the logical type is preserved
-    assertEquals(schema, actual);
+    assertThat(actual).isEqualTo(schema);
 
     PrimitiveType primitiveType = actual.getType("geomField").asPrimitiveType();
     LogicalTypeAnnotation logicalType = primitiveType.getLogicalTypeAnnotation();
-    assertTrue(logicalType instanceof LogicalTypeAnnotation.GeometryLogicalTypeAnnotation);
-    assertEquals("EPSG:4326", ((LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) logicalType).getCrs());
+    assertThat(logicalType).isInstanceOf(LogicalTypeAnnotation.GeometryLogicalTypeAnnotation.class);
+    assertThat(((LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) logicalType).getCrs())
+        .isEqualTo("EPSG:4326");
   }
 
   @Test
@@ -1725,16 +1781,16 @@ public class TestParquetMetadataConverter {
     MessageType actual = parquetMetadataConverter.fromParquetSchema(parquetSchema, null);
 
     // Verify the logical type is preserved
-    assertEquals(schema, actual);
+    assertThat(actual).isEqualTo(schema);
 
     PrimitiveType primitiveType = actual.getType("geogField").asPrimitiveType();
     LogicalTypeAnnotation logicalType = primitiveType.getLogicalTypeAnnotation();
-    assertTrue(logicalType instanceof LogicalTypeAnnotation.GeographyLogicalTypeAnnotation);
+    assertThat(logicalType).isInstanceOf(LogicalTypeAnnotation.GeographyLogicalTypeAnnotation.class);
 
     LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType =
         (LogicalTypeAnnotation.GeographyLogicalTypeAnnotation) logicalType;
-    assertEquals("EPSG:4326", geographyType.getCrs());
-    assertEquals(EdgeInterpolationAlgorithm.SPHERICAL, geographyType.getAlgorithm());
+    assertThat(geographyType.getCrs()).isEqualTo("EPSG:4326");
+    assertThat(geographyType.getAlgorithm()).isEqualTo(EdgeInterpolationAlgorithm.SPHERICAL);
   }
 
   @Test
@@ -1749,16 +1805,18 @@ public class TestParquetMetadataConverter {
     LogicalTypeAnnotation annotation = converter.getLogicalTypeAnnotation(logicalType);
 
     // Verify the annotation is created correctly
-    assertNotNull("Geometry annotation should not be null", annotation);
-    assertTrue(
-        "Should be a GeometryLogicalTypeAnnotation",
-        annotation instanceof LogicalTypeAnnotation.GeometryLogicalTypeAnnotation);
+    assertThat(annotation).as("Geometry annotation should not be null").isNotNull();
+    assertThat(annotation)
+        .as("Should be a GeometryLogicalTypeAnnotation")
+        .isInstanceOf(LogicalTypeAnnotation.GeometryLogicalTypeAnnotation.class);
 
     LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryAnnotation =
         (LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) annotation;
 
     // Default behavior should use null or empty CRS
-    assertNull("CRS should be null or empty when not specified", geometryAnnotation.getCrs());
+    assertThat(geometryAnnotation.getCrs())
+        .as("CRS should be null or empty when not specified")
+        .isNull();
   }
 
   @Test
@@ -1774,27 +1832,33 @@ public class TestParquetMetadataConverter {
     LogicalTypeAnnotation annotation = converter.getLogicalTypeAnnotation(logicalType);
 
     // Verify the annotation is created correctly
-    assertNotNull("Geography annotation should not be null", annotation);
-    assertTrue(
-        "Should be a GeographyLogicalTypeAnnotation",
-        annotation instanceof LogicalTypeAnnotation.GeographyLogicalTypeAnnotation);
+    assertThat(annotation).as("Geography annotation should not be null").isNotNull();
+    assertThat(annotation)
+        .as("Should be a GeographyLogicalTypeAnnotation")
+        .isInstanceOf(LogicalTypeAnnotation.GeographyLogicalTypeAnnotation.class);
 
     // Check that optional parameters are handled correctly
     LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyAnnotation =
         (LogicalTypeAnnotation.GeographyLogicalTypeAnnotation) annotation;
-    assertNull("CRS should be null when not specified", geographyAnnotation.getCrs());
+    assertThat(geographyAnnotation.getCrs())
+        .as("CRS should be null when not specified")
+        .isNull();
     // Most implementations default to LINEAR when algorithm is not specified
-    assertNull("Algorithm should be null when not specified", geographyAnnotation.getAlgorithm());
+    assertThat(geographyAnnotation.getAlgorithm())
+        .as("Algorithm should be null when not specified")
+        .isNull();
 
     // Now test the round-trip conversion
     LogicalType roundTripType = converter.convertToLogicalType(annotation);
-    assertEquals("setField should be GEOGRAPHY", LogicalType._Fields.GEOGRAPHY, roundTripType.getSetField());
-    assertNull(
-        "Round trip CRS should still be null",
-        roundTripType.getGEOGRAPHY().getCrs());
-    assertNull(
-        "Round trip Algorithm should be null",
-        roundTripType.getGEOGRAPHY().getAlgorithm());
+    assertThat(roundTripType.getSetField())
+        .as("setField should be GEOGRAPHY")
+        .isEqualTo(LogicalType._Fields.GEOGRAPHY);
+    assertThat(roundTripType.getGEOGRAPHY().getCrs())
+        .as("Round trip CRS should still be null")
+        .isNull();
+    assertThat(roundTripType.getGEOGRAPHY().getAlgorithm())
+        .as("Round trip Algorithm should be null")
+        .isNull();
   }
 
   @Test
@@ -1810,16 +1874,17 @@ public class TestParquetMetadataConverter {
     LogicalTypeAnnotation annotation = converter.getLogicalTypeAnnotation(logicalType);
 
     // Verify the annotation is created correctly
-    Assert.assertNotNull("Geography annotation should not be null", annotation);
+    assertThat(annotation).as("Geography annotation should not be null").isNotNull();
     LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyAnnotation =
         (LogicalTypeAnnotation.GeographyLogicalTypeAnnotation) annotation;
 
     // CRS should be null/empty but algorithm should be set
-    assertNull("CRS should be null or empty", geographyAnnotation.getCrs());
-    assertEquals(
-        "Algorithm should be SPHERICAL",
-        EdgeInterpolationAlgorithm.SPHERICAL,
-        geographyAnnotation.getAlgorithm());
+    assertThat(geographyAnnotation.getCrs())
+        .as("CRS should be null or empty")
+        .isNull();
+    assertThat(geographyAnnotation.getAlgorithm())
+        .as("Algorithm should be SPHERICAL")
+        .isEqualTo(EdgeInterpolationAlgorithm.SPHERICAL);
   }
 
   @Test
@@ -1848,27 +1913,29 @@ public class TestParquetMetadataConverter {
     GeospatialStatistics thriftStats = converter.toParquetGeospatialStatistics(origStats);
 
     // Verify conversion to Thrift
-    assertNotNull("Thrift GeospatialStatistics should not be null", thriftStats);
-    assertTrue("BoundingBox should be set", thriftStats.isSetBbox());
-    assertTrue("Geospatial types should be set", thriftStats.isSetGeospatial_types());
+    assertThat(thriftStats)
+        .as("Thrift GeospatialStatistics should not be null")
+        .isNotNull();
+    assertThat(thriftStats.isSetBbox()).as("BoundingBox should be set").isTrue();
+    assertThat(thriftStats.isSetGeospatial_types())
+        .as("Geospatial types should be set")
+        .isTrue();
 
     // Check BoundingBox values
     BoundingBox thriftBbox = thriftStats.getBbox();
-    assertEquals(1.0, thriftBbox.getXmin(), 0.0001);
-    assertEquals(2.0, thriftBbox.getXmax(), 0.0001);
-    assertEquals(3.0, thriftBbox.getYmin(), 0.0001);
-    assertEquals(4.0, thriftBbox.getYmax(), 0.0001);
-    assertEquals(5.0, thriftBbox.getZmin(), 0.0001);
-    assertEquals(6.0, thriftBbox.getZmax(), 0.0001);
-    assertEquals(7.0, thriftBbox.getMmin(), 0.0001);
-    assertEquals(8.0, thriftBbox.getMmax(), 0.0001);
+    assertThat(thriftBbox.getXmin()).isCloseTo(1.0, offset(0.0001));
+    assertThat(thriftBbox.getXmax()).isCloseTo(2.0, offset(0.0001));
+    assertThat(thriftBbox.getYmin()).isCloseTo(3.0, offset(0.0001));
+    assertThat(thriftBbox.getYmax()).isCloseTo(4.0, offset(0.0001));
+    assertThat(thriftBbox.getZmin()).isCloseTo(5.0, offset(0.0001));
+    assertThat(thriftBbox.getZmax()).isCloseTo(6.0, offset(0.0001));
+    assertThat(thriftBbox.getMmin()).isCloseTo(7.0, offset(0.0001));
+    assertThat(thriftBbox.getMmax()).isCloseTo(8.0, offset(0.0001));
 
     // Check geospatial types
     List<Integer> thriftTypes = thriftStats.getGeospatial_types();
-    assertEquals(3, thriftTypes.size());
-    assertTrue(thriftTypes.contains(1));
-    assertTrue(thriftTypes.contains(2));
-    assertTrue(thriftTypes.contains(3));
+    assertThat(thriftTypes).hasSize(3);
+    assertThat(thriftTypes).contains(1, 2, 3);
 
     // Create primitive geometry type for conversion back
     LogicalTypeAnnotation geometryAnnotation = LogicalTypeAnnotation.geometryType("EPSG:4326");
@@ -1880,27 +1947,31 @@ public class TestParquetMetadataConverter {
         ParquetMetadataConverter.fromParquetStatistics(thriftStats, geometryType);
 
     // Verify conversion from Thrift
-    assertNotNull("Converted GeospatialStatistics should not be null", convertedStats);
-    assertNotNull("BoundingBox should not be null", convertedStats.getBoundingBox());
-    assertNotNull("GeospatialTypes should not be null", convertedStats.getGeospatialTypes());
+    assertThat(convertedStats)
+        .as("Converted GeospatialStatistics should not be null")
+        .isNotNull();
+    assertThat(convertedStats.getBoundingBox())
+        .as("BoundingBox should not be null")
+        .isNotNull();
+    assertThat(convertedStats.getGeospatialTypes())
+        .as("GeospatialTypes should not be null")
+        .isNotNull();
 
     // Check BoundingBox values
     org.apache.parquet.column.statistics.geospatial.BoundingBox convertedBbox = convertedStats.getBoundingBox();
-    assertEquals(1.0, convertedBbox.getXMin(), 0.0001);
-    assertEquals(2.0, convertedBbox.getXMax(), 0.0001);
-    assertEquals(3.0, convertedBbox.getYMin(), 0.0001);
-    assertEquals(4.0, convertedBbox.getYMax(), 0.0001);
-    assertEquals(5.0, convertedBbox.getZMin(), 0.0001);
-    assertEquals(6.0, convertedBbox.getZMax(), 0.0001);
-    assertEquals(7.0, convertedBbox.getMMin(), 0.0001);
-    assertEquals(8.0, convertedBbox.getMMax(), 0.0001);
+    assertThat(convertedBbox.getXMin()).isCloseTo(1.0, offset(0.0001));
+    assertThat(convertedBbox.getXMax()).isCloseTo(2.0, offset(0.0001));
+    assertThat(convertedBbox.getYMin()).isCloseTo(3.0, offset(0.0001));
+    assertThat(convertedBbox.getYMax()).isCloseTo(4.0, offset(0.0001));
+    assertThat(convertedBbox.getZMin()).isCloseTo(5.0, offset(0.0001));
+    assertThat(convertedBbox.getZMax()).isCloseTo(6.0, offset(0.0001));
+    assertThat(convertedBbox.getMMin()).isCloseTo(7.0, offset(0.0001));
+    assertThat(convertedBbox.getMMax()).isCloseTo(8.0, offset(0.0001));
 
     // Check geospatial types
     Set<Integer> convertedTypes = convertedStats.getGeospatialTypes().getTypes();
-    assertEquals(3, convertedTypes.size());
-    assertTrue(convertedTypes.contains(1));
-    assertTrue(convertedTypes.contains(2));
-    assertTrue(convertedTypes.contains(3));
+    assertThat(convertedTypes).hasSize(3);
+    assertThat(convertedTypes).contains(1, 2, 3);
   }
 
   @Test
@@ -1917,9 +1988,13 @@ public class TestParquetMetadataConverter {
     GeospatialStatistics thriftStats = converter.toParquetGeospatialStatistics(origStats);
 
     // Verify conversion to Thrift
-    assertNotNull("Thrift GeospatialStatistics should not be null", thriftStats);
-    assertFalse("BoundingBox should not be set", thriftStats.isSetBbox());
-    assertTrue("Geospatial types should be set", thriftStats.isSetGeospatial_types());
+    assertThat(thriftStats)
+        .as("Thrift GeospatialStatistics should not be null")
+        .isNotNull();
+    assertThat(thriftStats.isSetBbox()).as("BoundingBox should not be set").isFalse();
+    assertThat(thriftStats.isSetGeospatial_types())
+        .as("Geospatial types should be set")
+        .isTrue();
 
     // Create primitive geometry type for conversion back
     LogicalTypeAnnotation geometryAnnotation = LogicalTypeAnnotation.geometryType("EPSG:4326");
@@ -1931,9 +2006,15 @@ public class TestParquetMetadataConverter {
         ParquetMetadataConverter.fromParquetStatistics(thriftStats, geometryType);
 
     // Verify conversion from Thrift
-    assertNotNull("Converted GeospatialStatistics should not be null", convertedStats);
-    assertNull("BoundingBox should be null", convertedStats.getBoundingBox());
-    assertNotNull("GeospatialTypes should not be null", convertedStats.getGeospatialTypes());
+    assertThat(convertedStats)
+        .as("Converted GeospatialStatistics should not be null")
+        .isNotNull();
+    assertThat(convertedStats.getBoundingBox())
+        .as("BoundingBox should be null")
+        .isNull();
+    assertThat(convertedStats.getGeospatialTypes())
+        .as("GeospatialTypes should not be null")
+        .isNotNull();
   }
 
   @Test
@@ -1957,7 +2038,7 @@ public class TestParquetMetadataConverter {
 
     // Convert to Thrift format - should return null for invalid bbox
     GeospatialStatistics thriftStats = converter.toParquetGeospatialStatistics(origStats);
-    assertNull("Should return null for invalid BoundingBox", thriftStats);
+    assertThat(thriftStats).as("Should return null for invalid BoundingBox").isNull();
   }
 
   @Test
@@ -1972,11 +2053,13 @@ public class TestParquetMetadataConverter {
         org.apache.parquet.column.schema.EdgeInterpolationAlgorithm.SPHERICAL;
     org.apache.parquet.column.schema.EdgeInterpolationAlgorithm actual =
         ParquetMetadataConverter.toParquetEdgeInterpolationAlgorithm(thriftAlgo);
-    assertEquals(expected, actual);
+    assertThat(actual).isEqualTo(expected);
 
     // Test with null
-    assertNull(ParquetMetadataConverter.fromParquetEdgeInterpolationAlgorithm(null));
-    assertNull(ParquetMetadataConverter.toParquetEdgeInterpolationAlgorithm(null));
+    assertThat(ParquetMetadataConverter.fromParquetEdgeInterpolationAlgorithm(null))
+        .isNull();
+    assertThat(ParquetMetadataConverter.toParquetEdgeInterpolationAlgorithm(null))
+        .isNull();
   }
 
   @Test
@@ -1997,19 +2080,17 @@ public class TestParquetMetadataConverter {
     FileMetaData formatMetadata = converter.toParquetMetadata(1, metadata);
 
     List<org.apache.parquet.format.ColumnOrder> columnOrders = formatMetadata.getColumn_orders();
-    assertEquals(2, columnOrders.size());
+    assertThat(columnOrders).hasSize(2);
     for (org.apache.parquet.format.ColumnOrder columnOrder : columnOrders) {
-      assertTrue(columnOrder.isSetIEEE_754_TOTAL_ORDER());
+      assertThat(columnOrder.isSetIEEE_754_TOTAL_ORDER()).isTrue();
     }
 
     MessageType resultSchema =
         converter.fromParquetMetadata(formatMetadata).getFileMetaData().getSchema();
-    assertEquals(
-        ColumnOrder.ieee754TotalOrder(),
-        resultSchema.getType("float_ieee754").asPrimitiveType().columnOrder());
-    assertEquals(
-        ColumnOrder.ieee754TotalOrder(),
-        resultSchema.getType("double_ieee754").asPrimitiveType().columnOrder());
+    assertThat(resultSchema.getType("float_ieee754").asPrimitiveType().columnOrder())
+        .isEqualTo(ColumnOrder.ieee754TotalOrder());
+    assertThat(resultSchema.getType("double_ieee754").asPrimitiveType().columnOrder())
+        .isEqualTo(ColumnOrder.ieee754TotalOrder());
   }
 
   @Test
@@ -2036,15 +2117,10 @@ public class TestParquetMetadataConverter {
     MessageType resultSchema =
         converter.fromParquetMetadata(formatMetadata).getFileMetaData().getSchema();
     List<ColumnDescriptor> columns = resultSchema.getColumns();
-    assertEquals(3, columns.size());
-    assertEquals(
-        ColumnOrder.ieee754TotalOrder(),
-        columns.get(0).getPrimitiveType().columnOrder());
-    assertEquals(
-        ColumnOrder.typeDefined(), columns.get(1).getPrimitiveType().columnOrder());
-    assertEquals(
-        ColumnOrder.ieee754TotalOrder(),
-        columns.get(2).getPrimitiveType().columnOrder());
+    assertThat(columns).hasSize(3);
+    assertThat(columns.get(0).getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.ieee754TotalOrder());
+    assertThat(columns.get(1).getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.typeDefined());
+    assertThat(columns.get(2).getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.ieee754TotalOrder());
   }
 
   @Test
@@ -2057,13 +2133,13 @@ public class TestParquetMetadataConverter {
     stats.updateStats(Float.NaN);
 
     org.apache.parquet.format.Statistics formatStats = ParquetMetadataConverter.toParquetStatistics(stats);
-    assertTrue("nan_count should be set", formatStats.isSetNan_count());
-    assertEquals(2, formatStats.getNan_count());
+    assertThat(formatStats.isSetNan_count()).as("nan_count should be set").isTrue();
+    assertThat(formatStats.getNan_count()).isEqualTo(2);
 
     Statistics<?> roundTrip = ParquetMetadataConverter.fromParquetStatisticsInternal(
         Version.FULL_VERSION, formatStats, type, ParquetMetadataConverter.SortOrder.SIGNED);
-    assertTrue(roundTrip.isNanCountSet());
-    assertEquals(2, roundTrip.getNanCount());
+    assertThat(roundTrip.isNanCountSet()).isTrue();
+    assertThat(roundTrip.getNanCount()).isEqualTo(2);
   }
 
   @Test
@@ -2075,13 +2151,13 @@ public class TestParquetMetadataConverter {
     stats.updateStats(3.0);
 
     org.apache.parquet.format.Statistics formatStats = ParquetMetadataConverter.toParquetStatistics(stats);
-    assertTrue("nan_count should be set", formatStats.isSetNan_count());
-    assertEquals(1, formatStats.getNan_count());
+    assertThat(formatStats.isSetNan_count()).as("nan_count should be set").isTrue();
+    assertThat(formatStats.getNan_count()).isEqualTo(1);
 
     Statistics<?> roundTrip = ParquetMetadataConverter.fromParquetStatisticsInternal(
         Version.FULL_VERSION, formatStats, type, ParquetMetadataConverter.SortOrder.SIGNED);
-    assertTrue(roundTrip.isNanCountSet());
-    assertEquals(1, roundTrip.getNanCount());
+    assertThat(roundTrip.isNanCountSet()).isTrue();
+    assertThat(roundTrip.getNanCount()).isEqualTo(1);
   }
 
   @Test
@@ -2097,13 +2173,13 @@ public class TestParquetMetadataConverter {
     stats.updateStats(Binary.fromConstantByteArray(new byte[] {0x00, 0x7E}));
 
     org.apache.parquet.format.Statistics formatStats = ParquetMetadataConverter.toParquetStatistics(stats);
-    assertTrue("nan_count should be set", formatStats.isSetNan_count());
-    assertEquals(1, formatStats.getNan_count());
+    assertThat(formatStats.isSetNan_count()).as("nan_count should be set").isTrue();
+    assertThat(formatStats.getNan_count()).isEqualTo(1);
 
     Statistics<?> roundTrip = ParquetMetadataConverter.fromParquetStatisticsInternal(
         Version.FULL_VERSION, formatStats, type, ParquetMetadataConverter.SortOrder.SIGNED);
-    assertTrue(roundTrip.isNanCountSet());
-    assertEquals(1, roundTrip.getNanCount());
+    assertThat(roundTrip.isNanCountSet()).isTrue();
+    assertThat(roundTrip.getNanCount()).isEqualTo(1);
   }
 
   @Test
@@ -2114,13 +2190,15 @@ public class TestParquetMetadataConverter {
     stats.updateStats(2.0f);
 
     org.apache.parquet.format.Statistics formatStats = ParquetMetadataConverter.toParquetStatistics(stats);
-    assertTrue("nan_count should be set even when zero", formatStats.isSetNan_count());
-    assertEquals(0, formatStats.getNan_count());
+    assertThat(formatStats.isSetNan_count())
+        .as("nan_count should be set even when zero")
+        .isTrue();
+    assertThat(formatStats.getNan_count()).isEqualTo(0);
 
     Statistics<?> roundTrip = ParquetMetadataConverter.fromParquetStatisticsInternal(
         Version.FULL_VERSION, formatStats, type, ParquetMetadataConverter.SortOrder.SIGNED);
-    assertTrue(roundTrip.isNanCountSet());
-    assertEquals(0, roundTrip.getNanCount());
+    assertThat(roundTrip.isNanCountSet()).isTrue();
+    assertThat(roundTrip.getNanCount()).isEqualTo(0);
   }
 
   @Test
@@ -2151,12 +2229,14 @@ public class TestParquetMetadataConverter {
     ColumnIndex columnIndex = builder.build();
     org.apache.parquet.format.ColumnIndex parquetColumnIndex =
         ParquetMetadataConverter.toParquetColumnIndex(type, columnIndex);
-    assertNotNull(parquetColumnIndex);
-    assertNotNull("nan_counts should be set", parquetColumnIndex.getNan_counts());
-    assertEquals(List.of(1L, 0L, 0L), parquetColumnIndex.getNan_counts());
+    assertThat(parquetColumnIndex).isNotNull();
+    assertThat(parquetColumnIndex.getNan_counts())
+        .as("nan_counts should be set")
+        .isNotNull();
+    assertThat(parquetColumnIndex.getNan_counts()).containsExactly(1L, 0L, 0L);
 
     ColumnIndex roundTrip = ParquetMetadataConverter.fromParquetColumnIndex(type, parquetColumnIndex);
-    assertNotNull(roundTrip);
-    assertEquals(List.of(1L, 0L, 0L), roundTrip.getNanCounts());
+    assertThat(roundTrip).isNotNull();
+    assertThat(roundTrip.getNanCounts()).containsExactly(1L, 0L, 0L);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/DeprecatedInputFormatTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/DeprecatedInputFormatTest.java
@@ -19,8 +19,7 @@
 package org.apache.parquet.hadoop;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -254,9 +253,7 @@ public class DeprecatedInputFormatTest {
       while ((line = br.readLine()) != null) {
         s.add(line.split("\t")[1]);
       }
-      assertEquals(s.size(), 2);
-      assertTrue(s.contains("hello"));
-      assertTrue(s.contains("world"));
+      assertThat(s).containsExactlyInAnyOrder("hello", "world");
     }
 
     FileUtils.deleteDirectory(inputDir);
@@ -266,28 +263,19 @@ public class DeprecatedInputFormatTest {
   @Test
   public void testReadWriteWithCountDeprecated() throws Exception {
     runMapReduceJob(CompressionCodecName.GZIP);
-    assertTrue(mapRedJob
-            .getCounters()
-            .getGroup("parquet")
-            .getCounterForName("bytesread")
-            .getValue()
-        > 0L);
-    assertTrue(mapRedJob
-            .getCounters()
-            .getGroup("parquet")
-            .getCounterForName("bytestotal")
-            .getValue()
-        > 0L);
-    assertTrue(mapRedJob
-            .getCounters()
-            .getGroup("parquet")
-            .getCounterForName("bytesread")
-            .getValue()
-        == mapRedJob
-            .getCounters()
-            .getGroup("parquet")
-            .getCounterForName("bytestotal")
-            .getValue());
+    long bytesRead = mapRedJob
+        .getCounters()
+        .getGroup("parquet")
+        .getCounterForName("bytesread")
+        .getValue();
+    long bytesTotal = mapRedJob
+        .getCounters()
+        .getGroup("parquet")
+        .getCounterForName("bytestotal")
+        .getValue();
+    assertThat(bytesRead).isPositive();
+    assertThat(bytesTotal).isPositive();
+    assertThat(bytesRead).isEqualTo(bytesTotal);
     // not testing the time read counter since it could be zero due to the size of data is too small
   }
 
@@ -297,27 +285,24 @@ public class DeprecatedInputFormatTest {
     jobConf.set("parquet.benchmark.bytes.total", "false");
     jobConf.set("parquet.benchmark.bytes.read", "false");
     runMapReduceJob(CompressionCodecName.GZIP);
-    assertEquals(
-        mapRedJob
+    assertThat(mapRedJob
             .getCounters()
             .getGroup("parquet")
             .getCounterForName("bytesread")
-            .getValue(),
-        0L);
-    assertEquals(
-        mapRedJob
+            .getValue())
+        .isZero();
+    assertThat(mapRedJob
             .getCounters()
             .getGroup("parquet")
             .getCounterForName("bytestotal")
-            .getValue(),
-        0L);
-    assertEquals(
-        mapRedJob
+            .getValue())
+        .isZero();
+    assertThat(mapRedJob
             .getCounters()
             .getGroup("parquet")
             .getCounterForName("timeread")
-            .getValue(),
-        0L);
+            .getValue())
+        .isZero();
   }
 
   private void waitForJob(Job job) throws InterruptedException, IOException {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestAdaptiveBlockSplitBloomFiltering.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestAdaptiveBlockSplitBloomFiltering.java
@@ -19,7 +19,7 @@
 
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
@@ -72,7 +72,7 @@ public class TestAdaptiveBlockSplitBloomFiltering extends TestBloomFiltering {
               // expectedNVD=8192],
               // [byteSize=16384, expectedNVD=13500], [byteSize=32768, expectedNVD=27000] ......
               // number of distinct values is less than 100, so the byteSize should be less than 2048.
-              assertTrue(bitsetSize <= 2048);
+              assertThat(bitsetSize).isLessThanOrEqualTo(2048);
             });
       });
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestBloomFiltering.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestBloomFiltering.java
@@ -28,9 +28,7 @@ import static org.apache.parquet.filter2.predicate.FilterApi.in;
 import static org.apache.parquet.filter2.predicate.FilterApi.longColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.or;
 import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -256,7 +254,9 @@ public class TestBloomFiltering {
         exp = expIt.next();
       }
     }
-    assertFalse("Not all expected elements are in the actual list. E.g.: " + exp, expIt.hasNext());
+    assertThat(expIt)
+        .as("Not all expected elements are in the actual list. E.g.: " + exp)
+        .isExhausted();
   }
 
   private void assertCorrectFiltering(Predicate<PhoneBookWriter.User> expectedFilter, FilterPredicate actualFilter)
@@ -264,7 +264,7 @@ public class TestBloomFiltering {
     // Check with only bloom filter based filtering
     List<PhoneBookWriter.User> result = readUsers(actualFilter, false, true);
 
-    assertTrue("Bloom filtering should drop some row groups", result.size() < DATA.size());
+    assertThat(result).as("Bloom filtering should drop some row groups").hasSizeLessThan(DATA.size());
     LOGGER.info(
         "{}/{} records read; filtering ratio: {}%",
         result.size(), DATA.size(), 100 * result.size() / DATA.size());
@@ -275,7 +275,7 @@ public class TestBloomFiltering {
 
     // Check with all the filtering filtering to ensure the result contains exactly the required values
     result = readUsers(actualFilter, true, false);
-    assertEquals(DATA.stream().filter(expectedFilter).collect(Collectors.toList()), result);
+    assertThat(result).isEqualTo(DATA.stream().filter(expectedFilter).collect(Collectors.toList()));
   }
 
   protected static FileEncryptionProperties getFileEncryptionProperties() {
@@ -456,7 +456,7 @@ public class TestBloomFiltering {
               int bitsetSize =
                   bloomFilterReader.readBloomFilter(column).getBitsetSize();
               // when setting nvd to a fixed value 10000L, bitsetSize will always be 16384
-              assertEquals(16384, bitsetSize);
+              assertThat(bitsetSize).isEqualTo(16384);
             });
       });
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestByteStreamSplitConfiguration.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestByteStreamSplitConfiguration.java
@@ -18,9 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.column.ParquetProperties;
@@ -31,22 +29,21 @@ public class TestByteStreamSplitConfiguration {
   public void testDefault() throws Exception {
     Configuration conf = new Configuration();
     // default should be false
-    assertEquals(
-        ParquetProperties.DEFAULT_IS_BYTE_STREAM_SPLIT_ENABLED,
-        ParquetOutputFormat.getByteStreamSplitEnabled(conf));
+    assertThat(ParquetOutputFormat.getByteStreamSplitEnabled(conf))
+        .isEqualTo(ParquetProperties.DEFAULT_IS_BYTE_STREAM_SPLIT_ENABLED);
   }
 
   @Test
   public void testSetTrue() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(ParquetOutputFormat.ENABLE_BYTE_STREAM_SPLIT, true);
-    assertTrue(ParquetOutputFormat.getByteStreamSplitEnabled(conf));
+    assertThat(ParquetOutputFormat.getByteStreamSplitEnabled(conf)).isTrue();
   }
 
   @Test
   public void testSetFalse() throws Exception {
     Configuration conf = new Configuration();
     conf.setBoolean(ParquetOutputFormat.ENABLE_BYTE_STREAM_SPLIT, false);
-    assertFalse(ParquetOutputFormat.getByteStreamSplitEnabled(conf));
+    assertThat(ParquetOutputFormat.getByteStreamSplitEnabled(conf)).isFalse();
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageReadStore.java
@@ -20,8 +20,7 @@ package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.column.Encoding.PLAIN;
 import static org.apache.parquet.column.Encoding.RLE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.util.Collections;
@@ -89,12 +88,11 @@ public class TestColumnChunkPageReadStore {
       storeReleaser.releaseLater(storeAllocator.allocate(8));
       store.setReleaser(storeReleaser);
 
-      try {
-        store.close();
-        throw new AssertionError("Expected close() to propagate the reader failure");
-      } catch (RuntimeException e) {
-        assertSame(releaseFailure, e.getCause());
-      }
+      assertThatThrownBy(store::close)
+          .isInstanceOf(RuntimeException.class)
+          .hasMessage("Unable to close resource")
+          .cause()
+          .isSameAs(releaseFailure);
     }
   }
 
@@ -112,18 +110,12 @@ public class TestColumnChunkPageReadStore {
     storeReleaser.releaseLater(throwingReleaserAllocator.allocate(8));
     store.setReleaser(storeReleaser);
 
-    try {
-      store.close();
-      throw new AssertionError("Expected close() to propagate the failures");
-    } catch (RuntimeException e) {
-      // Readers are released before the releaser, so the reader failure is the primary (root) cause and the
-      // releaser failure is attached to it as a suppressed exception, ensuring both are reported.
-      Throwable root = e.getCause();
-      assertSame(readerFailure, root);
-      Throwable[] suppressed = root.getSuppressed();
-      assertEquals(1, suppressed.length);
-      assertSame(releaserFailure, suppressed[0]);
-    }
+    assertThatThrownBy(store::close)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessage("Unable to close resource")
+        .cause()
+        .isSameAs(readerFailure)
+        .hasSuppressedException(releaserFailure);
   }
 
   private static ByteBufferAllocator throwingAllocator(RuntimeException releaseFailure) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnChunkPageWriteStore.java
@@ -31,11 +31,8 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -223,29 +220,26 @@ public class TestColumnChunkPageWriteStore {
       PageReadStore rowGroup = reader.readNextRowGroup();
       PageReader pageReader = rowGroup.getPageReader(col);
       DataPageV2 page = (DataPageV2) pageReader.readPage();
-      assertEquals(rowCount, page.getRowCount());
-      assertEquals(nullCount, page.getNullCount());
-      assertEquals(valueCount, page.getValueCount());
-      assertEquals(d, intValue(page.getDefinitionLevels()));
-      assertEquals(r, intValue(page.getRepetitionLevels()));
-      assertEquals(dataEncoding, page.getDataEncoding());
-      assertEquals(v, intValue(page.getData()));
+      assertThat(page.getRowCount()).isEqualTo(rowCount);
+      assertThat(page.getNullCount()).isEqualTo(nullCount);
+      assertThat(page.getValueCount()).isEqualTo(valueCount);
+      assertThat(intValue(page.getDefinitionLevels())).isEqualTo(d);
+      assertThat(intValue(page.getRepetitionLevels())).isEqualTo(r);
+      assertThat(page.getDataEncoding()).isEqualTo(dataEncoding);
+      assertThat(intValue(page.getData())).isEqualTo(v);
 
       // Checking column/offset indexes for the one page
       ColumnChunkMetaData column = footer.getBlocks().get(0).getColumns().get(0);
       ColumnIndex columnIndex = reader.readColumnIndex(column);
-      assertArrayEquals(
-          statistics.getMinBytes(), columnIndex.getMinValues().get(0).array());
-      assertArrayEquals(
-          statistics.getMaxBytes(), columnIndex.getMaxValues().get(0).array());
-      assertEquals(
-          statistics.getNumNulls(), columnIndex.getNullCounts().get(0).longValue());
-      assertFalse(columnIndex.getNullPages().get(0));
+      assertThat(columnIndex.getMinValues().get(0).array()).isEqualTo(statistics.getMinBytes());
+      assertThat(columnIndex.getMaxValues().get(0).array()).isEqualTo(statistics.getMaxBytes());
+      assertThat(columnIndex.getNullCounts().get(0).longValue()).isEqualTo(statistics.getNumNulls());
+      assertThat(columnIndex.getNullPages().get(0)).isFalse();
       OffsetIndex offsetIndex = reader.readOffsetIndex(column);
-      assertEquals(1, offsetIndex.getPageCount());
-      assertEquals(pageSize, offsetIndex.getCompressedPageSize(0));
-      assertEquals(0, offsetIndex.getFirstRowIndex(0));
-      assertEquals(pageOffset, offsetIndex.getOffset(0));
+      assertThat(offsetIndex.getPageCount()).isEqualTo(1);
+      assertThat(offsetIndex.getCompressedPageSize(0)).isEqualTo(pageSize);
+      assertThat(offsetIndex.getFirstRowIndex(0)).isEqualTo(0);
+      assertThat(offsetIndex.getOffset(0)).isEqualTo(pageOffset);
 
       reader.close();
     }
@@ -326,8 +320,8 @@ public class TestColumnChunkPageWriteStore {
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecs(schema, SNAPPY, props);
 
-    assertEquals(SNAPPY, codecs.get("col_a"));
-    assertEquals(SNAPPY, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(SNAPPY);
+    assertThat(codecs.get("col_b")).isEqualTo(SNAPPY);
   }
 
   @Test
@@ -339,8 +333,8 @@ public class TestColumnChunkPageWriteStore {
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecs(schema, SNAPPY, props);
 
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(SNAPPY, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(SNAPPY);
   }
 
   @Test
@@ -354,8 +348,8 @@ public class TestColumnChunkPageWriteStore {
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecs(schema, SNAPPY, props);
 
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(GZIP, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(GZIP);
   }
 
   @Test
@@ -369,8 +363,8 @@ public class TestColumnChunkPageWriteStore {
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecs(schema, SNAPPY, props);
 
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(SNAPPY, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(SNAPPY);
   }
 
   @Test
@@ -381,9 +375,9 @@ public class TestColumnChunkPageWriteStore {
         .withCompressionLevel("col_a", 23)
         .build();
 
-    BadConfigurationException ex =
-        assertThrows(BadConfigurationException.class, () -> writeAndReadCodecs(schema, SNAPPY, props));
-    assertTrue(ex.getMessage().contains("23"));
+    assertThatThrownBy(() -> writeAndReadCodecs(schema, SNAPPY, props))
+        .isInstanceOf(BadConfigurationException.class)
+        .hasMessageContaining("23");
   }
 
   @Test
@@ -394,9 +388,9 @@ public class TestColumnChunkPageWriteStore {
         .withCompressionLevel("col_a", 10)
         .build();
 
-    BadConfigurationException ex =
-        assertThrows(BadConfigurationException.class, () -> writeAndReadCodecs(schema, SNAPPY, props));
-    assertTrue(ex.getMessage().contains("10"));
+    assertThatThrownBy(() -> writeAndReadCodecs(schema, SNAPPY, props))
+        .isInstanceOf(BadConfigurationException.class)
+        .hasMessageContaining("10");
   }
 
   private Map<String, CompressionCodecName> writeAndReadCodecs(

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnIndexFiltering.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestColumnIndexFiltering.java
@@ -41,9 +41,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Types.optional;
 import static org.apache.parquet.schema.Types.required;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -315,7 +313,9 @@ public class TestColumnIndexFiltering {
         exp = expIt.next();
       }
     }
-    assertFalse("Not all expected elements are in the actual list. E.g.: " + exp, expIt.hasNext());
+    assertThat(expIt)
+        .as("Not all expected elements are in the actual list. E.g.: " + exp)
+        .isExhausted();
   }
 
   private void assertCorrectFiltering(Predicate<User> expectedFilter, FilterPredicate actualFilter)
@@ -323,7 +323,7 @@ public class TestColumnIndexFiltering {
     // Check with only column index based filtering
     List<User> result = readUsers(actualFilter, false);
 
-    assertTrue("Column-index filtering should drop some pages", result.size() < DATA.size());
+    assertThat(result).as("Column-index filtering should drop some pages").hasSizeLessThan(DATA.size());
     LOGGER.info(
         "{}/{} records read; filtering ratio: {}%",
         result.size(), DATA.size(), 100 * result.size() / DATA.size());
@@ -334,7 +334,7 @@ public class TestColumnIndexFiltering {
 
     // Check with all the filtering filtering to ensure the result contains exactly the required values
     result = readUsers(actualFilter, true);
-    assertEquals(DATA.stream().filter(expectedFilter).collect(Collectors.toList()), result);
+    assertThat(result).isEqualTo(DATA.stream().filter(expectedFilter).collect(Collectors.toList()));
   }
 
   @BeforeClass
@@ -449,28 +449,28 @@ public class TestColumnIndexFiltering {
   @Test
   public void testNoFiltering() throws IOException {
     // Column index filtering with no-op filter
-    assertEquals(DATA, readUsers(FilterCompat.NOOP, false));
-    assertEquals(DATA, readUsers(FilterCompat.NOOP, true));
+    assertThat(readUsers(FilterCompat.NOOP, false)).isEqualTo(DATA);
+    assertThat(readUsers(FilterCompat.NOOP, true)).isEqualTo(DATA);
 
     // Column index filtering with null filter
-    assertEquals(DATA, readUsers((Filter) null, false));
-    assertEquals(DATA, readUsers((Filter) null, true));
+    assertThat(readUsers((Filter) null, false)).isEqualTo(DATA);
+    assertThat(readUsers((Filter) null, true)).isEqualTo(DATA);
 
     // Column index filtering turned off
-    assertEquals(
-        DATA.stream().filter(user -> user.getId() == 1234).collect(Collectors.toList()),
-        readUsers(eq(longColumn("id"), 1234l), true, false));
-    assertEquals(
-        DATA.stream().filter(user -> "miller".equals(user.getName())).collect(Collectors.toList()),
-        readUsers(eq(binaryColumn("name"), Binary.fromString("miller")), true, false));
-    assertEquals(
-        DATA.stream().filter(user -> user.getName() == null).collect(Collectors.toList()),
-        readUsers(eq(binaryColumn("name"), null), true, false));
+    assertThat(readUsers(eq(longColumn("id"), 1234l), true, false))
+        .isEqualTo(DATA.stream().filter(user -> user.getId() == 1234).collect(Collectors.toList()));
+    assertThat(readUsers(eq(binaryColumn("name"), Binary.fromString("miller")), true, false))
+        .isEqualTo(DATA.stream()
+            .filter(user -> "miller".equals(user.getName()))
+            .collect(Collectors.toList()));
+    assertThat(readUsers(eq(binaryColumn("name"), null), true, false))
+        .isEqualTo(DATA.stream().filter(user -> user.getName() == null).collect(Collectors.toList()));
 
     // Every filtering mechanism turned off
-    assertEquals(DATA, readUsers(eq(longColumn("id"), 1234l), false, false));
-    assertEquals(DATA, readUsers(eq(binaryColumn("name"), Binary.fromString("miller")), false, false));
-    assertEquals(DATA, readUsers(eq(binaryColumn("name"), null), false, false));
+    assertThat(readUsers(eq(longColumn("id"), 1234l), false, false)).isEqualTo(DATA);
+    assertThat(readUsers(eq(binaryColumn("name"), Binary.fromString("miller")), false, false))
+        .isEqualTo(DATA);
+    assertThat(readUsers(eq(binaryColumn("name"), null), false, false)).isEqualTo(DATA);
   }
 
   @Test
@@ -606,7 +606,8 @@ public class TestColumnIndexFiltering {
   @Test
   public void testFilteringWithMissingColumns() throws IOException {
     // Missing column filter is always true
-    assertEquals(DATA, readUsers(notEq(binaryColumn("not-existing-binary"), Binary.EMPTY), true));
+    assertThat(readUsers(notEq(binaryColumn("not-existing-binary"), Binary.EMPTY), true))
+        .isEqualTo(DATA);
     assertCorrectFiltering(
         record -> record.getId() == 1234,
         and(eq(longColumn("id"), 1234l), eq(longColumn("not-existing-long"), null)));
@@ -617,7 +618,7 @@ public class TestColumnIndexFiltering {
             invert(userDefined(binaryColumn("not-existing-binary"), NameStartsWithVowel.class))));
 
     // Missing column filter is always false
-    assertEquals(emptyList(), readUsers(lt(longColumn("not-existing-long"), 0l), true));
+    assertThat(readUsers(lt(longColumn("not-existing-long"), 0l), true)).isEqualTo(emptyList());
     assertCorrectFiltering(
         record -> "miller".equals(record.getName()),
         or(
@@ -631,22 +632,19 @@ public class TestColumnIndexFiltering {
   @Test
   public void testFilteringWithProjection() throws IOException {
     // All rows shall be retrieved because all values in column 'name' shall be handled as null values
-    assertEquals(
-        DATA.stream().map(user -> user.cloneWithName(null)).collect(toList()),
-        readUsersWithProjection(
-            FilterCompat.get(eq(binaryColumn("name"), null)), SCHEMA_WITHOUT_NAME, true, true));
+    assertThat(readUsersWithProjection(
+            FilterCompat.get(eq(binaryColumn("name"), null)), SCHEMA_WITHOUT_NAME, true, true))
+        .isEqualTo(DATA.stream().map(user -> user.cloneWithName(null)).collect(toList()));
 
     // Column index filter shall drop all pages because all values in column 'name' shall be handled as null values
-    assertEquals(
-        emptyList(),
-        readUsersWithProjection(
-            FilterCompat.get(notEq(binaryColumn("name"), null)), SCHEMA_WITHOUT_NAME, false, true));
-    assertEquals(
-        emptyList(),
-        readUsersWithProjection(
+    assertThat(readUsersWithProjection(
+            FilterCompat.get(notEq(binaryColumn("name"), null)), SCHEMA_WITHOUT_NAME, false, true))
+        .isEqualTo(emptyList());
+    assertThat(readUsersWithProjection(
             FilterCompat.get(userDefined(binaryColumn("name"), NameStartsWithVowel.class)),
             SCHEMA_WITHOUT_NAME,
             false,
-            true));
+            true))
+        .isEqualTo(emptyList());
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageChecksums.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDataPageChecksums.java
@@ -20,11 +20,8 @@
 package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -488,13 +485,15 @@ public class TestDataPageChecksums {
           PageReadStore pageReadStore = reader.readNextRowGroup();
 
           DataPage colAPage1 = readNextPage(colADesc, pageReadStore);
-          assertFalse(
-              "Data in page was not corrupted", Arrays.equals(getPageBytes(colAPage1), colAPage1Bytes));
+          assertThat(getPageBytes(colAPage1))
+              .as("Data in page was not corrupted")
+              .isNotEqualTo(colAPage1Bytes);
           readNextPage(colADesc, pageReadStore);
           readNextPage(colBDesc, pageReadStore);
           DataPage colBPage2 = readNextPage(colBDesc, pageReadStore);
-          assertFalse(
-              "Data in page was not corrupted", Arrays.equals(getPageBytes(colBPage2), colBPage2Bytes));
+          assertThat(getPageBytes(colBPage2))
+              .as("Data in page was not corrupted")
+              .isNotEqualTo(colBPage2Bytes);
         }
 
         // Now we enable checksum verification, the corruption should be detected
@@ -716,7 +715,9 @@ public class TestDataPageChecksums {
    * Compare the extracted (decompressed) bytes to the reference bytes
    */
   private void assertCorrectContent(byte[] pageBytes, byte[] referenceBytes) {
-    assertArrayEquals("Read page content was different from expected page content", referenceBytes, pageBytes);
+    assertThat(pageBytes)
+        .as("Read page content was different from expected page content")
+        .isEqualTo(referenceBytes);
   }
 
   private byte[] getPageBytes(DataPage page) throws IOException {
@@ -738,21 +739,20 @@ public class TestDataPageChecksums {
    * check that the crc's are identical.
    */
   private void assertCrcSetAndCorrect(Page page, byte[] referenceBytes) {
-    assertTrue("Checksum was not set in page", page.getCrc().isPresent());
+    assertThat(page.getCrc()).as("Checksum was not set in page").isPresent();
     int crcFromPage = page.getCrc().getAsInt();
     crc.reset();
     crc.update(referenceBytes);
-    assertEquals(
-        "Checksum found in page did not match calculated reference checksum",
-        crc.getValue(),
-        (long) crcFromPage & 0xffffffffL);
+    assertThat((long) crcFromPage & 0xffffffffL)
+        .as("Checksum found in page did not match calculated reference checksum")
+        .isEqualTo(crc.getValue());
   }
 
   /**
    * Verify that the crc is not set
    */
   private void assertCrcNotSet(Page page) {
-    assertFalse("Checksum was set in page", page.getCrc().isPresent());
+    assertThat(page.getCrc()).as("Checksum was set in page").isEmpty();
   }
 
   /**
@@ -760,14 +760,8 @@ public class TestDataPageChecksums {
    * if the read succeeds (no exception was thrown ), verify that the checksum was not set.
    */
   private void assertVerificationFailed(ParquetFileReader reader) {
-    try {
-      reader.readNextRowGroup();
-      fail("Expected checksum verification exception to be thrown");
-    } catch (Exception e) {
-      assertTrue("Thrown exception is of incorrect type", e instanceof ParquetDecodingException);
-      assertTrue(
-          "Did not catch checksum verification ParquetDecodingException",
-          e.getMessage().contains("CRC checksum verification failed"));
-    }
+    assertThatThrownBy(reader::readNextRowGroup)
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasMessageContaining("CRC checksum verification failed");
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDirectCodecFactory.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestDirectCodecFactory.java
@@ -25,6 +25,8 @@ import static org.apache.parquet.hadoop.metadata.CompressionCodecName.LZO;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.SNAPPY;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.ZSTD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -43,7 +45,6 @@ import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompressor;
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -88,9 +89,9 @@ public class TestDirectCodecFactory {
       if (codec == LZ4_RAW) {
         // Hadoop codecs support direct decompressors only if the related native libraries are available.
         // This is not the case for our CI so let's rely on LZ4_RAW where the implementation is our own.
-        Assert.assertTrue(
-            String.format("The hadoop codec %s should support direct decompression", codec),
-            directDecompressor instanceof DirectCodecFactory.FullDirectDecompressor);
+        assertThat(directDecompressor)
+            .as(String.format("The hadoop codec %s should support direct decompression", codec))
+            .isInstanceOf(DirectCodecFactory.FullDirectDecompressor.class);
       }
 
       final BytesInput directCompressed;
@@ -156,16 +157,16 @@ public class TestDirectCodecFactory {
           b.position(shift);
           outBuf.position(shift);
           d.decompress(b, (int) compressed.size(), outBuf, size);
-          Assert.assertEquals(
-              "Input buffer position mismatch for codec " + codec,
-              compressed.size() + shift,
-              b.position());
-          Assert.assertEquals(
-              "Output buffer position mismatch for codec " + codec, size + shift, outBuf.position());
+          assertThat(b.position())
+              .as("Input buffer position mismatch for codec " + codec)
+              .isEqualTo(compressed.size() + shift);
+          assertThat(outBuf.position())
+              .as("Output buffer position mismatch for codec " + codec)
+              .isEqualTo(size + shift);
           for (int i = 0; i < size; i++) {
-            Assert.assertTrue(
-                String.format("Data didn't match at %d, while testing codec %s", i, codec),
-                outBuf.get(shift + i) == rawBuf.get(i));
+            assertThat(outBuf.get(shift + i))
+                .as(String.format("Data didn't match at %d, while testing codec %s", i, codec))
+                .isEqualTo(rawBuf.get(i));
           }
         } finally {
           allocator.release(b);
@@ -181,8 +182,9 @@ public class TestDirectCodecFactory {
           b.put(buf);
           b.flip();
           final BytesInput input = d.decompress(BytesInput.from(b), size);
-          Assert.assertArrayEquals(
-              String.format("While testing codec %s", codec), input.toByteArray(), rawArr);
+          assertThat(rawArr)
+              .as(String.format("While testing codec %s", codec))
+              .isEqualTo(input.toByteArray());
         } finally {
           allocator.release(b);
         }
@@ -191,7 +193,9 @@ public class TestDirectCodecFactory {
       case ON_HEAP: {
         final byte[] buf = compressed.toByteArray();
         final BytesInput input = d.decompress(BytesInput.from(buf), size);
-        Assert.assertArrayEquals(String.format("While testing codec %s", codec), input.toByteArray(), rawArr);
+        assertThat(rawArr)
+            .as(String.format("While testing codec %s", codec))
+            .isEqualTo(input.toByteArray());
         break;
       }
     }
@@ -199,19 +203,10 @@ public class TestDirectCodecFactory {
 
   @Test
   public void createDirectFactoryWithHeapAllocatorFails() {
-    String errorMsg =
-        "Test failed, creation of a direct codec factory should have failed when passed a non-direct allocator.";
-    try {
-      CodecFactory.createDirectCodecFactory(new Configuration(), new HeapByteBufferAllocator(), 0);
-      throw new RuntimeException(errorMsg);
-    } catch (IllegalStateException ex) {
-      // indicates successful completion of the test
-      Assert.assertTrue(
-          "Missing expected error message.",
-          ex.getMessage().contains("A DirectCodecFactory requires a direct buffer allocator be provided."));
-    } catch (Exception ex) {
-      throw new RuntimeException(errorMsg + " Failed with the wrong error.");
-    }
+    assertThatThrownBy(() ->
+            CodecFactory.createDirectCodecFactory(new Configuration(), new HeapByteBufferAllocator(), 0))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("A DirectCodecFactory requires a direct buffer allocator be provided.");
   }
 
   @Test
@@ -268,8 +263,8 @@ public class TestDirectCodecFactory {
     CompressionCodec codec_2_2 = codecFactory_2.getCodec(CompressionCodecName.GZIP);
     CompressionCodec codec_5_1 = codecFactory_5.getCodec(CompressionCodecName.GZIP);
 
-    Assert.assertEquals(codec_2_1, codec_2_2);
-    Assert.assertNotEquals(codec_2_1, codec_5_1);
+    assertThat(codec_2_2).isEqualTo(codec_2_1);
+    assertThat(codec_2_1).isNotEqualTo(codec_5_1);
   }
 
   @Test
@@ -287,8 +282,8 @@ public class TestDirectCodecFactory {
     CompressionCodec codec_2_2 = codecFactory_2.getCodec(CompressionCodecName.ZSTD);
     CompressionCodec codec_5_1 = codecFactory_5.getCodec(CompressionCodecName.ZSTD);
 
-    Assert.assertEquals(codec_2_1, codec_2_2);
-    Assert.assertNotEquals(codec_2_1, codec_5_1);
+    assertThat(codec_2_2).isEqualTo(codec_2_1);
+    assertThat(codec_2_1).isNotEqualTo(codec_5_1);
   }
 
   @Test
@@ -296,7 +291,7 @@ public class TestDirectCodecFactory {
     CodecFactory factory = new CodecFactory(new Configuration(), pageSize);
     BytesInputCompressor c1 = factory.getCompressor(ZSTD, 3);
     BytesInputCompressor c2 = factory.getCompressor(ZSTD, 3);
-    Assert.assertSame("Same codec+level should return the cached instance", c1, c2);
+    assertThat(c2).as("Same codec+level should return the cached instance").isSameAs(c1);
     factory.release();
   }
 
@@ -305,7 +300,9 @@ public class TestDirectCodecFactory {
     CodecFactory factory = new CodecFactory(new Configuration(), pageSize);
     BytesInputCompressor c1 = factory.getCompressor(ZSTD, 1);
     BytesInputCompressor c3 = factory.getCompressor(ZSTD, 3);
-    Assert.assertNotSame("Different levels should return different compressor instances", c1, c3);
+    assertThat(c3)
+        .as("Different levels should return different compressor instances")
+        .isNotSameAs(c1);
     factory.release();
   }
 
@@ -314,8 +311,9 @@ public class TestDirectCodecFactory {
     CodecFactory factory = new CodecFactory(new Configuration(), pageSize);
     BytesInputCompressor noLevel = factory.getCompressor(ZSTD);
     BytesInputCompressor withLevel = factory.getCompressor(ZSTD, 3);
-    Assert.assertNotSame(
-        "Level-aware and no-level compressors should use separate cache entries", noLevel, withLevel);
+    assertThat(withLevel)
+        .as("Level-aware and no-level compressors should use separate cache entries")
+        .isNotSameAs(noLevel);
     factory.release();
   }
 
@@ -323,7 +321,7 @@ public class TestDirectCodecFactory {
   public void leveledUncompressedReturnsNoOp() {
     CodecFactory factory = new CodecFactory(new Configuration(), pageSize);
     BytesInputCompressor comp = factory.getCompressor(UNCOMPRESSED, 5);
-    Assert.assertSame(CodecFactory.NO_OP_COMPRESSOR, comp);
+    assertThat(comp).isSameAs(CodecFactory.NO_OP_COMPRESSOR);
     factory.release();
   }
 
@@ -331,8 +329,8 @@ public class TestDirectCodecFactory {
   public void leveledSnappyIgnoresLevel() {
     CodecFactory factory = new CodecFactory(new Configuration(), pageSize);
     BytesInputCompressor comp = factory.getCompressor(SNAPPY, 99);
-    Assert.assertNotNull(comp);
-    Assert.assertEquals(SNAPPY, comp.getCodecName());
+    assertThat(comp).isNotNull();
+    assertThat(comp.getCodecName()).isEqualTo(SNAPPY);
     factory.release();
   }
 
@@ -340,9 +338,9 @@ public class TestDirectCodecFactory {
   public void leveledGzipInvalidLevelThrows() {
     CodecFactory factory = new CodecFactory(new Configuration(), pageSize);
     try {
-      BadConfigurationException ex =
-          Assert.assertThrows(BadConfigurationException.class, () -> factory.getCompressor(GZIP, 99));
-      Assert.assertTrue(ex.getMessage().contains("99"));
+      assertThatThrownBy(() -> factory.getCompressor(GZIP, 99))
+          .isInstanceOf(BadConfigurationException.class)
+          .hasMessageContaining("99");
     } finally {
       factory.release();
     }
@@ -353,8 +351,12 @@ public class TestDirectCodecFactory {
     CodecFactory factory = new CodecFactory(new Configuration(), pageSize);
     for (int level : new int[] {-1, 0, 1, 9}) {
       BytesInputCompressor comp = factory.getCompressor(GZIP, level);
-      Assert.assertNotNull("Compressor should not be null for GZIP level " + level, comp);
-      Assert.assertEquals("Codec name should be GZIP for level " + level, GZIP, comp.getCodecName());
+      assertThat(comp)
+          .as("Compressor should not be null for GZIP level " + level)
+          .isNotNull();
+      assertThat(comp.getCodecName())
+          .as("Codec name should be GZIP for level " + level)
+          .isEqualTo(GZIP);
     }
     factory.release();
   }
@@ -367,7 +369,7 @@ public class TestDirectCodecFactory {
     for (int level : new int[] {-5, 0, 1, 3, 10, 22}) {
       BytesInput compressed = factory.getCompressor(ZSTD, level).compress(BytesInput.from(original));
       byte[] result = decompressor.decompress(compressed, original.length).toByteArray();
-      Assert.assertArrayEquals("Round-trip failed at ZSTD level " + level, original, result);
+      assertThat(result).as("Round-trip failed at ZSTD level " + level).isEqualTo(original);
     }
     factory.release();
   }
@@ -380,7 +382,7 @@ public class TestDirectCodecFactory {
     for (int level : new int[] {1, 5, 9}) {
       BytesInput compressed = factory.getCompressor(GZIP, level).compress(BytesInput.from(original));
       byte[] result = decompressor.decompress(compressed, original.length).toByteArray();
-      Assert.assertArrayEquals("Round-trip failed at GZIP level " + level, original, result);
+      assertThat(result).as("Round-trip failed at GZIP level " + level).isEqualTo(original);
     }
     factory.release();
   }
@@ -391,30 +393,27 @@ public class TestDirectCodecFactory {
     CodecFactory direct =
         CodecFactory.createDirectCodecFactory(new Configuration(), new DirectByteBufferAllocator(), pageSize);
     try {
-      // Sanity: the heap factory's leveled path yields a HeapBytesCompressor.
-      Assert.assertTrue(
-          "heap factory should produce a HeapBytesCompressor",
-          heap.getCompressor(ZSTD, 3) instanceof CodecFactory.HeapBytesCompressor);
+      assertThat(heap.getCompressor(ZSTD, 3))
+          .as("heap factory should produce a HeapBytesCompressor")
+          .isInstanceOf(CodecFactory.HeapBytesCompressor.class);
 
       // The direct factory must not fall back to the heap/Hadoop path for leveled ZSTD/SNAPPY.
       BytesInputCompressor directZstd = direct.getCompressor(ZSTD, 3);
-      Assert.assertFalse(
-          "direct factory ZSTD(level) should not fall back to HeapBytesCompressor",
-          directZstd instanceof CodecFactory.HeapBytesCompressor);
-      Assert.assertEquals(ZSTD, directZstd.getCodecName());
-      Assert.assertEquals(
-          "leveled ZSTD should use the same direct compressor type as the no-level path",
-          direct.getCompressor(ZSTD).getClass(),
-          directZstd.getClass());
+      assertThat(directZstd)
+          .as("direct factory ZSTD(level) should not fall back to HeapBytesCompressor")
+          .isNotInstanceOf(CodecFactory.HeapBytesCompressor.class);
+      assertThat(directZstd.getCodecName()).isEqualTo(ZSTD);
+      assertThat(directZstd.getClass())
+          .as("leveled ZSTD should use the same direct compressor type as the no-level path")
+          .isEqualTo(direct.getCompressor(ZSTD).getClass());
 
       BytesInputCompressor directSnappy = direct.getCompressor(SNAPPY, 5);
-      Assert.assertFalse(
-          "direct factory SNAPPY(level) should not fall back to HeapBytesCompressor",
-          directSnappy instanceof CodecFactory.HeapBytesCompressor);
-      Assert.assertEquals(
-          "leveled SNAPPY should use the same direct compressor type as the no-level path",
-          direct.getCompressor(SNAPPY).getClass(),
-          directSnappy.getClass());
+      assertThat(directSnappy)
+          .as("direct factory SNAPPY(level) should not fall back to HeapBytesCompressor")
+          .isNotInstanceOf(CodecFactory.HeapBytesCompressor.class);
+      assertThat(directSnappy.getClass())
+          .as("leveled SNAPPY should use the same direct compressor type as the no-level path")
+          .isEqualTo(direct.getCompressor(SNAPPY).getClass());
 
       // The direct ZSTD level path must compress/decompress correctly at each level.
       byte[] original = "hello parquet per-column zstd direct compression".getBytes(StandardCharsets.UTF_8);
@@ -426,7 +425,9 @@ public class TestDirectCodecFactory {
         byte[] result = decompressor
             .decompress(BytesInput.from(compressed), original.length)
             .toByteArray();
-        Assert.assertArrayEquals("Direct ZSTD round-trip failed at level " + level, original, result);
+        assertThat(result)
+            .as("Direct ZSTD round-trip failed at level " + level)
+            .isEqualTo(original);
       }
     } finally {
       heap.release();
@@ -439,7 +440,9 @@ public class TestDirectCodecFactory {
     CodecFactory direct =
         CodecFactory.createDirectCodecFactory(new Configuration(), new DirectByteBufferAllocator(), pageSize);
     try {
-      Assert.assertThrows(BadConfigurationException.class, () -> direct.getCompressor(ZSTD, 23));
+      assertThatThrownBy(() -> direct.getCompressor(ZSTD, 23))
+          .isInstanceOf(BadConfigurationException.class)
+          .hasMessageContaining("23");
     } finally {
       direct.release();
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestIndexCache.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestIndexCache.java
@@ -23,6 +23,8 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -42,7 +44,6 @@ import org.apache.parquet.io.LocalInputFile;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -80,7 +81,7 @@ public class TestIndexCache {
     ParquetReadOptions options = ParquetReadOptions.builder().build();
     ParquetFileReader fileReader = new ParquetFileReader(new LocalInputFile(Paths.get(file)), options);
     IndexCache indexCache = IndexCache.create(fileReader, new HashSet<>(), IndexCache.CacheStrategy.NONE, false);
-    Assert.assertTrue(indexCache instanceof NoneIndexCache);
+    assertThat(indexCache).isInstanceOf(NoneIndexCache.class);
     List<BlockMetaData> blocks = fileReader.getFooter().getBlocks();
     for (BlockMetaData blockMetaData : blocks) {
       indexCache.setBlockMetadata(blockMetaData);
@@ -88,10 +89,9 @@ public class TestIndexCache {
         validateColumnIndex(fileReader.readColumnIndex(chunk), indexCache.getColumnIndex(chunk));
         validateOffsetIndex(fileReader.readOffsetIndex(chunk), indexCache.getOffsetIndex(chunk));
 
-        Assert.assertEquals(
-            "BloomFilter should match",
-            fileReader.readBloomFilter(chunk),
-            indexCache.getBloomFilter(chunk));
+        assertThat(indexCache.getBloomFilter(chunk))
+            .as("BloomFilter should match")
+            .isEqualTo(fileReader.readBloomFilter(chunk));
       }
     }
   }
@@ -110,11 +110,11 @@ public class TestIndexCache {
     columns.add(ColumnPath.fromDotString("Links.Forward"));
 
     IndexCache indexCache = IndexCache.create(fileReader, columns, IndexCache.CacheStrategy.PREFETCH_BLOCK, false);
-    Assert.assertTrue(indexCache instanceof PrefetchIndexCache);
+    assertThat(indexCache).isInstanceOf(PrefetchIndexCache.class);
     validPrecacheIndexCache(fileReader, indexCache, columns, false);
 
     indexCache = IndexCache.create(fileReader, columns, IndexCache.CacheStrategy.PREFETCH_BLOCK, true);
-    Assert.assertTrue(indexCache instanceof PrefetchIndexCache);
+    assertThat(indexCache).isInstanceOf(PrefetchIndexCache.class);
     validPrecacheIndexCache(fileReader, indexCache, columns, true);
   }
 
@@ -139,16 +139,21 @@ public class TestIndexCache {
         validateColumnIndex(fileReader.readColumnIndex(chunk), indexCache.getColumnIndex(chunk));
         validateOffsetIndex(fileReader.readOffsetIndex(chunk), indexCache.getOffsetIndex(chunk));
 
-        Assert.assertEquals(
-            "BloomFilter should match",
-            fileReader.readBloomFilter(chunk),
-            indexCache.getBloomFilter(chunk));
+        assertThat(indexCache.getBloomFilter(chunk))
+            .as("BloomFilter should match")
+            .isEqualTo(fileReader.readBloomFilter(chunk));
 
         if (freeCacheAfterGet) {
-          Assert.assertThrows(IllegalStateException.class, () -> indexCache.getColumnIndex(chunk));
-          Assert.assertThrows(IllegalStateException.class, () -> indexCache.getOffsetIndex(chunk));
+          assertThatThrownBy(() -> indexCache.getColumnIndex(chunk))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("Not found cached ColumnIndex");
+          assertThatThrownBy(() -> indexCache.getOffsetIndex(chunk))
+              .isInstanceOf(IllegalStateException.class)
+              .hasMessageContaining("Not found cached OffsetIndex");
           if (columns.contains(chunk.getPath())) {
-            Assert.assertThrows(IllegalStateException.class, () -> indexCache.getBloomFilter(chunk));
+            assertThatThrownBy(() -> indexCache.getBloomFilter(chunk))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Not found cached BloomFilter");
           }
         }
       }
@@ -157,25 +162,25 @@ public class TestIndexCache {
 
   private static void validateColumnIndex(ColumnIndex expected, ColumnIndex target) {
     if (expected == null) {
-      Assert.assertEquals("ColumnIndex should should equal", expected, target);
+      assertThat(target).as("ColumnIndex should should equal").isEqualTo(expected);
     } else {
-      Assert.assertNotNull("ColumnIndex should not be null", target);
-      Assert.assertEquals(expected.getClass(), target.getClass());
-      Assert.assertEquals(expected.getMinValues(), target.getMinValues());
-      Assert.assertEquals(expected.getMaxValues(), target.getMaxValues());
-      Assert.assertEquals(expected.getBoundaryOrder(), target.getBoundaryOrder());
-      Assert.assertEquals(expected.getNullCounts(), target.getNullCounts());
-      Assert.assertEquals(expected.getNullPages(), target.getNullPages());
+      assertThat(target).as("ColumnIndex should not be null").isNotNull();
+      assertThat(target.getClass()).isEqualTo(expected.getClass());
+      assertThat(target.getMinValues()).containsExactlyElementsOf(expected.getMinValues());
+      assertThat(target.getMaxValues()).containsExactlyElementsOf(expected.getMaxValues());
+      assertThat(target.getBoundaryOrder()).isEqualTo(expected.getBoundaryOrder());
+      assertThat(target.getNullCounts()).containsExactlyElementsOf(expected.getNullCounts());
+      assertThat(target.getNullPages()).containsExactlyElementsOf(expected.getNullPages());
     }
   }
 
   private static void validateOffsetIndex(OffsetIndex expected, OffsetIndex target) {
     if (expected == null) {
-      Assert.assertEquals("OffsetIndex should should equal", expected, target);
+      assertThat(target).as("OffsetIndex should should equal").isEqualTo(expected);
     } else {
-      Assert.assertNotNull("OffsetIndex should not be null", target);
-      Assert.assertEquals(expected.getClass(), target.getClass());
-      Assert.assertEquals(expected.toString(), target.toString());
+      assertThat(target).as("OffsetIndex should not be null").isNotNull();
+      assertThat(target.getClass()).isEqualTo(expected.getClass());
+      assertThat(target).asString().isEqualTo(expected.toString());
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormat.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormat.java
@@ -27,10 +27,8 @@ import static org.apache.parquet.filter2.predicate.FilterApi.intColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.not;
 import static org.apache.parquet.filter2.predicate.FilterApi.notEq;
 import static org.apache.parquet.filter2.predicate.FilterApi.or;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.io.Files;
@@ -101,26 +99,18 @@ public class TestInputFormat {
 
   @Test
   public void testThrowExceptionWhenMaxSplitSizeIsSmallerThanMinSplitSize() throws IOException {
-    try {
-      generateSplitByMinMaxSize(50, 49);
-      fail("should throw exception when max split size is smaller than the min split size");
-    } catch (ParquetDecodingException e) {
-      assertEquals(
-          "maxSplitSize and minSplitSize should be positive and max should be greater or equal to the minSplitSize: maxSplitSize = 49; minSplitSize is 50",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> generateSplitByMinMaxSize(50, 49))
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasMessage(
+            "maxSplitSize and minSplitSize should be positive and max should be greater or equal to the minSplitSize: maxSplitSize = 49; minSplitSize is 50");
   }
 
   @Test
   public void testThrowExceptionWhenMaxSplitSizeIsNegative() throws IOException {
-    try {
-      generateSplitByMinMaxSize(-100, -50);
-      fail("should throw exception when max split size is negative");
-    } catch (ParquetDecodingException e) {
-      assertEquals(
-          "maxSplitSize and minSplitSize should be positive and max should be greater or equal to the minSplitSize: maxSplitSize = -50; minSplitSize is -100",
-          e.getMessage());
-    }
+    assertThatThrownBy(() -> generateSplitByMinMaxSize(-100, -50))
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasMessage(
+            "maxSplitSize and minSplitSize should be positive and max should be greater or equal to the minSplitSize: maxSplitSize = -50; minSplitSize is -100");
   }
 
   @Test
@@ -130,17 +120,17 @@ public class TestInputFormat {
     Configuration conf = new Configuration();
     ParquetInputFormat.setFilterPredicate(conf, p);
     Filter read = ParquetInputFormat.getFilter(conf);
-    assertTrue(read instanceof FilterPredicateCompat);
-    assertEquals(p, ((FilterPredicateCompat) read).getFilterPredicate());
+    assertThat(read).isInstanceOf(FilterPredicateCompat.class);
+    assertThat(((FilterPredicateCompat) read).getFilterPredicate()).isEqualTo(p);
 
     conf = new Configuration();
     ParquetInputFormat.setFilterPredicate(conf, not(p));
     read = ParquetInputFormat.getFilter(conf);
-    assertTrue(read instanceof FilterPredicateCompat);
-    assertEquals(
-        and(notEq(intColumn, 7), notEq(intColumn, 12)), ((FilterPredicateCompat) read).getFilterPredicate());
+    assertThat(read).isInstanceOf(FilterPredicateCompat.class);
+    assertThat(((FilterPredicateCompat) read).getFilterPredicate())
+        .isEqualTo(and(notEq(intColumn, 7), notEq(intColumn, 12)));
 
-    assertEquals(FilterCompat.NOOP, ParquetInputFormat.getFilter(new Configuration()));
+    assertThat(ParquetInputFormat.getFilter(new Configuration())).isEqualTo(FilterCompat.NOOP);
   }
 
   /*
@@ -314,27 +304,20 @@ public class TestInputFormat {
     IntColumn foo = intColumn("foo");
     FilterPredicate p = or(eq(foo, 10), eq(foo, 11));
 
-    Job job = new Job();
+    Job jobWithUnboundFilter = new Job();
+    Configuration confWithUnboundFilter = jobWithUnboundFilter.getConfiguration();
+    ParquetInputFormat.setUnboundRecordFilter(jobWithUnboundFilter, DummyUnboundRecordFilter.class);
+    assertThatThrownBy(() -> ParquetInputFormat.setFilterPredicate(confWithUnboundFilter, p))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("You cannot provide a FilterPredicate after providing an UnboundRecordFilter");
 
-    Configuration conf = job.getConfiguration();
-    ParquetInputFormat.setUnboundRecordFilter(job, DummyUnboundRecordFilter.class);
-    try {
-      ParquetInputFormat.setFilterPredicate(conf, p);
-      fail("this should throw");
-    } catch (IllegalArgumentException e) {
-      assertEquals("You cannot provide a FilterPredicate after providing an UnboundRecordFilter", e.getMessage());
-    }
-
-    job = new Job();
-    conf = job.getConfiguration();
-
-    ParquetInputFormat.setFilterPredicate(conf, p);
-    try {
-      ParquetInputFormat.setUnboundRecordFilter(job, DummyUnboundRecordFilter.class);
-      fail("this should throw");
-    } catch (IllegalArgumentException e) {
-      assertEquals("You cannot provide an UnboundRecordFilter after providing a FilterPredicate", e.getMessage());
-    }
+    Job jobWithPredicate = new Job();
+    Configuration confWithPredicate = jobWithPredicate.getConfiguration();
+    ParquetInputFormat.setFilterPredicate(confWithPredicate, p);
+    assertThatThrownBy(() ->
+            ParquetInputFormat.setUnboundRecordFilter(jobWithPredicate, DummyUnboundRecordFilter.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("You cannot provide an UnboundRecordFilter after providing a FilterPredicate");
   }
 
   public static BlockMetaData makeBlockFromStats(IntStatistics stats, long valueCount) {
@@ -363,9 +346,10 @@ public class TestInputFormat {
     FileSystem fs = FileSystem.getLocal(new Configuration());
     ParquetInputFormat.FootersCacheValue cacheValue = getDummyCacheValue(tempFile, fs);
 
-    assertTrue(tempFile.setLastModified(tempFile.lastModified() + 5000));
-    assertFalse(cacheValue.isCurrent(
-        new ParquetInputFormat.FileStatusWrapper(fs.getFileStatus(new Path(tempFile.getAbsolutePath())))));
+    assertThat(tempFile.setLastModified(tempFile.lastModified() + 5000)).isTrue();
+    assertThat(cacheValue.isCurrent(new ParquetInputFormat.FileStatusWrapper(
+            fs.getFileStatus(new Path(tempFile.getAbsolutePath())))))
+        .isFalse();
   }
 
   @Test
@@ -374,14 +358,14 @@ public class TestInputFormat {
     FileSystem fs = FileSystem.getLocal(new Configuration());
     ParquetInputFormat.FootersCacheValue cacheValue = getDummyCacheValue(tempFile, fs);
 
-    assertTrue(cacheValue.isNewerThan(null));
-    assertFalse(cacheValue.isNewerThan(cacheValue));
+    assertThat(cacheValue.isNewerThan(null)).isTrue();
+    assertThat(cacheValue.isNewerThan(cacheValue)).isFalse();
 
-    assertTrue(tempFile.setLastModified(tempFile.lastModified() + 5000));
+    assertThat(tempFile.setLastModified(tempFile.lastModified() + 5000)).isTrue();
     ParquetInputFormat.FootersCacheValue newerCacheValue = getDummyCacheValue(tempFile, fs);
 
-    assertTrue(newerCacheValue.isNewerThan(cacheValue));
-    assertFalse(cacheValue.isNewerThan(newerCacheValue));
+    assertThat(newerCacheValue.isNewerThan(cacheValue)).isTrue();
+    assertThat(cacheValue.isNewerThan(newerCacheValue)).isFalse();
   }
 
   @Test
@@ -417,7 +401,7 @@ public class TestInputFormat {
     for (int i = 0; i < numFiles; i++) {
       Footer footer = footers.get(i);
       File file = new File(tempDir, String.format("part-%05d.parquet", i));
-      assertEquals(file.toURI().toString(), footer.getFile().toString());
+      assertThat(footer.getFile()).asString().isEqualTo(file.toURI().toString());
     }
   }
 
@@ -464,7 +448,7 @@ public class TestInputFormat {
     ParquetMetadata mockMetadata = mock(ParquetMetadata.class);
     ParquetInputFormat.FootersCacheValue cacheValue =
         new ParquetInputFormat.FootersCacheValue(statusWrapper, new Footer(path, mockMetadata));
-    assertTrue(cacheValue.isCurrent(statusWrapper));
+    assertThat(cacheValue.isCurrent(statusWrapper)).isTrue();
     return cacheValue;
   }
 
@@ -504,35 +488,36 @@ public class TestInputFormat {
   }
 
   private void shouldSplitStartBe(List<ParquetInputSplit> splits, long... offsets) {
-    assertEquals(message(splits), offsets.length, splits.size());
+    assertThat(splits).as(message(splits)).hasSameSizeAs(offsets);
     for (int i = 0; i < offsets.length; i++) {
-      assertEquals(message(splits) + i, offsets[i], splits.get(i).getStart());
+      assertThat(splits.get(i).getStart()).as(message(splits) + i).isEqualTo(offsets[i]);
     }
   }
 
   private void shouldSplitBlockSizeBe(List<ParquetInputSplit> splits, int... sizes) {
-    assertEquals(message(splits), sizes.length, splits.size());
+    assertThat(splits).as(message(splits)).hasSameSizeAs(sizes);
     for (int i = 0; i < sizes.length; i++) {
-      assertEquals(message(splits) + i, sizes[i], splits.get(i).getRowGroupOffsets().length);
+      assertThat(splits.get(i).getRowGroupOffsets().length)
+          .as(message(splits) + i)
+          .isEqualTo(sizes[i]);
     }
   }
 
   private void shouldSplitLocationBe(List<ParquetInputSplit> splits, int... locations) throws IOException {
-    assertEquals(message(splits), locations.length, splits.size());
+    assertThat(splits).as(message(splits)).hasSameSizeAs(locations);
     for (int i = 0; i < locations.length; i++) {
       int loc = locations[i];
       ParquetInputSplit split = splits.get(i);
-      assertEquals(
-          message(splits) + i,
-          "[foo" + loc + ".datanode, bar" + loc + ".datanode]",
-          Arrays.toString(split.getLocations()));
+      assertThat(Arrays.toString(split.getLocations()))
+          .as(message(splits) + i)
+          .isEqualTo("[foo" + loc + ".datanode, bar" + loc + ".datanode]");
     }
   }
 
   private void shouldOneSplitRowGroupOffsetBe(ParquetInputSplit split, int... rowGroupOffsets) {
-    assertEquals(split.toString(), rowGroupOffsets.length, split.getRowGroupOffsets().length);
+    assertThat(split.getRowGroupOffsets()).hasSameSizeAs(rowGroupOffsets);
     for (int i = 0; i < rowGroupOffsets.length; i++) {
-      assertEquals(split.toString(), rowGroupOffsets[i], split.getRowGroupOffsets()[i]);
+      assertThat(split.getRowGroupOffsets()[i]).as(split.toString()).isEqualTo(rowGroupOffsets[i]);
     }
   }
 
@@ -541,9 +526,9 @@ public class TestInputFormat {
   }
 
   private void shouldSplitLengthBe(List<ParquetInputSplit> splits, int... lengths) {
-    assertEquals(message(splits), lengths.length, splits.size());
+    assertThat(splits).as(message(splits)).hasSameSizeAs(lengths);
     for (int i = 0; i < lengths.length; i++) {
-      assertEquals(message(splits) + i, lengths[i], splits.get(i).getLength());
+      assertThat(splits.get(i).getLength()).as(message(splits) + i).isEqualTo(lengths[i]);
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormatColumnProjection.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputFormatColumnProjection.java
@@ -21,6 +21,8 @@ package org.apache.parquet.hadoop;
 import static java.lang.Thread.sleep;
 import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -46,8 +48,6 @@ import org.apache.parquet.hadoop.util.ContextUtil;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
-import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -123,8 +123,7 @@ public class TestInputFormatColumnProjection {
 
   @Test
   public void testProjectionSize() throws Exception {
-    Assume.assumeTrue( // only run this test for Hadoop 2
-        org.apache.hadoop.mapreduce.JobContext.class.isInterface());
+    assumeThat(org.apache.hadoop.mapreduce.JobContext.class.isInterface()).isTrue();
 
     File inputFile = temp.newFile();
     FileOutputStream out = new FileOutputStream(inputFile);
@@ -195,10 +194,10 @@ public class TestInputFormatColumnProjection {
       bytesRead = Reader.bytesReadCounter.getValue();
     }
 
-    Assert.assertTrue(
-        "Should read (" + bytesRead + " bytes)" + " less than 10% of the input file size (" + bytesWritten
-            + ")",
-        bytesRead < (bytesWritten / 10));
+    assertThat(bytesRead)
+        .as("Should read (" + bytesRead + " bytes)" + " less than 10% of the input file size (" + bytesWritten
+            + ")")
+        .isLessThan(bytesWritten / 10);
   }
 
   private void waitForJob(Job job) throws Exception {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputOutputFormatWithPadding.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInputOutputFormatWithPadding.java
@@ -21,6 +21,7 @@ package org.apache.parquet.hadoop;
 import static java.lang.Thread.sleep;
 import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -48,7 +49,6 @@ import org.apache.parquet.hadoop.util.HadoopOutputFile;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -157,7 +157,9 @@ public class TestInputOutputFormatWithPadding {
     ParquetMetadata footer = ParquetFileReader.readFooter(
         conf, new Path(parquetFile.toString()), ParquetMetadataConverter.NO_FILTER);
     for (BlockMetaData block : footer.getBlocks()) {
-      Assert.assertTrue("Block should start at a multiple of the block size", block.getStartingPos() % 1024 == 0);
+      assertThat(block.getStartingPos() % 1024)
+          .as("Block should start at a multiple of the block size")
+          .isZero();
     }
 
     {
@@ -175,14 +177,14 @@ public class TestInputOutputFormatWithPadding {
     }
 
     File dataFile = getDataFile(outputFolder);
-    Assert.assertNotNull("Should find a data file", dataFile);
+    assertThat(dataFile).as("Should find a data file").isNotNull();
 
     StringBuilder contentBuilder = new StringBuilder();
     for (String line : Files.readAllLines(dataFile.toPath(), StandardCharsets.UTF_8)) {
       contentBuilder.append(line);
     }
     String reconstructed = contentBuilder.toString();
-    Assert.assertEquals("Should match written file content", FILE_CONTENT, reconstructed);
+    assertThat(reconstructed).as("Should match written file content").isEqualTo(FILE_CONTENT);
 
     HadoopOutputFile.getBlockFileSystems().remove("file");
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadByteStreamSplit.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadByteStreamSplit.java
@@ -19,10 +19,7 @@
 
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import org.apache.hadoop.fs.Path;
@@ -46,32 +43,32 @@ public class TestInterOpReadByteStreamSplit {
         ParquetReader.builder(new GroupReadSupport(), floatsFile).build()) {
       for (int i = 0; i < expectRows; ++i) {
         Group group = reader.read();
-        assertNotNull(group);
+        assertThat(group).isNotNull();
         float fval = group.getFloat("f32", 0);
         double dval = group.getDouble("f64", 0);
         // Values are from the normal distribution
-        assertTrue(Math.abs(fval) < 4.0);
-        assertTrue(Math.abs(dval) < 4.0);
+        assertThat(Math.abs(fval)).isLessThan(4.0f);
+        assertThat(Math.abs(dval)).isLessThan(4.0);
         switch (i) {
           case 0:
-            assertEquals(1.7640524f, fval, 0.0);
-            assertEquals(-1.3065268517353166, dval, 0.0);
+            assertThat(fval).isEqualTo(1.7640524f);
+            assertThat(dval).isEqualTo(-1.3065268517353166);
             break;
           case 1:
-            assertEquals(0.4001572f, fval, 0.0);
-            assertEquals(1.658130679618188, dval, 0.0);
+            assertThat(fval).isEqualTo(0.4001572f);
+            assertThat(dval).isEqualTo(1.658130679618188);
             break;
           case expectRows - 2:
-            assertEquals(-0.39944902f, fval, 0.0);
-            assertEquals(-0.9301565025243212, dval, 0.0);
+            assertThat(fval).isEqualTo(-0.39944902f);
+            assertThat(dval).isEqualTo(-0.9301565025243212);
             break;
           case expectRows - 1:
-            assertEquals(0.37005588f, fval, 0.0);
-            assertEquals(-0.17858909208732915, dval, 0.0);
+            assertThat(fval).isEqualTo(0.37005588f);
+            assertThat(dval).isEqualTo(-0.17858909208732915);
             break;
         }
       }
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -80,12 +77,12 @@ public class TestInterOpReadByteStreamSplit {
         ParquetReader.builder(new GroupReadSupport(), path).build()) {
       for (int i = 0; i < expectRows; ++i) {
         SimpleGroup group = (SimpleGroup) reader.read();
-        assertNotNull(group);
+        assertThat(group).isNotNull();
         Object left = group.getObject(leftCol, 0);
         Object right = group.getObject(rightCol, 0);
-        assertEquals(left, right);
+        assertThat(right).isEqualTo(left);
       }
-      assertNull(reader.read());
+      assertThat(reader.read()).isNull();
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadFloat16.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadFloat16.java
@@ -19,9 +19,7 @@
 
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
@@ -61,25 +59,24 @@ public class TestInterOpReadFloat16 {
       ColumnChunkMetaData column =
           reader.getFooter().getBlocks().get(0).getColumns().get(0);
 
-      assertArrayEquals(
-          new byte[] {0x00, (byte) 0xc0}, column.getStatistics().getMinBytes());
+      assertThat(column.getStatistics().getMinBytes()).isEqualTo(new byte[] {0x00, (byte) 0xc0});
       // 0x40 equals @ in ASCII
-      assertArrayEquals(new byte[] {0x00, 0x40}, column.getStatistics().getMaxBytes());
+      assertThat(column.getStatistics().getMaxBytes()).isEqualTo(new byte[] {0x00, (byte) 0x40});
     }
 
     try (ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), filePath).build()) {
       for (int i = 0; i < expectRows; ++i) {
         Group group = reader.read();
-        if (group == null) {
-          fail("Should not reach end of file before " + expectRows + " rows");
-        }
+        assertThat(group)
+            .as("Should not reach end of file before " + expectRows + " rows")
+            .isNotNull();
         if (group.getFieldRepetitionCount(0) != 0) {
           // Check if the field is not null
-          assertEquals(c0ExpectValues[i], group.getBinary(0, 0));
+          assertThat(group.getBinary(0, 0)).isEqualTo(c0ExpectValues[i]);
         } else {
           // Check if the field is null
-          assertEquals(0, i);
+          assertThat(i).isEqualTo(0);
         }
       }
     }
@@ -101,24 +98,23 @@ public class TestInterOpReadFloat16 {
       ColumnChunkMetaData column =
           reader.getFooter().getBlocks().get(0).getColumns().get(0);
 
-      assertArrayEquals(
-          new byte[] {0x00, (byte) 0x80}, column.getStatistics().getMinBytes());
-      assertArrayEquals(new byte[] {0x00, 0x00}, column.getStatistics().getMaxBytes());
+      assertThat(column.getStatistics().getMinBytes()).isEqualTo(new byte[] {0x00, (byte) 0x80});
+      assertThat(column.getStatistics().getMaxBytes()).isEqualTo(new byte[] {0x00, 0x00});
     }
 
     try (ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), filePath).build()) {
       for (int i = 0; i < expectRows; ++i) {
         Group group = reader.read();
-        if (group == null) {
-          fail("Should not reach end of file before " + expectRows + " rows");
-        }
+        assertThat(group)
+            .as("Should not reach end of file before " + expectRows + " rows")
+            .isNotNull();
         if (group.getFieldRepetitionCount(0) != 0) {
           // Check if the field is not null
-          assertEquals(c0ExpectValues[i], group.getBinary(0, 0));
+          assertThat(group.getBinary(0, 0)).isEqualTo(c0ExpectValues[i]);
         } else {
           // Check if the field is null
-          assertEquals(0, i);
+          assertThat(i).isEqualTo(0);
         }
       }
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadFloatingPointNanCount.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInterOpReadFloatingPointNanCount.java
@@ -19,10 +19,7 @@
 
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -112,7 +109,7 @@ public class TestInterOpReadFloatingPointNanCount {
             .withConf(conf)
             .build()) {
       List<BlockMetaData> blocks = reader.getFooter().getBlocks();
-      assertEquals(scenarios.length, blocks.size());
+      assertThat(blocks).hasSameSizeAs(scenarios);
 
       // Verify read values
       int rowId = 0;
@@ -124,16 +121,16 @@ public class TestInterOpReadFloatingPointNanCount {
         assertDoubleValue(expectDoubles.get(rowId), group.getDouble("double_ieee754", 0));
         assertDoubleValue(expectDoubles.get(rowId), group.getDouble("double_typedef", 0));
 
-        assertEquals(expectFloat16s.get(rowId), group.getBinary("float16_ieee754", 0));
-        assertEquals(expectFloat16s.get(rowId), group.getBinary("float16_typedef", 0));
+        assertThat(group.getBinary("float16_ieee754", 0)).isEqualTo(expectFloat16s.get(rowId));
+        assertThat(group.getBinary("float16_typedef", 0)).isEqualTo(expectFloat16s.get(rowId));
         rowId++;
       }
-      assertEquals(10 * scenarios.length, rowId);
+      assertThat(rowId).isEqualTo(10 * scenarios.length);
 
       // Verify stats
       for (int rg = 0; rg < blocks.size(); rg++) {
         BlockMetaData block = blocks.get(rg);
-        assertEquals(10L, block.getRowCount());
+        assertThat(block.getRowCount()).isEqualTo(10L);
         for (ColumnChunkMetaData column : block.getColumns()) {
           verifyStats(scenarios[rg], column);
           verifyColumnIndex(reader, scenarios[rg], column);
@@ -145,7 +142,7 @@ public class TestInterOpReadFloatingPointNanCount {
   private static void verifyStats(Scenario scenario, ColumnChunkMetaData column) {
     String name = column.getPath().toDotString();
     Statistics<?> stats = column.getStatistics();
-    assertTrue(stats.isNanCountSet());
+    assertThat(stats.isNanCountSet()).isTrue();
 
     if (name.contains("float16")) {
       verifyFloat16Stats(scenario, name, (BinaryStatistics) stats);
@@ -158,111 +155,110 @@ public class TestInterOpReadFloatingPointNanCount {
 
   private static void verifyFloatStats(Scenario scenario, String name, FloatStatistics stats) {
     if (scenario == Scenario.NO_NAN) {
-      assertEquals(0L, stats.getNanCount());
-      assertEquals(-2f, stats.getMin(), 0f);
-      assertEquals(5f, stats.getMax(), 0f);
+      assertThat(stats.getNanCount()).isEqualTo(0L);
+      assertThat(stats.getMin()).isEqualTo(-2f);
+      assertThat(stats.getMax()).isEqualTo(5f);
       return;
     }
 
     if (scenario == Scenario.MIXED_NAN) {
-      assertEquals(4L, stats.getNanCount());
+      assertThat(stats.getNanCount()).isEqualTo(4L);
       if (isIeee(name)) {
-        assertEquals(-2f, stats.getMin(), 0f);
-        assertEquals(3f, stats.getMax(), 0f);
+        assertThat(stats.getMin()).isEqualTo(-2f);
+        assertThat(stats.getMax()).isEqualTo(3f);
       }
       return;
     }
 
     if (scenario == Scenario.ALL_NAN) {
-      assertEquals(10L, stats.getNanCount());
+      assertThat(stats.getNanCount()).isEqualTo(10L);
       if (isIeee(name)) {
-        assertEquals(0xffffffff, Float.floatToRawIntBits(stats.getMin()));
-        assertEquals(0x7fffffff, Float.floatToRawIntBits(stats.getMax()));
+        assertThat(Float.floatToRawIntBits(stats.getMin())).isEqualTo(0xffffffff);
+        assertThat(Float.floatToRawIntBits(stats.getMax())).isEqualTo(0x7fffffff);
       }
       return;
     }
 
     if (scenario == Scenario.ZERO_MIN) {
-      assertEquals(0L, stats.getNanCount());
-      assertEquals(isIeee(name) ? 0x00000000 : 0x80000000, Float.floatToRawIntBits(stats.getMin()));
-      assertEquals(5f, stats.getMax(), 0f);
+      assertThat(stats.getNanCount()).isEqualTo(0L);
+      assertThat(Float.floatToRawIntBits(stats.getMin())).isEqualTo(isIeee(name) ? 0x00000000 : 0x80000000);
+      assertThat(stats.getMax()).isEqualTo(5f);
       return;
     }
 
-    assertEquals(0L, stats.getNanCount());
-    assertEquals(-5f, stats.getMin(), 0f);
-    assertEquals(isIeee(name) ? 0x80000000 : 0x00000000, Float.floatToRawIntBits(stats.getMax()));
+    assertThat(stats.getNanCount()).isEqualTo(0L);
+    assertThat(stats.getMin()).isEqualTo(-5f);
+    assertThat(Float.floatToRawIntBits(stats.getMax())).isEqualTo(isIeee(name) ? 0x80000000 : 0x00000000);
   }
 
   private static void verifyDoubleStats(Scenario scenario, String name, DoubleStatistics stats) {
     if (scenario == Scenario.NO_NAN) {
-      assertEquals(0L, stats.getNanCount());
-      assertEquals(-2d, stats.getMin(), 0d);
-      assertEquals(5d, stats.getMax(), 0d);
+      assertThat(stats.getNanCount()).isEqualTo(0L);
+      assertThat(stats.getMin()).isEqualTo(-2d);
+      assertThat(stats.getMax()).isEqualTo(5d);
       return;
     }
 
     if (scenario == Scenario.MIXED_NAN) {
-      assertEquals(4L, stats.getNanCount());
+      assertThat(stats.getNanCount()).isEqualTo(4L);
       if (isIeee(name)) {
-        assertEquals(-2d, stats.getMin(), 0d);
-        assertEquals(3d, stats.getMax(), 0d);
+        assertThat(stats.getMin()).isEqualTo(-2d);
+        assertThat(stats.getMax()).isEqualTo(3d);
       }
       return;
     }
 
     if (scenario == Scenario.ALL_NAN) {
-      assertEquals(10L, stats.getNanCount());
+      assertThat(stats.getNanCount()).isEqualTo(10L);
       if (isIeee(name)) {
-        assertEquals(0xffffffffffffffffL, Double.doubleToRawLongBits(stats.getMin()));
-        assertEquals(0x7fffffffffffffffL, Double.doubleToRawLongBits(stats.getMax()));
+        assertThat(Double.doubleToRawLongBits(stats.getMin())).isEqualTo(0xffffffffffffffffL);
+        assertThat(Double.doubleToRawLongBits(stats.getMax())).isEqualTo(0x7fffffffffffffffL);
       }
       return;
     }
 
     if (scenario == Scenario.ZERO_MIN) {
-      assertEquals(0L, stats.getNanCount());
-      assertEquals(
-          isIeee(name) ? 0x0000000000000000L : 0x8000000000000000L,
-          Double.doubleToRawLongBits(stats.getMin()));
-      assertEquals(5d, stats.getMax(), 0d);
+      assertThat(stats.getNanCount()).isEqualTo(0L);
+      assertThat(Double.doubleToRawLongBits(stats.getMin()))
+          .isEqualTo(isIeee(name) ? 0x0000000000000000L : 0x8000000000000000L);
+      assertThat(stats.getMax()).isEqualTo(5d);
       return;
     }
 
-    assertEquals(0L, stats.getNanCount());
-    assertEquals(-5d, stats.getMin(), 0d);
-    assertEquals(
-        isIeee(name) ? 0x8000000000000000L : 0x0000000000000000L, Double.doubleToRawLongBits(stats.getMax()));
+    assertThat(stats.getNanCount()).isEqualTo(0L);
+    assertThat(stats.getMin()).isEqualTo(-5d);
+    assertThat(Double.doubleToRawLongBits(stats.getMax()))
+        .isEqualTo(isIeee(name) ? 0x8000000000000000L : 0x0000000000000000L);
   }
 
   private static void verifyFloat16Stats(Scenario scenario, String name, BinaryStatistics stats) {
     if (scenario == Scenario.NO_NAN) {
       short min = stats.genericGetMin().get2BytesLittleEndian();
       short max = stats.genericGetMax().get2BytesLittleEndian();
-      assertEquals(0L, stats.getNanCount());
-      assertEquals((short) 0xc000, min);
-      assertEquals((short) 0x4500, max);
+      assertThat(stats.getNanCount()).isEqualTo(0L);
+      assertThat(min).isEqualTo((short) 0xc000);
+      assertThat(max).isEqualTo((short) 0x4500);
       return;
     }
 
     if (scenario == Scenario.MIXED_NAN) {
-      assertEquals(4L, stats.getNanCount());
+      assertThat(stats.getNanCount()).isEqualTo(4L);
       if (isIeee(name)) {
         short min = stats.genericGetMin().get2BytesLittleEndian();
         short max = stats.genericGetMax().get2BytesLittleEndian();
-        assertEquals((short) 0xc000, min);
-        assertEquals((short) 0x4200, max);
+        assertThat(min).isEqualTo((short) 0xc000);
+        assertThat(max).isEqualTo((short) 0x4200);
       }
       return;
     }
 
     if (scenario == Scenario.ALL_NAN) {
-      assertEquals(10L, stats.getNanCount());
+      assertThat(stats.getNanCount()).isEqualTo(10L);
       if (isIeee(name)) {
         short min = stats.genericGetMin().get2BytesLittleEndian();
         short max = stats.genericGetMax().get2BytesLittleEndian();
-        assertEquals((short) 0xffff, min);
-        assertEquals((short) 0x7fff, max);
+        assertThat(min).isEqualTo((short) 0xffff);
+        assertThat(max).isEqualTo((short) 0x7fff);
       }
       return;
     }
@@ -270,23 +266,23 @@ public class TestInterOpReadFloatingPointNanCount {
     if (scenario == Scenario.ZERO_MIN) {
       short min = stats.genericGetMin().get2BytesLittleEndian();
       short max = stats.genericGetMax().get2BytesLittleEndian();
-      assertEquals(0L, stats.getNanCount());
-      assertEquals((short) (isIeee(name) ? 0x0000 : 0x8000), min);
-      assertEquals((short) 0x4500, max);
+      assertThat(stats.getNanCount()).isEqualTo(0L);
+      assertThat(min).isEqualTo((short) (isIeee(name) ? 0x0000 : 0x8000));
+      assertThat(max).isEqualTo((short) 0x4500);
       return;
     }
 
-    assertEquals(0L, stats.getNanCount());
+    assertThat(stats.getNanCount()).isEqualTo(0L);
     if (isIeee(name)) {
       short min = stats.genericGetMin().get2BytesLittleEndian();
       short max = stats.genericGetMax().get2BytesLittleEndian();
-      assertEquals((short) 0xc500, min);
-      assertEquals((short) 0x8000, max);
+      assertThat(min).isEqualTo((short) 0xc500);
+      assertThat(max).isEqualTo((short) 0x8000);
     } else {
       short min = stats.genericGetMin().get2BytesLittleEndian();
       short max = stats.genericGetMax().get2BytesLittleEndian();
-      assertEquals((short) 0xc500, min);
-      assertEquals((short) 0x0000, max);
+      assertThat(min).isEqualTo((short) 0xc500);
+      assertThat(max).isEqualTo((short) 0x0000);
     }
   }
 
@@ -299,18 +295,17 @@ public class TestInterOpReadFloatingPointNanCount {
     ColumnIndex columnIndex = reader.readColumnIndex(column);
     if (!ieee && hasNaN) {
       // TypeDefinedOrder + NaN => page index is intentionally invalidated.
-      assertNull(columnIndex);
+      assertThat(columnIndex).isNull();
       return;
     }
 
-    assertNotNull(columnIndex);
-    assertNotNull(columnIndex.getNanCounts());
-    assertEquals(1, columnIndex.getNanCounts().size());
-    assertEquals(
-        expectedNanCount(scenario), (long) columnIndex.getNanCounts().get(0));
+    assertThat(columnIndex).isNotNull();
+    assertThat(columnIndex.getNanCounts()).isNotNull();
+    assertThat(columnIndex.getNanCounts()).hasSize(1);
+    assertThat((long) columnIndex.getNanCounts().get(0)).isEqualTo(expectedNanCount(scenario));
 
-    assertEquals(1, columnIndex.getMinValues().size());
-    assertEquals(1, columnIndex.getMaxValues().size());
+    assertThat(columnIndex.getMinValues()).hasSize(1);
+    assertThat(columnIndex.getMaxValues()).hasSize(1);
     ByteBuffer min = columnIndex.getMinValues().get(0).order(ByteOrder.LITTLE_ENDIAN);
     ByteBuffer max = columnIndex.getMaxValues().get(0).order(ByteOrder.LITTLE_ENDIAN);
 
@@ -342,17 +337,17 @@ public class TestInterOpReadFloatingPointNanCount {
     short minV = min.getShort(0);
     short maxV = max.getShort(0);
     if (scenario == Scenario.ALL_NAN) {
-      assertEquals((short) 0xffff, minV);
-      assertEquals((short) 0x7fff, maxV);
+      assertThat(minV).isEqualTo((short) 0xffff);
+      assertThat(maxV).isEqualTo((short) 0x7fff);
     } else if (scenario == Scenario.MIXED_NAN || scenario == Scenario.NO_NAN) {
-      assertEquals((short) 0xc000, minV);
-      assertEquals((short) (scenario == Scenario.MIXED_NAN ? 0x4200 : 0x4500), maxV);
+      assertThat(minV).isEqualTo((short) 0xc000);
+      assertThat(maxV).isEqualTo((short) (scenario == Scenario.MIXED_NAN ? 0x4200 : 0x4500));
     } else if (scenario == Scenario.ZERO_MIN) {
-      assertEquals((short) (ieee ? 0x0000 : 0x8000), minV);
-      assertEquals((short) 0x4500, maxV);
+      assertThat(minV).isEqualTo((short) (ieee ? 0x0000 : 0x8000));
+      assertThat(maxV).isEqualTo((short) 0x4500);
     } else {
-      assertEquals((short) 0xc500, minV);
-      assertEquals((short) (ieee ? 0x8000 : 0x0000), maxV);
+      assertThat(minV).isEqualTo((short) 0xc500);
+      assertThat(maxV).isEqualTo((short) (ieee ? 0x8000 : 0x0000));
     }
   }
 
@@ -360,17 +355,17 @@ public class TestInterOpReadFloatingPointNanCount {
     long minV = min.getLong(0);
     long maxV = max.getLong(0);
     if (scenario == Scenario.ALL_NAN) {
-      assertEquals(0xffffffffffffffffL, minV);
-      assertEquals(0x7fffffffffffffffL, maxV);
+      assertThat(minV).isEqualTo(0xffffffffffffffffL);
+      assertThat(maxV).isEqualTo(0x7fffffffffffffffL);
     } else if (scenario == Scenario.MIXED_NAN || scenario == Scenario.NO_NAN) {
-      assertEquals(Double.doubleToRawLongBits(-2d), minV);
-      assertEquals(Double.doubleToRawLongBits(scenario == Scenario.MIXED_NAN ? 3d : 5d), maxV);
+      assertThat(minV).isEqualTo(Double.doubleToRawLongBits(-2d));
+      assertThat(maxV).isEqualTo(Double.doubleToRawLongBits(scenario == Scenario.MIXED_NAN ? 3d : 5d));
     } else if (scenario == Scenario.ZERO_MIN) {
-      assertEquals(Double.doubleToRawLongBits(ieee ? 0d : -0d), minV);
-      assertEquals(Double.doubleToRawLongBits(5d), maxV);
+      assertThat(minV).isEqualTo(Double.doubleToRawLongBits(ieee ? 0d : -0d));
+      assertThat(maxV).isEqualTo(Double.doubleToRawLongBits(5d));
     } else {
-      assertEquals(Double.doubleToRawLongBits(-5d), minV);
-      assertEquals(Double.doubleToRawLongBits(ieee ? -0d : 0d), maxV);
+      assertThat(minV).isEqualTo(Double.doubleToRawLongBits(-5d));
+      assertThat(maxV).isEqualTo(Double.doubleToRawLongBits(ieee ? -0d : 0d));
     }
   }
 
@@ -378,17 +373,17 @@ public class TestInterOpReadFloatingPointNanCount {
     int minV = min.getInt(0);
     int maxV = max.getInt(0);
     if (scenario == Scenario.ALL_NAN) {
-      assertEquals(0xffffffff, minV);
-      assertEquals(0x7fffffff, maxV);
+      assertThat(minV).isEqualTo(0xffffffff);
+      assertThat(maxV).isEqualTo(0x7fffffff);
     } else if (scenario == Scenario.MIXED_NAN || scenario == Scenario.NO_NAN) {
-      assertEquals(Float.floatToRawIntBits(-2f), minV);
-      assertEquals(Float.floatToRawIntBits(scenario == Scenario.MIXED_NAN ? 3f : 5f), maxV);
+      assertThat(minV).isEqualTo(Float.floatToRawIntBits(-2f));
+      assertThat(maxV).isEqualTo(Float.floatToRawIntBits(scenario == Scenario.MIXED_NAN ? 3f : 5f));
     } else if (scenario == Scenario.ZERO_MIN) {
-      assertEquals(Float.floatToRawIntBits(ieee ? 0f : -0f), minV);
-      assertEquals(Float.floatToRawIntBits(5f), maxV);
+      assertThat(minV).isEqualTo(Float.floatToRawIntBits(ieee ? 0f : -0f));
+      assertThat(maxV).isEqualTo(Float.floatToRawIntBits(5f));
     } else {
-      assertEquals(Float.floatToRawIntBits(-5f), minV);
-      assertEquals(Float.floatToRawIntBits(ieee ? -0f : 0f), maxV);
+      assertThat(minV).isEqualTo(Float.floatToRawIntBits(-5f));
+      assertThat(maxV).isEqualTo(Float.floatToRawIntBits(ieee ? -0f : 0f));
     }
   }
 
@@ -397,11 +392,11 @@ public class TestInterOpReadFloatingPointNanCount {
   }
 
   private static void assertFloatValue(float expected, float actual) {
-    assertEquals(Float.floatToRawIntBits(expected), Float.floatToRawIntBits(actual));
+    assertThat(Float.floatToRawIntBits(actual)).isEqualTo(Float.floatToRawIntBits(expected));
   }
 
   private static void assertDoubleValue(double expected, double actual) {
-    assertEquals(Double.doubleToRawLongBits(expected), Double.doubleToRawLongBits(actual));
+    assertThat(Double.doubleToRawLongBits(actual)).isEqualTo(Double.doubleToRawLongBits(expected));
   }
 
   private static List<Float> concatFloatValues(Scenario... scenarios) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInteropBloomFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestInteropBloomFilter.java
@@ -19,10 +19,8 @@
 
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.io.IOException;
 import java.util.List;
@@ -41,7 +39,6 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,10 +87,8 @@ public class TestInteropBloomFilter {
         ParquetReader.builder(new GroupReadSupport(), filePath).build()) {
       for (int i = 0; i < expectedRowCount; ++i) {
         Group group = reader.read();
-        if (group == null) {
-          fail("Should not reach end of file");
-        }
-        assertEquals(expectedValues[i], group.getString(0, 0));
+        assertThat(group).as("Should not reach end of file").isNotNull();
+        assertThat(group.getString(0, 0)).isEqualTo(expectedValues[i]);
       }
     }
 
@@ -101,30 +96,29 @@ public class TestInteropBloomFilter {
         HadoopInputFile.fromPath(filePath, new Configuration()),
         ParquetReadOptions.builder().build());
     List<BlockMetaData> blocks = reader.getRowGroups();
-    blocks.forEach(block -> {
-      try {
-        assertEquals(14, block.getRowCount());
-        ColumnChunkMetaData idMeta = block.getColumns().get(0);
-        BloomFilter bloomFilter = reader.readBloomFilter(idMeta);
-        Assert.assertNotNull(bloomFilter);
-        assertEquals(192, idMeta.getBloomFilterOffset());
-        assertEquals(-1, idMeta.getBloomFilterLength());
-        for (int i = 0; i < expectedRowCount; ++i) {
-          assertTrue(bloomFilter.findHash(bloomFilter.hash(Binary.fromString(expectedValues[i]))));
-        }
-        for (int i = 0; i < unexpectedValues.length; ++i) {
-          assertFalse(bloomFilter.findHash(bloomFilter.hash(Binary.fromString(unexpectedValues[i]))));
-        }
-        assertEquals(152, idMeta.getTotalSize());
-        assertEquals(163, idMeta.getTotalUncompressedSize());
-        assertEquals(181, idMeta.getOffsetIndexReference().getOffset());
-        assertEquals(11, idMeta.getOffsetIndexReference().getLength());
-        assertEquals(156, idMeta.getColumnIndexReference().getOffset());
-        assertEquals(25, idMeta.getColumnIndexReference().getLength());
-      } catch (IOException e) {
-        fail("Should not throw exception: " + e.getMessage());
-      }
-    });
+    blocks.forEach(block -> assertThatCode(() -> {
+          assertThat(block.getRowCount()).isEqualTo(14);
+          ColumnChunkMetaData idMeta = block.getColumns().get(0);
+          BloomFilter bloomFilter = reader.readBloomFilter(idMeta);
+          assertThat(bloomFilter).isNotNull();
+          assertThat(idMeta.getBloomFilterOffset()).isEqualTo(192);
+          assertThat(idMeta.getBloomFilterLength()).isEqualTo(-1);
+          for (int i = 0; i < expectedRowCount; ++i) {
+            assertThat(bloomFilter.findHash(bloomFilter.hash(Binary.fromString(expectedValues[i]))))
+                .isTrue();
+          }
+          for (int i = 0; i < unexpectedValues.length; ++i) {
+            assertThat(bloomFilter.findHash(bloomFilter.hash(Binary.fromString(unexpectedValues[i]))))
+                .isFalse();
+          }
+          assertThat(idMeta.getTotalSize()).isEqualTo(152);
+          assertThat(idMeta.getTotalUncompressedSize()).isEqualTo(163);
+          assertThat(idMeta.getOffsetIndexReference().getOffset()).isEqualTo(181);
+          assertThat(idMeta.getOffsetIndexReference().getLength()).isEqualTo(11);
+          assertThat(idMeta.getColumnIndexReference().getOffset()).isEqualTo(156);
+          assertThat(idMeta.getColumnIndexReference().getLength()).isEqualTo(25);
+        })
+        .doesNotThrowAnyException());
   }
 
   @Test
@@ -158,10 +152,8 @@ public class TestInteropBloomFilter {
         ParquetReader.builder(new GroupReadSupport(), filePath).build()) {
       for (int i = 0; i < expectedRowCount; ++i) {
         Group group = reader.read();
-        if (group == null) {
-          fail("Should not reach end of file");
-        }
-        assertEquals(expectedValues[i], group.getString(0, 0));
+        assertThat(group).as("Should not reach end of file").isNotNull();
+        assertThat(group.getString(0, 0)).isEqualTo(expectedValues[i]);
       }
     }
 
@@ -169,30 +161,29 @@ public class TestInteropBloomFilter {
         HadoopInputFile.fromPath(filePath, new Configuration()),
         ParquetReadOptions.builder().build());
     List<BlockMetaData> blocks = reader.getRowGroups();
-    blocks.forEach(block -> {
-      try {
-        assertEquals(14, block.getRowCount());
-        ColumnChunkMetaData idMeta = block.getColumns().get(0);
-        BloomFilter bloomFilter = reader.readBloomFilter(idMeta);
-        Assert.assertNotNull(bloomFilter);
-        assertEquals(253, idMeta.getBloomFilterOffset());
-        assertEquals(2064, idMeta.getBloomFilterLength());
-        for (int i = 0; i < expectedRowCount; ++i) {
-          assertTrue(bloomFilter.findHash(bloomFilter.hash(Binary.fromString(expectedValues[i]))));
-        }
-        for (int i = 0; i < unexpectedValues.length; ++i) {
-          assertFalse(bloomFilter.findHash(bloomFilter.hash(Binary.fromString(unexpectedValues[i]))));
-        }
-        assertEquals(199, idMeta.getTotalSize());
-        assertEquals(199, idMeta.getTotalUncompressedSize());
-        assertEquals(2342, idMeta.getOffsetIndexReference().getOffset());
-        assertEquals(11, idMeta.getOffsetIndexReference().getLength());
-        assertEquals(2317, idMeta.getColumnIndexReference().getOffset());
-        assertEquals(25, idMeta.getColumnIndexReference().getLength());
-      } catch (Exception e) {
-        fail("Should not throw exception: " + e.getMessage());
-      }
-    });
+    blocks.forEach(block -> assertThatCode(() -> {
+          assertThat(block.getRowCount()).isEqualTo(14);
+          ColumnChunkMetaData idMeta = block.getColumns().get(0);
+          BloomFilter bloomFilter = reader.readBloomFilter(idMeta);
+          assertThat(bloomFilter).isNotNull();
+          assertThat(idMeta.getBloomFilterOffset()).isEqualTo(253);
+          assertThat(idMeta.getBloomFilterLength()).isEqualTo(2064);
+          for (int i = 0; i < expectedRowCount; ++i) {
+            assertThat(bloomFilter.findHash(bloomFilter.hash(Binary.fromString(expectedValues[i]))))
+                .isTrue();
+          }
+          for (int i = 0; i < unexpectedValues.length; ++i) {
+            assertThat(bloomFilter.findHash(bloomFilter.hash(Binary.fromString(unexpectedValues[i]))))
+                .isFalse();
+          }
+          assertThat(idMeta.getTotalSize()).isEqualTo(199);
+          assertThat(idMeta.getTotalUncompressedSize()).isEqualTo(199);
+          assertThat(idMeta.getOffsetIndexReference().getOffset()).isEqualTo(2342);
+          assertThat(idMeta.getOffsetIndexReference().getLength()).isEqualTo(11);
+          assertThat(idMeta.getColumnIndexReference().getOffset()).isEqualTo(2317);
+          assertThat(idMeta.getColumnIndexReference().getLength()).isEqualTo(25);
+        })
+        .doesNotThrowAnyException());
   }
 
   private Path downloadInterOpFiles(Path rootPath, String fileName, OkHttpClient httpClient) throws IOException {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestLargeColumnChunk.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestLargeColumnChunk.java
@@ -27,8 +27,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Types.buildMessage;
 import static org.apache.parquet.schema.Types.required;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Random;
@@ -119,10 +118,10 @@ public class TestLargeColumnChunk {
         ParquetReader.builder(new GroupReadSupport(), file).build()) {
       for (long id = 0; id < ROW_COUNT; ++id) {
         Group group = reader.read();
-        assertEquals(id, group.getLong(ID_INDEX, 0));
-        assertEquals(nextBinary(random), group.getBinary(DATA_INDEX, 0));
+        assertThat(group.getLong(ID_INDEX, 0)).isEqualTo(id);
+        assertThat(group.getBinary(DATA_INDEX, 0)).isEqualTo(nextBinary(random));
       }
-      assertNull("No more record should be read", reader.read());
+      assertThat(reader.read()).as("No more record should be read").isNull();
     }
   }
 
@@ -132,14 +131,14 @@ public class TestLargeColumnChunk {
         .withFilter(FilterCompat.get(eq(binaryColumn("data"), VALUE_IN_DATA)))
         .build()) {
       Group group = reader.read();
-      assertEquals(ID_OF_FILTERED_DATA, group.getLong(ID_INDEX, 0));
-      assertEquals(VALUE_IN_DATA, group.getBinary(DATA_INDEX, 0));
-      assertNull("No more record should be read", reader.read());
+      assertThat(group.getLong(ID_INDEX, 0)).isEqualTo(ID_OF_FILTERED_DATA);
+      assertThat(group.getBinary(DATA_INDEX, 0)).isEqualTo(VALUE_IN_DATA);
+      assertThat(reader.read()).as("No more record should be read").isNull();
     }
     try (ParquetReader<Group> reader = ParquetReader.builder(new GroupReadSupport(), file)
         .withFilter(FilterCompat.get(eq(binaryColumn("data"), VALUE_NOT_IN_DATA)))
         .build()) {
-      assertNull("No record should be read", reader.read());
+      assertThat(reader.read()).as("No record should be read").isNull();
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestLruCache.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestLruCache.java
@@ -18,8 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
@@ -59,14 +58,14 @@ public class TestLruCache {
 
     SimpleValue oldValue = new SimpleValue(true, true);
     cache.put(oldKey, oldValue);
-    assertEquals(oldValue, cache.getCurrentValue(oldKey));
-    assertEquals(1, cache.size());
+    assertThat(cache.getCurrentValue(oldKey)).isEqualTo(oldValue);
+    assertThat(cache.size()).isOne();
 
     SimpleValue newValue = new SimpleValue(true, true);
     cache.put(newKey, newValue);
-    assertNull(cache.getCurrentValue(oldKey));
-    assertEquals(newValue, cache.getCurrentValue(newKey));
-    assertEquals(1, cache.size());
+    assertThat(cache.getCurrentValue(oldKey)).isNull();
+    assertThat(cache.getCurrentValue(newKey)).isEqualTo(newValue);
+    assertThat(cache.size()).isOne();
   }
 
   @Test
@@ -77,8 +76,9 @@ public class TestLruCache {
     SimpleValue notAsCurrentValue = new SimpleValue(true, false);
     cache.put(DEFAULT_KEY, currentValue);
     cache.put(DEFAULT_KEY, notAsCurrentValue);
-    assertEquals(
-        "The existing value in the cache was overwritten", currentValue, cache.getCurrentValue(DEFAULT_KEY));
+    assertThat(cache.getCurrentValue(DEFAULT_KEY))
+        .as("The existing value in the cache was overwritten")
+        .isEqualTo(currentValue);
   }
 
   @Test
@@ -87,8 +87,8 @@ public class TestLruCache {
 
     SimpleValue outdatedValue = new SimpleValue(false, true);
     cache.put(DEFAULT_KEY, outdatedValue);
-    assertEquals(0, cache.size());
-    assertNull(cache.getCurrentValue(DEFAULT_KEY));
+    assertThat(cache.size()).isZero();
+    assertThat(cache.getCurrentValue(DEFAULT_KEY)).isNull();
   }
 
   @Test
@@ -98,13 +98,12 @@ public class TestLruCache {
     SimpleValue currentValue = new SimpleValue(true, true);
     SimpleValue notAsCurrentValue = new SimpleValue(true, false);
     cache.put(DEFAULT_KEY, notAsCurrentValue);
-    assertEquals(1, cache.size());
+    assertThat(cache.size()).isOne();
     cache.put(DEFAULT_KEY, currentValue);
-    assertEquals(1, cache.size());
-    assertEquals(
-        "The existing value in the cache was NOT overwritten",
-        currentValue,
-        cache.getCurrentValue(DEFAULT_KEY));
+    assertThat(cache.size()).isOne();
+    assertThat(cache.getCurrentValue(DEFAULT_KEY))
+        .as("The existing value in the cache was NOT overwritten")
+        .isEqualTo(currentValue);
   }
 
   @Test
@@ -113,12 +112,14 @@ public class TestLruCache {
 
     SimpleValue value = new SimpleValue(true, true);
     cache.put(DEFAULT_KEY, value);
-    assertEquals(1, cache.size());
-    assertEquals(value, cache.getCurrentValue(DEFAULT_KEY));
+    assertThat(cache.size()).isOne();
+    assertThat(cache.getCurrentValue(DEFAULT_KEY)).isEqualTo(value);
 
     value.setCurrent(false);
-    assertNull("The value should not be current anymore", cache.getCurrentValue(DEFAULT_KEY));
-    assertEquals(0, cache.size());
+    assertThat(cache.getCurrentValue(DEFAULT_KEY))
+        .as("The value should not be current anymore")
+        .isNull();
+    assertThat(cache.size()).isZero();
   }
 
   @Test
@@ -127,13 +128,13 @@ public class TestLruCache {
 
     SimpleValue value = new SimpleValue(true, true);
     cache.put(DEFAULT_KEY, value);
-    assertEquals(1, cache.size());
-    assertEquals(value, cache.getCurrentValue(DEFAULT_KEY));
+    assertThat(cache.size()).isOne();
+    assertThat(cache.getCurrentValue(DEFAULT_KEY)).isEqualTo(value);
 
     // remove the only value
-    assertEquals(value, cache.remove(DEFAULT_KEY));
-    assertNull(cache.getCurrentValue(DEFAULT_KEY));
-    assertEquals(0, cache.size());
+    assertThat(cache.remove(DEFAULT_KEY)).isEqualTo(value);
+    assertThat(cache.getCurrentValue(DEFAULT_KEY)).isNull();
+    assertThat(cache.size()).isZero();
   }
 
   @Test
@@ -145,13 +146,13 @@ public class TestLruCache {
     SimpleValue value = new SimpleValue(true, true);
     cache.put(key1, value);
     cache.put(key2, value);
-    assertEquals(value, cache.getCurrentValue(key1));
-    assertEquals(value, cache.getCurrentValue(key2));
-    assertEquals(2, cache.size());
+    assertThat(cache.getCurrentValue(key1)).isEqualTo(value);
+    assertThat(cache.getCurrentValue(key2)).isEqualTo(value);
+    assertThat(cache.size()).isEqualTo(2);
 
     cache.clear();
-    assertNull(cache.getCurrentValue(key1));
-    assertNull(cache.getCurrentValue(key2));
-    assertEquals(0, cache.size());
+    assertThat(cache.getCurrentValue(key1)).isNull();
+    assertThat(cache.getCurrentValue(key2)).isNull();
+    assertThat(cache.size()).isZero();
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMemoryManager.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMemoryManager.java
@@ -18,6 +18,9 @@
  */
 package org.apache.parquet.hadoop;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.util.Set;
@@ -27,7 +30,6 @@ import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,10 +68,10 @@ public class TestMemoryManager {
     // this value tends to change a little between setup and tests, so this
     // validates that it is within 15% of the expected value
     long poolSize = ParquetOutputFormat.getMemoryManager().getTotalMemoryPool();
-    Assert.assertTrue(
-        "Pool size should be within 15% of the expected value" + " (expected = " + expectedPoolSize
-            + " actual = " + poolSize + ")",
-        Math.abs(expectedPoolSize - poolSize) < (long) (expectedPoolSize * 0.15));
+    assertThat(Math.abs(expectedPoolSize - poolSize))
+        .as("Pool size should be within 15% of the expected value" + " (expected = " + expectedPoolSize
+            + " actual = " + poolSize + ")")
+        .isLessThan((long) (expectedPoolSize * 0.15));
   }
 
   @Test
@@ -78,35 +80,52 @@ public class TestMemoryManager {
     long rowGroupSize = poolSize / 2;
     conf.setLong(ParquetOutputFormat.BLOCK_SIZE, rowGroupSize);
 
-    Assert.assertTrue("Pool should hold 2 full row groups", (2 * rowGroupSize) <= poolSize);
-    Assert.assertTrue("Pool should not hold 3 full row groups", poolSize < (3 * rowGroupSize));
+    assertThat(2 * rowGroupSize).as("Pool should hold 2 full row groups").isLessThanOrEqualTo(poolSize);
+    assertThat(poolSize).as("Pool should not hold 3 full row groups").isLessThan(3 * rowGroupSize);
 
-    Assert.assertEquals("Allocations should start out at 0", 0, getTotalAllocation());
+    assertThat(getTotalAllocation()).as("Allocations should start out at 0").isEqualTo(0);
 
     RecordWriter writer1 = createWriter(1);
-    Assert.assertTrue("Allocations should never exceed pool size", getTotalAllocation() <= poolSize);
-    Assert.assertEquals("First writer should be limited by row group size", rowGroupSize, getTotalAllocation());
+    assertThat(getTotalAllocation())
+        .as("Allocations should never exceed pool size")
+        .isLessThanOrEqualTo(poolSize);
+    assertThat(getTotalAllocation())
+        .as("First writer should be limited by row group size")
+        .isEqualTo(rowGroupSize);
 
     RecordWriter writer2 = createWriter(2);
-    Assert.assertTrue("Allocations should never exceed pool size", getTotalAllocation() <= poolSize);
-    Assert.assertEquals(
-        "Second writer should be limited by row group size", 2 * rowGroupSize, getTotalAllocation());
+    assertThat(getTotalAllocation())
+        .as("Allocations should never exceed pool size")
+        .isLessThanOrEqualTo(poolSize);
+    assertThat(getTotalAllocation())
+        .as("Second writer should be limited by row group size")
+        .isEqualTo(2 * rowGroupSize);
 
     RecordWriter writer3 = createWriter(3);
-    Assert.assertTrue("Allocations should never exceed pool size", getTotalAllocation() <= poolSize);
+    assertThat(getTotalAllocation())
+        .as("Allocations should never exceed pool size")
+        .isLessThanOrEqualTo(poolSize);
 
     writer1.close(null);
-    Assert.assertTrue("Allocations should never exceed pool size", getTotalAllocation() <= poolSize);
-    Assert.assertEquals(
-        "Allocations should be increased to the row group size", 2 * rowGroupSize, getTotalAllocation());
+    assertThat(getTotalAllocation())
+        .as("Allocations should never exceed pool size")
+        .isLessThanOrEqualTo(poolSize);
+    assertThat(getTotalAllocation())
+        .as("Allocations should be increased to the row group size")
+        .isEqualTo(2 * rowGroupSize);
 
     writer2.close(null);
-    Assert.assertTrue("Allocations should never exceed pool size", getTotalAllocation() <= poolSize);
-    Assert.assertEquals(
-        "Allocations should be increased to the row group size", rowGroupSize, getTotalAllocation());
+    assertThat(getTotalAllocation())
+        .as("Allocations should never exceed pool size")
+        .isLessThanOrEqualTo(poolSize);
+    assertThat(getTotalAllocation())
+        .as("Allocations should be increased to the row group size")
+        .isEqualTo(rowGroupSize);
 
     writer3.close(null);
-    Assert.assertEquals("Allocations should be increased to the row group size", 0, getTotalAllocation());
+    assertThat(getTotalAllocation())
+        .as("Allocations should be increased to the row group size")
+        .isEqualTo(0);
   }
 
   @Test
@@ -116,20 +135,18 @@ public class TestMemoryManager {
     long rowGroupSize = poolSize / 2;
     conf.setLong(ParquetOutputFormat.BLOCK_SIZE, rowGroupSize);
 
-    Assert.assertTrue("Pool should hold 2 full row groups", (2 * rowGroupSize) <= poolSize);
-    Assert.assertTrue("Pool should not hold 3 full row groups", poolSize < (3 * rowGroupSize));
+    assertThat(2 * rowGroupSize).as("Pool should hold 2 full row groups").isLessThanOrEqualTo(poolSize);
+    assertThat(poolSize).as("Pool should not hold 3 full row groups").isLessThan(3 * rowGroupSize);
 
     Runnable callback = () -> counter++;
 
     // first-time registration should succeed
     ParquetOutputFormat.getMemoryManager().registerScaleCallBack("increment-test-counter", callback);
 
-    try {
-      ParquetOutputFormat.getMemoryManager().registerScaleCallBack("increment-test-counter", callback);
-      Assert.fail("Duplicated registering callback should throw duplicates exception.");
-    } catch (IllegalArgumentException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> ParquetOutputFormat.getMemoryManager()
+            .registerScaleCallBack("increment-test-counter", callback))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("The callBackName increment-test-counter is duplicated and has been registered already.");
 
     // hit the limit once and clean up
     RecordWriter writer1 = createWriter(1);
@@ -140,11 +157,10 @@ public class TestMemoryManager {
     writer3.close(null);
 
     // Verify Callback mechanism
-    Assert.assertEquals("Allocations should be adjusted once", 1, counter);
-    Assert.assertEquals(
-        "Should not allow duplicate callbacks",
-        1,
-        ParquetOutputFormat.getMemoryManager().getScaleCallBacks().size());
+    assertThat(counter).as("Allocations should be adjusted once").isEqualTo(1);
+    assertThat(ParquetOutputFormat.getMemoryManager().getScaleCallBacks())
+        .as("Should not allow duplicate callbacks")
+        .hasSize(1);
   }
 
   @Rule

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMergeMetadataFiles.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMergeMetadataFiles.java
@@ -19,10 +19,8 @@
 package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -162,23 +160,20 @@ public class TestMergeMetadataFiles {
     ParquetMetadata meta2 =
         ParquetFileReader.readFooter(info.conf, info.metaPath2, ParquetMetadataConverter.NO_FILTER);
 
-    assertTrue(commonMeta1.getBlocks().isEmpty());
-    assertTrue(commonMeta2.getBlocks().isEmpty());
-    assertEquals(
-        commonMeta1.getFileMetaData().getSchema(),
-        commonMeta2.getFileMetaData().getSchema());
+    assertThat(commonMeta1.getBlocks()).isEmpty();
+    assertThat(commonMeta2.getBlocks()).isEmpty();
+    assertThat(commonMeta2.getFileMetaData().getSchema())
+        .isEqualTo(commonMeta1.getFileMetaData().getSchema());
 
-    assertFalse(meta1.getBlocks().isEmpty());
-    assertFalse(meta2.getBlocks().isEmpty());
-    assertEquals(
-        meta1.getFileMetaData().getSchema(), meta2.getFileMetaData().getSchema());
+    assertThat(meta1.getBlocks()).isNotEmpty();
+    assertThat(meta2.getBlocks()).isNotEmpty();
+    assertThat(meta2.getFileMetaData().getSchema())
+        .isEqualTo(meta1.getFileMetaData().getSchema());
 
-    assertEquals(
-        commonMeta1.getFileMetaData().getKeyValueMetaData(),
-        commonMeta2.getFileMetaData().getKeyValueMetaData());
-    assertEquals(
-        meta1.getFileMetaData().getKeyValueMetaData(),
-        meta2.getFileMetaData().getKeyValueMetaData());
+    assertThat(commonMeta2.getFileMetaData().getKeyValueMetaData())
+        .isEqualTo(commonMeta1.getFileMetaData().getKeyValueMetaData());
+    assertThat(meta2.getFileMetaData().getKeyValueMetaData())
+        .isEqualTo(meta1.getFileMetaData().getKeyValueMetaData());
 
     // test file serialization
     Path mergedOut = new Path(new File(temp.getRoot(), "merged_meta").getAbsolutePath());
@@ -193,24 +188,19 @@ public class TestMergeMetadataFiles {
         ParquetFileReader.readFooter(info.conf, mergedCommonOut, ParquetMetadataConverter.NO_FILTER);
 
     // ideally we'd assert equality here, but BlockMetaData and it's references don't implement equals
-    assertEquals(
-        meta1.getBlocks().size() + meta2.getBlocks().size(),
-        mergedMeta.getBlocks().size());
-    assertTrue(mergedCommonMeta.getBlocks().isEmpty());
+    assertThat(mergedMeta.getBlocks())
+        .hasSize(meta1.getBlocks().size() + meta2.getBlocks().size());
+    assertThat(mergedCommonMeta.getBlocks()).isEmpty();
 
-    assertEquals(
-        meta1.getFileMetaData().getSchema(),
-        mergedMeta.getFileMetaData().getSchema());
-    assertEquals(
-        commonMeta1.getFileMetaData().getSchema(),
-        mergedCommonMeta.getFileMetaData().getSchema());
+    assertThat(mergedMeta.getFileMetaData().getSchema())
+        .isEqualTo(meta1.getFileMetaData().getSchema());
+    assertThat(mergedCommonMeta.getFileMetaData().getSchema())
+        .isEqualTo(commonMeta1.getFileMetaData().getSchema());
 
-    assertEquals(
-        meta1.getFileMetaData().getKeyValueMetaData(),
-        mergedMeta.getFileMetaData().getKeyValueMetaData());
-    assertEquals(
-        commonMeta1.getFileMetaData().getKeyValueMetaData(),
-        mergedCommonMeta.getFileMetaData().getKeyValueMetaData());
+    assertThat(mergedMeta.getFileMetaData().getKeyValueMetaData())
+        .isEqualTo(meta1.getFileMetaData().getKeyValueMetaData());
+    assertThat(mergedCommonMeta.getFileMetaData().getKeyValueMetaData())
+        .isEqualTo(commonMeta1.getFileMetaData().getKeyValueMetaData());
   }
 
   @Test
@@ -220,29 +210,14 @@ public class TestMergeMetadataFiles {
     Path mergedOut = new Path(new File(temp.getRoot(), "merged_meta").getAbsolutePath());
     Path mergedCommonOut = new Path(new File(temp.getRoot(), "merged_common_meta").getAbsolutePath());
 
-    try {
-      ParquetFileWriter.writeMergedMetadataFile(List.of(info.metaPath1, info.metaPath2), mergedOut, info.conf);
-      fail("this should throw");
-    } catch (RuntimeException e) {
-      boolean eq1 =
-          e.getMessage().equals("could not merge metadata: key schema_num has conflicting values: [2, 1]");
-      boolean eq2 =
-          e.getMessage().equals("could not merge metadata: key schema_num has conflicting values: [1, 2]");
+    assertThatThrownBy(() -> ParquetFileWriter.writeMergedMetadataFile(
+            List.of(info.metaPath1, info.metaPath2), mergedOut, info.conf))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("could not merge metadata: key schema_num has conflicting values");
 
-      assertEquals(eq1 || eq2, true);
-    }
-
-    try {
-      ParquetFileWriter.writeMergedMetadataFile(
-          List.of(info.commonMetaPath1, info.commonMetaPath2), mergedCommonOut, info.conf);
-      fail("this should throw");
-    } catch (RuntimeException e) {
-      boolean eq1 =
-          e.getMessage().equals("could not merge metadata: key schema_num has conflicting values: [2, 1]");
-      boolean eq2 =
-          e.getMessage().equals("could not merge metadata: key schema_num has conflicting values: [1, 2]");
-
-      assertEquals(eq1 || eq2, true);
-    }
+    assertThatThrownBy(() -> ParquetFileWriter.writeMergedMetadataFile(
+            List.of(info.commonMetaPath1, info.commonMetaPath2), mergedCommonOut, info.conf))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("could not merge metadata: key schema_num has conflicting values");
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMultipleWriteRead.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestMultipleWriteRead.java
@@ -32,7 +32,7 @@ import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.io.Files;
 import java.io.IOException;
@@ -161,7 +161,7 @@ public class TestMultipleWriteRead {
     try (ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), file).build()) {
       for (Group group : data) {
-        assertEquals(group.toString(), reader.read().toString());
+        assertThat(reader.read()).asString().isEqualTo(group.toString());
       }
     }
   }
@@ -171,7 +171,7 @@ public class TestMultipleWriteRead {
         .withFilter(filter)
         .build()) {
       for (Iterator<Group> it = data.iterator(); it.hasNext(); ) {
-        assertEquals(it.next().toString(), reader.read().toString());
+        assertThat(reader.read()).asString().isEqualTo(it.next().toString());
       }
     }
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileReaderMaxMessageSize.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileReaderMaxMessageSize.java
@@ -18,7 +18,8 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -95,9 +96,9 @@ public class TestParquetFileReaderMaxMessageSize {
         ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
 
       ParquetMetadata metadata = reader.getFooter();
-      assertNotNull(metadata);
-      assertEquals(schema, metadata.getFileMetaData().getSchema());
-      assertTrue(metadata.getBlocks().size() > 0);
+      assertThat(metadata).isNotNull();
+      assertThat(metadata.getFileMetaData().getSchema()).isEqualTo(schema);
+      assertThat(metadata.getBlocks()).isNotEmpty();
     }
   }
 
@@ -114,8 +115,8 @@ public class TestParquetFileReaderMaxMessageSize {
         ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
 
       ParquetMetadata metadata = reader.getFooter();
-      assertNotNull(metadata);
-      assertEquals(1, metadata.getBlocks().get(0).getRowCount());
+      assertThat(metadata).isNotNull();
+      assertThat(metadata.getBlocks().get(0).getRowCount()).isEqualTo(1);
     }
   }
 
@@ -123,25 +124,21 @@ public class TestParquetFileReaderMaxMessageSize {
    * Test that insufficient max message size produces error
    */
   @Test
-  public void testInsufficientMaxMessageSizeError() throws IOException {
+  public void testInsufficientMaxMessageSizeError() {
     // Try to read with very small max message size
     Configuration readConf = new Configuration();
     readConf.setInt("parquet.thrift.string.size.limit", 1); // Only 1 byte
 
     ParquetReadOptions options = HadoopReadOptions.builder(readConf).build();
 
-    try (ParquetFileReader reader =
-        ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
-      fail("Should have thrown Message size exceeds limit due to MaxMessageSize");
-    } catch (IOException e) {
-      e.printStackTrace();
-      assertTrue(
-          "Error should mention TTransportException",
-          e.getMessage().contains("Message size exceeds limit")
-              || e.getCause().getMessage().contains("Message size exceeds limit")
-              || e.getMessage().contains("MaxMessageSize reached")
-              || e.getCause().getMessage().contains("MaxMessageSize reached"));
-    }
+    assertThatThrownBy(() -> {
+          try (ParquetFileReader reader =
+              ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
+            reader.getFooter();
+          }
+        })
+        .isInstanceOf(IOException.class)
+        .hasMessageMatching("(?s).*(Message size exceeds limit|MaxMessageSize reached).*");
   }
 
   /**
@@ -157,8 +154,8 @@ public class TestParquetFileReaderMaxMessageSize {
     try (ParquetFileReader reader =
         ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
       ParquetMetadata metadata = reader.getFooter();
-      assertNotNull(metadata);
-      assertEquals(schema, metadata.getFileMetaData().getSchema());
+      assertThat(metadata).isNotNull();
+      assertThat(metadata.getFileMetaData().getSchema()).isEqualTo(schema);
     }
   }
 
@@ -172,23 +169,18 @@ public class TestParquetFileReaderMaxMessageSize {
     assertRejectsNonPositiveMaxMessageSize(-5);
   }
 
-  private void assertRejectsNonPositiveMaxMessageSize(int maxMessageSize) throws IOException {
+  private void assertRejectsNonPositiveMaxMessageSize(int maxMessageSize) {
     Configuration readConf = new Configuration();
     readConf.setInt("parquet.thrift.string.size.limit", maxMessageSize);
     ParquetReadOptions options = HadoopReadOptions.builder(readConf).build();
 
-    try (ParquetFileReader reader =
-        ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
-      fail("Expected failure for non-positive max message size: " + maxMessageSize);
-    } catch (RuntimeException | IOException e) {
-      String message = e.getMessage() == null ? "" : e.getMessage();
-      String causeMessage = e.getCause() == null || e.getCause().getMessage() == null
-          ? ""
-          : e.getCause().getMessage();
-      assertTrue(
-          "Expected 'Max message size must be positive' in " + message + " / " + causeMessage,
-          message.contains("Max message size must be positive")
-              || causeMessage.contains("Max message size must be positive"));
-    }
+    assertThatThrownBy(() -> {
+          try (ParquetFileReader reader =
+              ParquetFileReader.open(HadoopInputFile.fromPath(TEST_FILE, readConf), options)) {
+            reader.getFooter();
+          }
+        })
+        .isInstanceOf(NumberFormatException.class)
+        .hasMessage("Max message size must be positive: " + maxMessageSize);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileReaderRowRanges.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileReaderRowRanges.java
@@ -19,9 +19,8 @@
 package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -85,13 +84,13 @@ public class TestParquetFileReaderRowRanges {
   @Test
   public void getRowRangesWithoutFilterCoversAllRows() throws IOException {
     try (ParquetFileReader reader = openReader()) {
-      assertEquals(1, reader.getRowGroups().size());
+      assertThat(reader.getRowGroups()).hasSize(1);
       BlockMetaData block = reader.getRowGroups().get(0);
 
       RowRanges ranges = reader.getRowRanges(0);
 
-      assertEquals(block.getRowCount(), ranges.rowCount());
-      assertTrue(ranges.isOverlapping(0L, block.getRowCount() - 1));
+      assertThat(ranges.rowCount()).isEqualTo(block.getRowCount());
+      assertThat(ranges.isOverlapping(0L, block.getRowCount() - 1)).isTrue();
     }
   }
 
@@ -99,8 +98,12 @@ public class TestParquetFileReaderRowRanges {
   public void getRowRangesRejectsOutOfRangeBlockIndex() throws IOException {
     try (ParquetFileReader reader = openReader()) {
       int blockCount = reader.getRowGroups().size();
-      assertThrows(IllegalArgumentException.class, () -> reader.getRowRanges(-1));
-      assertThrows(IllegalArgumentException.class, () -> reader.getRowRanges(blockCount));
+      assertThatThrownBy(() -> reader.getRowRanges(-1))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Invalid block index");
+      assertThatThrownBy(() -> reader.getRowRanges(blockCount))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Invalid block index");
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetFileWriter.java
@@ -33,13 +33,10 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,7 +47,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -109,7 +105,6 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -227,22 +222,11 @@ public class TestParquetFileWriter {
         "message m { required group a {required binary b;} required group " + "c { required int64 d; }}");
     Configuration conf = new Configuration();
 
-    ParquetFileWriter writer = null;
-    boolean exceptionThrown = false;
     Path path = new Path(testFile.toURI());
-    try {
-      writer = createWriter(conf, schema, path);
-    } catch (IOException ioe1) {
-      exceptionThrown = true;
-    }
-    assertTrue(exceptionThrown);
-    exceptionThrown = false;
-    try {
-      writer = createWriter(conf, schema, path, OVERWRITE);
-    } catch (IOException ioe2) {
-      exceptionThrown = true;
-    }
-    assertTrue(!exceptionThrown);
+    assertThatThrownBy(() -> createWriter(conf, schema, path))
+        .isInstanceOf(IOException.class)
+        .hasMessageContaining("already exists");
+    assertThatCode(() -> createWriter(conf, schema, path, OVERWRITE)).doesNotThrowAnyException();
     testFile.delete();
   }
 
@@ -288,23 +272,23 @@ public class TestParquetFileWriter {
     w.close();
 
     ParquetMetadata readFooter = ParquetFileReader.readFooter(configuration, path);
-    assertEquals("footer: " + readFooter, 2, readFooter.getBlocks().size());
+    assertThat(readFooter.getBlocks()).as("footer: " + readFooter).hasSize(2);
     BlockMetaData rowGroup = readFooter.getBlocks().get(0);
-    assertEquals(c1Ends - c1Starts, rowGroup.getColumns().get(0).getTotalSize());
-    assertEquals(c2Ends - c2Starts, rowGroup.getColumns().get(1).getTotalSize());
-    assertEquals(c2Ends - c1Starts, rowGroup.getTotalByteSize());
+    assertThat(rowGroup.getColumns().get(0).getTotalSize()).isEqualTo(c1Ends - c1Starts);
+    assertThat(rowGroup.getColumns().get(1).getTotalSize()).isEqualTo(c2Ends - c2Starts);
+    assertThat(rowGroup.getTotalByteSize()).isEqualTo(c2Ends - c1Starts);
 
-    assertEquals(c1Starts, rowGroup.getColumns().get(0).getStartingPos());
-    assertEquals(0, rowGroup.getColumns().get(0).getDictionaryPageOffset());
-    assertEquals(c1p1Starts, rowGroup.getColumns().get(0).getFirstDataPageOffset());
-    assertEquals(c2Starts, rowGroup.getColumns().get(1).getStartingPos());
-    assertEquals(c2Starts, rowGroup.getColumns().get(1).getDictionaryPageOffset());
-    assertEquals(c2p1Starts, rowGroup.getColumns().get(1).getFirstDataPageOffset());
+    assertThat(rowGroup.getColumns().get(0).getStartingPos()).isEqualTo(c1Starts);
+    assertThat(rowGroup.getColumns().get(0).getDictionaryPageOffset()).isEqualTo(0);
+    assertThat(rowGroup.getColumns().get(0).getFirstDataPageOffset()).isEqualTo(c1p1Starts);
+    assertThat(rowGroup.getColumns().get(1).getStartingPos()).isEqualTo(c2Starts);
+    assertThat(rowGroup.getColumns().get(1).getDictionaryPageOffset()).isEqualTo(c2Starts);
+    assertThat(rowGroup.getColumns().get(1).getFirstDataPageOffset()).isEqualTo(c2p1Starts);
 
     HashSet<Encoding> expectedEncoding = new HashSet<Encoding>();
     expectedEncoding.add(PLAIN);
     expectedEncoding.add(BIT_PACKED);
-    assertEquals(expectedEncoding, rowGroup.getColumns().get(0).getEncodings());
+    assertThat(rowGroup.getColumns().get(0).getEncodings()).isEqualTo(expectedEncoding);
 
     { // read first block of col #1
       try (ParquetFileReader r = new ParquetFileReader(
@@ -314,10 +298,10 @@ public class TestParquetFileWriter {
           List.of(rowGroup),
           List.of(SCHEMA.getColumnDescription(PATH1)))) {
         PageReadStore pages = r.readNextRowGroup();
-        assertEquals(3, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(3);
         validateContains(SCHEMA, pages, PATH1, 2, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH1, 3, BytesInput.from(BYTES1));
-        assertNull(r.readNextRowGroup());
+        assertThat(r.readNextRowGroup()).isNull();
       }
     }
 
@@ -330,7 +314,7 @@ public class TestParquetFileWriter {
           List.of(SCHEMA.getColumnDescription(PATH1), SCHEMA.getColumnDescription(PATH2)))) {
 
         PageReadStore pages = r.readNextRowGroup();
-        assertEquals(3, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(3);
         validateContains(SCHEMA, pages, PATH1, 2, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH1, 3, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH2, 2, BytesInput.from(BYTES2));
@@ -338,12 +322,12 @@ public class TestParquetFileWriter {
         validateContains(SCHEMA, pages, PATH2, 1, BytesInput.from(BYTES2));
 
         pages = r.readNextRowGroup();
-        assertEquals(4, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(4);
 
         validateContains(SCHEMA, pages, PATH1, 7, BytesInput.from(BYTES3));
         validateContains(SCHEMA, pages, PATH2, 8, BytesInput.from(BYTES4));
 
-        assertNull(r.readNextRowGroup());
+        assertThat(r.readNextRowGroup()).isNull();
       }
     }
     PrintFooter.main(new String[] {path.toString()});
@@ -388,25 +372,25 @@ public class TestParquetFileWriter {
     w.end(new HashMap<String, String>());
 
     ParquetMetadata readFooter = ParquetFileReader.readFooter(configuration, path);
-    assertEquals("footer: " + readFooter, 2, readFooter.getBlocks().size());
+    assertThat(readFooter.getBlocks()).as("footer: " + readFooter).hasSize(2);
     BlockMetaData rowGroup = readFooter.getBlocks().get(0);
-    assertEquals(c2Ends - c2Starts, rowGroup.getColumns().get(1).getTotalSize());
+    assertThat(rowGroup.getColumns().get(1).getTotalSize()).isEqualTo(c2Ends - c2Starts);
 
-    assertEquals(0, rowGroup.getColumns().get(0).getDictionaryPageOffset());
-    assertEquals(c2Starts, rowGroup.getColumns().get(1).getStartingPos());
-    assertEquals(c2Starts, rowGroup.getColumns().get(1).getDictionaryPageOffset());
-    assertEquals(c2p1Starts, rowGroup.getColumns().get(1).getFirstDataPageOffset());
+    assertThat(rowGroup.getColumns().get(0).getDictionaryPageOffset()).isEqualTo(0);
+    assertThat(rowGroup.getColumns().get(1).getStartingPos()).isEqualTo(c2Starts);
+    assertThat(rowGroup.getColumns().get(1).getDictionaryPageOffset()).isEqualTo(c2Starts);
+    assertThat(rowGroup.getColumns().get(1).getFirstDataPageOffset()).isEqualTo(c2p1Starts);
 
     BlockMetaData rowGroup2 = readFooter.getBlocks().get(1);
-    assertEquals(0, rowGroup2.getColumns().get(0).getDictionaryPageOffset());
-    assertEquals(c1Bock2Starts, rowGroup2.getColumns().get(0).getStartingPos());
-    assertEquals(c1p1Bock2Starts, rowGroup2.getColumns().get(0).getFirstDataPageOffset());
-    assertEquals(c1Block2Ends - c1Bock2Starts, rowGroup2.getColumns().get(0).getTotalSize());
+    assertThat(rowGroup2.getColumns().get(0).getDictionaryPageOffset()).isEqualTo(0);
+    assertThat(rowGroup2.getColumns().get(0).getStartingPos()).isEqualTo(c1Bock2Starts);
+    assertThat(rowGroup2.getColumns().get(0).getFirstDataPageOffset()).isEqualTo(c1p1Bock2Starts);
+    assertThat(rowGroup2.getColumns().get(0).getTotalSize()).isEqualTo(c1Block2Ends - c1Bock2Starts);
 
     HashSet<Encoding> expectedEncoding = new HashSet<Encoding>();
     expectedEncoding.add(PLAIN);
     expectedEncoding.add(BIT_PACKED);
-    assertEquals(expectedEncoding, rowGroup.getColumns().get(0).getEncodings());
+    assertThat(rowGroup.getColumns().get(0).getEncodings()).isEqualTo(expectedEncoding);
 
     ParquetInputSplit split = new ParquetInputSplit(
         path,
@@ -423,7 +407,7 @@ public class TestParquetFileWriter {
     TaskAttemptID taskAttemptID = TaskAttemptID.forName("attempt_0_1_m_1_1");
     TaskAttemptContext taskContext = ContextUtil.newTaskAttemptContext(configuration, taskAttemptID);
     RecordReader<Void, ArrayWritable> reader = input.createRecordReader(split, taskContext);
-    assertTrue(reader instanceof ParquetRecordReader);
+    assertThat(reader).isInstanceOf(ParquetRecordReader.class);
     // RowGroup.file_offset is checked here
     reader.initialize(split, taskContext);
     reader.close();
@@ -441,10 +425,9 @@ public class TestParquetFileWriter {
     w.start();
     w.startBlock(0);
 
-    TestUtils.assertThrows("End block with zero record", ParquetEncodingException.class, (Callable<Void>) () -> {
-      w.endBlock();
-      return null;
-    });
+    assertThatThrownBy(w::endBlock)
+        .isInstanceOf(ParquetEncodingException.class)
+        .hasMessage("End block with zero record");
   }
 
   @Test
@@ -483,8 +466,10 @@ public class TestParquetFileWriter {
           r.getBloomFilterDataReader(readFooter.getBlocks().get(0));
       BloomFilter bloomFilter = bloomFilterReader.readBloomFilter(
           readFooter.getBlocks().get(0).getColumns().get(0));
-      assertTrue(bloomFilter.findHash(blockSplitBloomFilter.hash(Binary.fromString("hello"))));
-      assertTrue(bloomFilter.findHash(blockSplitBloomFilter.hash(Binary.fromString("world"))));
+      assertThat(bloomFilter.findHash(blockSplitBloomFilter.hash(Binary.fromString("hello"))))
+          .isTrue();
+      assertThat(bloomFilter.findHash(blockSplitBloomFilter.hash(Binary.fromString("world"))))
+          .isTrue();
     }
   }
 
@@ -526,14 +511,12 @@ public class TestParquetFileWriter {
     w.end(new HashMap<>());
 
     ParquetMetadata readFooter = ParquetFileReader.readFooter(configuration, path);
-    assertEquals("footer: " + readFooter, 1, readFooter.getBlocks().size());
-    assertEquals(
-        c1Ends - c1Starts,
-        readFooter.getBlocks().get(0).getColumns().get(0).getTotalSize());
-    assertEquals(
-        c2Ends - c2Starts,
-        readFooter.getBlocks().get(0).getColumns().get(1).getTotalSize());
-    assertEquals(c2Ends - c1Starts, readFooter.getBlocks().get(0).getTotalByteSize());
+    assertThat(readFooter.getBlocks()).as("footer: " + readFooter).hasSize(1);
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(0).getTotalSize())
+        .isEqualTo(c1Ends - c1Starts);
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(1).getTotalSize())
+        .isEqualTo(c2Ends - c2Starts);
+    assertThat(readFooter.getBlocks().get(0).getTotalByteSize()).isEqualTo(c2Ends - c1Starts);
 
     // check for stats
     org.apache.parquet.column.statistics.Statistics<?> expectedStats = createStatistics("b", "z", C1);
@@ -542,9 +525,8 @@ public class TestParquetFileWriter {
 
     HashSet<Encoding> expectedEncoding = new HashSet<Encoding>();
     expectedEncoding.add(PLAIN);
-    assertEquals(
-        expectedEncoding,
-        readFooter.getBlocks().get(0).getColumns().get(0).getEncodings());
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(0).getEncodings())
+        .isEqualTo(expectedEncoding);
 
     try (ParquetFileReader reader = new ParquetFileReader(
         configuration,
@@ -553,7 +535,7 @@ public class TestParquetFileWriter {
         readFooter.getBlocks(),
         List.of(SCHEMA.getColumnDescription(PATH1), SCHEMA.getColumnDescription(PATH2)))) {
       PageReadStore pages = reader.readNextRowGroup();
-      assertEquals(14, pages.getRowCount());
+      assertThat(pages.getRowCount()).isEqualTo(14);
       validateV2Page(
           SCHEMA,
           pages,
@@ -598,7 +580,7 @@ public class TestParquetFileWriter {
           defLevels.toByteArray(),
           data2.toByteArray(),
           12);
-      assertNull(reader.readNextRowGroup());
+      assertThat(reader.readNextRowGroup()).isNull();
     }
   }
 
@@ -656,34 +638,33 @@ public class TestParquetFileWriter {
     }
     long startFooter = fileLen - footerLen - 8;
 
-    assertEquals("Footer should start after second row group without padding", secondRowGroupEnds, startFooter);
+    assertThat(startFooter)
+        .as("Footer should start after second row group without padding")
+        .isEqualTo(secondRowGroupEnds);
 
     ParquetMetadata readFooter = ParquetFileReader.readFooter(conf, path);
-    assertEquals("footer: " + readFooter, 2, readFooter.getBlocks().size());
-    assertEquals(
-        c1Ends - c1Starts,
-        readFooter.getBlocks().get(0).getColumns().get(0).getTotalSize());
-    assertEquals(
-        c2Ends - c2Starts,
-        readFooter.getBlocks().get(0).getColumns().get(1).getTotalSize());
-    assertEquals(c2Ends - c1Starts, readFooter.getBlocks().get(0).getTotalByteSize());
+    assertThat(readFooter.getBlocks()).as("footer: " + readFooter).hasSize(2);
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(0).getTotalSize())
+        .isEqualTo(c1Ends - c1Starts);
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(1).getTotalSize())
+        .isEqualTo(c2Ends - c2Starts);
+    assertThat(readFooter.getBlocks().get(0).getTotalByteSize()).isEqualTo(c2Ends - c1Starts);
     HashSet<Encoding> expectedEncoding = new HashSet<Encoding>();
     expectedEncoding.add(PLAIN);
     expectedEncoding.add(BIT_PACKED);
-    assertEquals(
-        expectedEncoding,
-        readFooter.getBlocks().get(0).getColumns().get(0).getEncodings());
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(0).getEncodings())
+        .isEqualTo(expectedEncoding);
 
     // verify block starting positions with padding
-    assertEquals(
-        "First row group should start after magic",
-        4,
-        readFooter.getBlocks().get(0).getStartingPos());
-    assertTrue("First row group should end before the block size (120)", firstRowGroupEnds < 120);
-    assertEquals(
-        "Second row group should start at the block size",
-        120,
-        readFooter.getBlocks().get(1).getStartingPos());
+    assertThat(readFooter.getBlocks().get(0).getStartingPos())
+        .as("First row group should start after magic")
+        .isEqualTo(4);
+    assertThat(firstRowGroupEnds)
+        .as("First row group should end before the block size (120)")
+        .isLessThan(120);
+    assertThat(readFooter.getBlocks().get(1).getStartingPos())
+        .as("Second row group should start at the block size")
+        .isEqualTo(120);
 
     { // read first block of col #1
       try (ParquetFileReader r = new ParquetFileReader(
@@ -693,10 +674,10 @@ public class TestParquetFileWriter {
           List.of(readFooter.getBlocks().get(0)),
           List.of(SCHEMA.getColumnDescription(PATH1)))) {
         PageReadStore pages = r.readNextRowGroup();
-        assertEquals(3, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(3);
         validateContains(SCHEMA, pages, PATH1, 2, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH1, 3, BytesInput.from(BYTES1));
-        assertNull(r.readNextRowGroup());
+        assertThat(r.readNextRowGroup()).isNull();
       }
     }
 
@@ -709,7 +690,7 @@ public class TestParquetFileWriter {
           List.of(SCHEMA.getColumnDescription(PATH1), SCHEMA.getColumnDescription(PATH2)))) {
 
         PageReadStore pages = r.readNextRowGroup();
-        assertEquals(3, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(3);
         validateContains(SCHEMA, pages, PATH1, 2, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH1, 3, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH2, 2, BytesInput.from(BYTES2));
@@ -717,12 +698,12 @@ public class TestParquetFileWriter {
         validateContains(SCHEMA, pages, PATH2, 1, BytesInput.from(BYTES2));
 
         pages = r.readNextRowGroup();
-        assertEquals(4, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(4);
 
         validateContains(SCHEMA, pages, PATH1, 7, BytesInput.from(BYTES3));
         validateContains(SCHEMA, pages, PATH2, 8, BytesInput.from(BYTES4));
 
-        assertNull(r.readNextRowGroup());
+        assertThat(r.readNextRowGroup()).isNull();
       }
     }
     PrintFooter.main(new String[] {path.toString()});
@@ -784,34 +765,33 @@ public class TestParquetFileWriter {
     }
     long startFooter = fileLen - footerLen - 8;
 
-    assertEquals("Footer should start after second row group without padding", secondRowGroupEnds, startFooter);
+    assertThat(startFooter)
+        .as("Footer should start after second row group without padding")
+        .isEqualTo(secondRowGroupEnds);
 
     ParquetMetadata readFooter = ParquetFileReader.readFooter(conf, path);
-    assertEquals("footer: " + readFooter, 2, readFooter.getBlocks().size());
-    assertEquals(
-        c1Ends - c1Starts,
-        readFooter.getBlocks().get(0).getColumns().get(0).getTotalSize());
-    assertEquals(
-        c2Ends - c2Starts,
-        readFooter.getBlocks().get(0).getColumns().get(1).getTotalSize());
-    assertEquals(c2Ends - c1Starts, readFooter.getBlocks().get(0).getTotalByteSize());
+    assertThat(readFooter.getBlocks()).as("footer: " + readFooter).hasSize(2);
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(0).getTotalSize())
+        .isEqualTo(c1Ends - c1Starts);
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(1).getTotalSize())
+        .isEqualTo(c2Ends - c2Starts);
+    assertThat(readFooter.getBlocks().get(0).getTotalByteSize()).isEqualTo(c2Ends - c1Starts);
     HashSet<Encoding> expectedEncoding = new HashSet<Encoding>();
     expectedEncoding.add(PLAIN);
     expectedEncoding.add(BIT_PACKED);
-    assertEquals(
-        expectedEncoding,
-        readFooter.getBlocks().get(0).getColumns().get(0).getEncodings());
+    assertThat(readFooter.getBlocks().get(0).getColumns().get(0).getEncodings())
+        .isEqualTo(expectedEncoding);
 
     // verify block starting positions with padding
-    assertEquals(
-        "First row group should start after magic",
-        4,
-        readFooter.getBlocks().get(0).getStartingPos());
-    assertTrue("First row group should end before the block size (120)", firstRowGroupEnds > 100);
-    assertEquals(
-        "Second row group should start after no padding",
-        109,
-        readFooter.getBlocks().get(1).getStartingPos());
+    assertThat(readFooter.getBlocks().get(0).getStartingPos())
+        .as("First row group should start after magic")
+        .isEqualTo(4);
+    assertThat(firstRowGroupEnds)
+        .as("First row group should end before the block size (120)")
+        .isGreaterThan(100);
+    assertThat(readFooter.getBlocks().get(1).getStartingPos())
+        .as("Second row group should start after no padding")
+        .isEqualTo(109);
 
     { // read first block of col #1
       try (ParquetFileReader r = new ParquetFileReader(
@@ -821,10 +801,10 @@ public class TestParquetFileWriter {
           List.of(readFooter.getBlocks().get(0)),
           List.of(SCHEMA.getColumnDescription(PATH1)))) {
         PageReadStore pages = r.readNextRowGroup();
-        assertEquals(3, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(3);
         validateContains(SCHEMA, pages, PATH1, 2, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH1, 3, BytesInput.from(BYTES1));
-        assertNull(r.readNextRowGroup());
+        assertThat(r.readNextRowGroup()).isNull();
       }
     }
 
@@ -836,7 +816,7 @@ public class TestParquetFileWriter {
           readFooter.getBlocks(),
           List.of(SCHEMA.getColumnDescription(PATH1), SCHEMA.getColumnDescription(PATH2)))) {
         PageReadStore pages = r.readNextRowGroup();
-        assertEquals(3, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(3);
         validateContains(SCHEMA, pages, PATH1, 2, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH1, 3, BytesInput.from(BYTES1));
         validateContains(SCHEMA, pages, PATH2, 2, BytesInput.from(BYTES2));
@@ -844,12 +824,12 @@ public class TestParquetFileWriter {
         validateContains(SCHEMA, pages, PATH2, 1, BytesInput.from(BYTES2));
 
         pages = r.readNextRowGroup();
-        assertEquals(4, pages.getRowCount());
+        assertThat(pages.getRowCount()).isEqualTo(4);
 
         validateContains(SCHEMA, pages, PATH1, 7, BytesInput.from(BYTES3));
         validateContains(SCHEMA, pages, PATH2, 8, BytesInput.from(BYTES4));
 
-        assertNull(r.readNextRowGroup());
+        assertThat(r.readNextRowGroup()).isNull();
       }
     }
     PrintFooter.main(new String[] {path.toString()});
@@ -872,15 +852,15 @@ public class TestParquetFileWriter {
         (LongStatistics) org.apache.parquet.format.converter.ParquetMetadataConverter.fromParquetStatistics(
             createdBy, thriftStats, PrimitiveTypeName.INT64);
 
-    assertEquals(parquetMRstats.getMax(), convertedBackStats.getMax());
-    assertEquals(parquetMRstats.getMin(), convertedBackStats.getMin());
-    assertEquals(parquetMRstats.getNumNulls(), convertedBackStats.getNumNulls());
+    assertThat(convertedBackStats.getMax()).isEqualTo(parquetMRstats.getMax());
+    assertThat(convertedBackStats.getMin()).isEqualTo(parquetMRstats.getMin());
+    assertThat(convertedBackStats.getNumNulls()).isEqualTo(parquetMRstats.getNumNulls());
   }
 
   @Test
   public void testWriteReadStatistics() throws Exception {
     // this test assumes statistics will be read
-    Assume.assumeTrue(!shouldIgnoreStatistics(Version.FULL_VERSION, BINARY));
+    assumeThat(shouldIgnoreStatistics(Version.FULL_VERSION, BINARY)).isFalse();
 
     File testFile = temp.newFile();
     testFile.delete();
@@ -999,7 +979,7 @@ public class TestParquetFileWriter {
     footers = ParquetFileReader.readFooters(configuration, outputStatus, false);
     validateFooters(footers);
     footers = ParquetFileReader.readFooters(configuration, fs.getFileStatus(new Path(testDirPath, "part0")), false);
-    assertEquals(1, footers.size());
+    assertThat(footers).hasSize(1);
 
     final FileStatus metadataFile =
         fs.getFileStatus(new Path(testDirPath, ParquetFileWriter.PARQUET_METADATA_FILE));
@@ -1024,7 +1004,7 @@ public class TestParquetFileWriter {
   @Test
   public void testWriteReadStatisticsAllNulls() throws Exception {
     // this test assumes statistics will be read
-    Assume.assumeTrue(!shouldIgnoreStatistics(Version.FULL_VERSION, BINARY));
+    assumeThat(shouldIgnoreStatistics(Version.FULL_VERSION, BINARY)).isFalse();
 
     File testFile = temp.newFile();
     testFile.delete();
@@ -1051,26 +1031,25 @@ public class TestParquetFileWriter {
     // assert the statistics object is not empty
     org.apache.parquet.column.statistics.Statistics stats =
         readFooter.getBlocks().get(0).getColumns().get(0).getStatistics();
-    assertFalse("is empty: " + stats, stats.isEmpty());
+    assertThat(stats.isEmpty()).as("is empty: " + stats).isFalse();
     // assert the number of nulls are correct for the first block
-    assertEquals("nulls: " + stats, 1, stats.getNumNulls());
+    assertThat(stats.getNumNulls()).as("nulls: " + stats).isEqualTo(1);
   }
 
   private void validateFooters(final List<Footer> metadata) {
     LOG.debug("{}", metadata);
-    assertEquals(String.valueOf(metadata), 3, metadata.size());
+    assertThat(metadata).as(String.valueOf(metadata)).hasSize(3);
     for (Footer footer : metadata) {
       final File file = new File(footer.getFile().toUri());
-      assertTrue(file.getName(), file.getName().startsWith("part"));
-      assertTrue(file.getPath(), file.exists());
+      assertThat(file.getName().startsWith("part")).as(file.getName()).isTrue();
+      assertThat(file.exists()).as(file.getPath()).isTrue();
       final ParquetMetadata parquetMetadata = footer.getParquetMetadata();
-      assertEquals(2, parquetMetadata.getBlocks().size());
+      assertThat(parquetMetadata.getBlocks()).hasSize(2);
       final Map<String, String> keyValueMetaData =
           parquetMetadata.getFileMetaData().getKeyValueMetaData();
-      assertEquals("bar", keyValueMetaData.get("foo"));
-      assertEquals(
-          footer.getFile().getName(),
-          keyValueMetaData.get(footer.getFile().getName()));
+      assertThat(keyValueMetaData.get("foo")).isEqualTo("bar");
+      assertThat(keyValueMetaData.get(footer.getFile().getName()))
+          .isEqualTo(footer.getFile().getName());
     }
   }
 
@@ -1130,13 +1109,13 @@ public class TestParquetFileWriter {
       throws IOException {
     PageReader pageReader = pages.getPageReader(schema.getColumnDescription(path));
     DataPageV2 page = (DataPageV2) pageReader.readPage();
-    assertEquals(values, page.getValueCount());
-    assertEquals(rows, page.getRowCount());
-    assertEquals(nullCount, page.getNullCount());
-    assertEquals(uncompressedSize, page.getUncompressedSize());
-    assertArrayEquals(repetition, page.getRepetitionLevels().toByteArray());
-    assertArrayEquals(definition, page.getDefinitionLevels().toByteArray());
-    assertArrayEquals(data, page.getData().toByteArray());
+    assertThat(page.getValueCount()).isEqualTo(values);
+    assertThat(page.getRowCount()).isEqualTo(rows);
+    assertThat(page.getNullCount()).isEqualTo(nullCount);
+    assertThat(page.getUncompressedSize()).isEqualTo(uncompressedSize);
+    assertThat(page.getRepetitionLevels().toByteArray()).isEqualTo(repetition);
+    assertThat(page.getDefinitionLevels().toByteArray()).isEqualTo(definition);
+    assertThat(page.getData().toByteArray()).isEqualTo(data);
   }
 
   private org.apache.parquet.column.statistics.Statistics<?> createStatistics(
@@ -1152,8 +1131,8 @@ public class TestParquetFileWriter {
       throws IOException {
     PageReader pageReader = pages.getPageReader(schema.getColumnDescription(path));
     DataPage page = pageReader.readPage();
-    assertEquals(values, page.getValueCount());
-    assertArrayEquals(bytes.toByteArray(), ((DataPageV1) page).getBytes().toByteArray());
+    assertThat(page.getValueCount()).isEqualTo(values);
+    assertThat(((DataPageV1) page).getBytes().toByteArray()).isEqualTo(bytes.toByteArray());
   }
 
   @Test
@@ -1168,13 +1147,12 @@ public class TestParquetFileWriter {
         new HashMap<String, String>(),
         "test2");
     GlobalMetaData merged = ParquetFileWriter.mergeInto(md2, ParquetFileWriter.mergeInto(md1, null));
-    assertEquals(
-        merged.getSchema(),
-        new MessageType(
+    assertThat(new MessageType(
             "root1",
             new PrimitiveType(REPEATED, BINARY, "a"),
             new PrimitiveType(OPTIONAL, BINARY, "b"),
-            new PrimitiveType(REQUIRED, BINARY, "c")));
+            new PrimitiveType(REQUIRED, BINARY, "c")))
+        .isEqualTo(merged.getSchema());
   }
 
   @Test
@@ -1215,15 +1193,14 @@ public class TestParquetFileWriter {
 
     ParquetMetadata merged = ParquetFileWriter.mergeFooters(new Path("/tmp"), footers);
 
-    assertEquals(
-        new MessageType(
+    assertThat(merged.getFileMetaData().getSchema())
+        .isEqualTo(new MessageType(
             "root1",
             new PrimitiveType(REPEATED, BINARY, "a"),
             new PrimitiveType(OPTIONAL, BINARY, "b"),
-            new PrimitiveType(REQUIRED, BINARY, "c")),
-        merged.getFileMetaData().getSchema());
+            new PrimitiveType(REQUIRED, BINARY, "c")));
 
-    assertEquals("Should have all blocks", expected, merged.getBlocks());
+    assertThat(merged.getBlocks()).as("Should have all blocks").isEqualTo(expected);
   }
 
   /**
@@ -1343,90 +1320,95 @@ public class TestParquetFileWriter {
         HadoopInputFile.fromPath(path, configuration),
         ParquetReadOptions.builder().build())) {
       ParquetMetadata footer = reader.getFooter();
-      assertEquals(3, footer.getBlocks().size());
+      assertThat(footer.getBlocks()).hasSize(3);
       BlockMetaData blockMeta = footer.getBlocks().get(1);
-      assertEquals(2, blockMeta.getColumns().size());
+      assertThat(blockMeta.getColumns()).hasSize(2);
 
       ColumnIndex columnIndex =
           reader.readColumnIndex(blockMeta.getColumns().get(0));
-      assertEquals(BoundaryOrder.ASCENDING, columnIndex.getBoundaryOrder());
-      assertTrue(List.of(1l, 0l).equals(columnIndex.getNullCounts()));
-      assertTrue(List.of(false, false).equals(columnIndex.getNullPages()));
+      assertThat(columnIndex.getBoundaryOrder()).isEqualTo(BoundaryOrder.ASCENDING);
+      assertThat(columnIndex.getNullCounts()).containsExactly(1L, 0L);
+      assertThat(columnIndex.getNullPages()).containsExactly(false, false);
       List<ByteBuffer> minValues = columnIndex.getMinValues();
-      assertEquals(2, minValues.size());
+      assertThat(minValues).hasSize(2);
       List<ByteBuffer> maxValues = columnIndex.getMaxValues();
-      assertEquals(2, maxValues.size());
-      assertEquals("aaa", new String(minValues.get(0).array(), StandardCharsets.UTF_8));
-      assertEquals("aaa", new String(maxValues.get(0).array(), StandardCharsets.UTF_8));
-      assertEquals("bbb", new String(minValues.get(1).array(), StandardCharsets.UTF_8));
-      assertEquals("ccc", new String(maxValues.get(1).array(), StandardCharsets.UTF_8));
+      assertThat(maxValues).hasSize(2);
+      assertThat(new String(minValues.get(0).array(), StandardCharsets.UTF_8))
+          .isEqualTo("aaa");
+      assertThat(new String(maxValues.get(0).array(), StandardCharsets.UTF_8))
+          .isEqualTo("aaa");
+      assertThat(new String(minValues.get(1).array(), StandardCharsets.UTF_8))
+          .isEqualTo("bbb");
+      assertThat(new String(maxValues.get(1).array(), StandardCharsets.UTF_8))
+          .isEqualTo("ccc");
 
       columnIndex = reader.readColumnIndex(blockMeta.getColumns().get(1));
-      assertEquals(BoundaryOrder.DESCENDING, columnIndex.getBoundaryOrder());
-      assertTrue(List.of(0l, 3l, 0l).equals(columnIndex.getNullCounts()));
-      assertTrue(List.of(false, true, false).equals(columnIndex.getNullPages()));
+      assertThat(columnIndex.getBoundaryOrder()).isEqualTo(BoundaryOrder.DESCENDING);
+      assertThat(columnIndex.getNullCounts()).containsExactly(0L, 3L, 0L);
+      assertThat(columnIndex.getNullPages()).containsExactly(false, true, false);
       minValues = columnIndex.getMinValues();
-      assertEquals(3, minValues.size());
+      assertThat(minValues).hasSize(3);
       maxValues = columnIndex.getMaxValues();
-      assertEquals(3, maxValues.size());
-      assertEquals(100, BytesUtils.bytesToLong(minValues.get(0).array()));
-      assertEquals(117, BytesUtils.bytesToLong(maxValues.get(0).array()));
-      assertEquals(0, minValues.get(1).array().length);
-      assertEquals(0, maxValues.get(1).array().length);
-      assertEquals(0, BytesUtils.bytesToLong(minValues.get(2).array()));
-      assertEquals(0, BytesUtils.bytesToLong(maxValues.get(2).array()));
+      assertThat(maxValues).hasSize(3);
+      assertThat(BytesUtils.bytesToLong(minValues.get(0).array())).isEqualTo(100);
+      assertThat(BytesUtils.bytesToLong(maxValues.get(0).array())).isEqualTo(117);
+      assertThat(minValues.get(1).array().length).isEqualTo(0);
+      assertThat(maxValues.get(1).array().length).isEqualTo(0);
+      assertThat(BytesUtils.bytesToLong(minValues.get(2).array())).isEqualTo(0);
+      assertThat(BytesUtils.bytesToLong(maxValues.get(2).array())).isEqualTo(0);
 
       OffsetIndex offsetIndex =
           reader.readOffsetIndex(blockMeta.getColumns().get(0));
-      assertEquals(2, offsetIndex.getPageCount());
-      assertEquals(c1p1Starts, offsetIndex.getOffset(0));
-      assertEquals(c1p2Starts, offsetIndex.getOffset(1));
-      assertEquals(c1p2Starts - c1p1Starts, offsetIndex.getCompressedPageSize(0));
-      assertEquals(c1Ends - c1p2Starts, offsetIndex.getCompressedPageSize(1));
-      assertEquals(0, offsetIndex.getFirstRowIndex(0));
-      assertEquals(1, offsetIndex.getFirstRowIndex(1));
+      assertThat(offsetIndex.getPageCount()).isEqualTo(2);
+      assertThat(offsetIndex.getOffset(0)).isEqualTo(c1p1Starts);
+      assertThat(offsetIndex.getOffset(1)).isEqualTo(c1p2Starts);
+      assertThat(offsetIndex.getCompressedPageSize(0)).isEqualTo(c1p2Starts - c1p1Starts);
+      assertThat(offsetIndex.getCompressedPageSize(1)).isEqualTo(c1Ends - c1p2Starts);
+      assertThat(offsetIndex.getFirstRowIndex(0)).isEqualTo(0);
+      assertThat(offsetIndex.getFirstRowIndex(1)).isEqualTo(1);
 
       offsetIndex = reader.readOffsetIndex(blockMeta.getColumns().get(1));
-      assertEquals(3, offsetIndex.getPageCount());
-      assertEquals(c2p1Starts, offsetIndex.getOffset(0));
-      assertEquals(c2p2Starts, offsetIndex.getOffset(1));
-      assertEquals(c2p3Starts, offsetIndex.getOffset(2));
-      assertEquals(c2p2Starts - c2p1Starts, offsetIndex.getCompressedPageSize(0));
-      assertEquals(c2p3Starts - c2p2Starts, offsetIndex.getCompressedPageSize(1));
-      assertEquals(c2Ends - c2p3Starts, offsetIndex.getCompressedPageSize(2));
-      assertEquals(0, offsetIndex.getFirstRowIndex(0));
-      assertEquals(1, offsetIndex.getFirstRowIndex(1));
-      assertEquals(3, offsetIndex.getFirstRowIndex(2));
+      assertThat(offsetIndex.getPageCount()).isEqualTo(3);
+      assertThat(offsetIndex.getOffset(0)).isEqualTo(c2p1Starts);
+      assertThat(offsetIndex.getOffset(1)).isEqualTo(c2p2Starts);
+      assertThat(offsetIndex.getOffset(2)).isEqualTo(c2p3Starts);
+      assertThat(offsetIndex.getCompressedPageSize(0)).isEqualTo(c2p2Starts - c2p1Starts);
+      assertThat(offsetIndex.getCompressedPageSize(1)).isEqualTo(c2p3Starts - c2p2Starts);
+      assertThat(offsetIndex.getCompressedPageSize(2)).isEqualTo(c2Ends - c2p3Starts);
+      assertThat(offsetIndex.getFirstRowIndex(0)).isEqualTo(0);
+      assertThat(offsetIndex.getFirstRowIndex(1)).isEqualTo(1);
+      assertThat(offsetIndex.getFirstRowIndex(2)).isEqualTo(3);
 
       if (columnIndexTruncateLen == Integer.MAX_VALUE) {
-        assertNull(reader.readColumnIndex(
-            footer.getBlocks().get(2).getColumns().get(0)));
+        assertThat(reader.readColumnIndex(
+                footer.getBlocks().get(2).getColumns().get(0)))
+            .isNull();
       } else {
         blockMeta = footer.getBlocks().get(2);
-        assertNotNull(reader.readColumnIndex(blockMeta.getColumns().get(0)));
+        assertThat(reader.readColumnIndex(blockMeta.getColumns().get(0)))
+            .isNotNull();
         columnIndex = reader.readColumnIndex(blockMeta.getColumns().get(0));
-        assertEquals(BoundaryOrder.ASCENDING, columnIndex.getBoundaryOrder());
-        assertTrue(List.of(0l).equals(columnIndex.getNullCounts()));
-        assertTrue(List.of(false).equals(columnIndex.getNullPages()));
+        assertThat(columnIndex.getBoundaryOrder()).isEqualTo(BoundaryOrder.ASCENDING);
+        assertThat(columnIndex.getNullCounts()).containsExactly(0L);
+        assertThat(columnIndex.getNullPages()).containsExactly(false);
         minValues = columnIndex.getMinValues();
-        assertEquals(1, minValues.size());
+        assertThat(minValues).hasSize(1);
         maxValues = columnIndex.getMaxValues();
-        assertEquals(1, maxValues.size());
+        assertThat(maxValues).hasSize(1);
 
         BinaryTruncator truncator =
             BinaryTruncator.getTruncator(SCHEMA.getType(PATH1).asPrimitiveType());
-        assertEquals(
-            new String(new byte[1], StandardCharsets.UTF_8),
-            new String(minValues.get(0).array(), StandardCharsets.UTF_8));
+        assertThat(new String(minValues.get(0).array(), StandardCharsets.UTF_8))
+            .isEqualTo(new String(new byte[1], StandardCharsets.UTF_8));
         byte[] truncatedMaxValue = truncator
             .truncateMax(
                 Binary.fromConstantByteArray(new byte[(int) MAX_STATS_SIZE]), columnIndexTruncateLen)
             .getBytes();
-        assertEquals(
-            new String(truncatedMaxValue, StandardCharsets.UTF_8),
-            new String(maxValues.get(0).array(), StandardCharsets.UTF_8));
+        assertThat(new String(maxValues.get(0).array(), StandardCharsets.UTF_8))
+            .isEqualTo(new String(truncatedMaxValue, StandardCharsets.UTF_8));
 
-        assertNull(reader.readColumnIndex(blockMeta.getColumns().get(1)));
+        assertThat(reader.readColumnIndex(blockMeta.getColumns().get(1)))
+            .isNull();
       }
     }
   }
@@ -1454,19 +1436,15 @@ public class TestParquetFileWriter {
         keyValues2,
         "test");
     GlobalMetaData merged = ParquetFileWriter.mergeInto(md2, ParquetFileWriter.mergeInto(md1, null));
-    try {
-      merged.merge(new StrictKeyValueMetadataMergeStrategy());
-      fail("Merge metadata is expected to fail because of conflicting key values");
-    } catch (RuntimeException e) {
-      // expected because of conflicting values
-      assertTrue(e.getMessage().contains("could not merge metadata"));
-    }
+    assertThatThrownBy(() -> merged.merge(new StrictKeyValueMetadataMergeStrategy()))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("could not merge metadata");
 
     Map<String, String> mergedKeyValues =
         merged.merge(new ConcatenatingKeyValueMetadataMergeStrategy()).getKeyValueMetaData();
-    assertEquals(1, mergedKeyValues.size());
+    assertThat(mergedKeyValues).hasSize(1);
     String mergedValue = mergedKeyValues.get("a");
-    assertTrue(mergedValue.equals("b,c") || mergedValue.equals("c,b"));
+    assertThat(mergedValue).isIn("b,c", "c,b");
   }
 
   @Test
@@ -1494,8 +1472,8 @@ public class TestParquetFileWriter {
     GlobalMetaData merged = ParquetFileWriter.mergeInto(md2, ParquetFileWriter.mergeInto(md1, null));
     Map<String, String> mergedValues =
         merged.merge(new StrictKeyValueMetadataMergeStrategy()).getKeyValueMetaData();
-    assertEquals("b", mergedValues.get("a"));
-    assertEquals("d", mergedValues.get("c"));
+    assertThat(mergedValues.get("a")).isEqualTo("b");
+    assertThat(mergedValues.get("c")).isEqualTo("d");
   }
 
   private org.apache.parquet.column.statistics.Statistics<?> statsC1(Binary... values) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetOutputFormatJobSummaryLevel.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetOutputFormatJobSummaryLevel.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.ParquetOutputFormat.JobSummaryLevel;
@@ -29,7 +29,7 @@ public class TestParquetOutputFormatJobSummaryLevel {
   public void testDefault() throws Exception {
     Configuration conf = new Configuration();
     // default should be ALL
-    assertEquals(JobSummaryLevel.ALL, ParquetOutputFormat.getJobSummaryLevel(conf));
+    assertThat(ParquetOutputFormat.getJobSummaryLevel(conf)).isEqualTo(JobSummaryLevel.ALL);
   }
 
   @Test
@@ -37,10 +37,10 @@ public class TestParquetOutputFormatJobSummaryLevel {
     Configuration conf = new Configuration();
 
     conf.set(ParquetOutputFormat.ENABLE_JOB_SUMMARY, "true");
-    assertEquals(JobSummaryLevel.ALL, ParquetOutputFormat.getJobSummaryLevel(conf));
+    assertThat(ParquetOutputFormat.getJobSummaryLevel(conf)).isEqualTo(JobSummaryLevel.ALL);
 
     conf.set(ParquetOutputFormat.ENABLE_JOB_SUMMARY, "false");
-    assertEquals(JobSummaryLevel.NONE, ParquetOutputFormat.getJobSummaryLevel(conf));
+    assertThat(ParquetOutputFormat.getJobSummaryLevel(conf)).isEqualTo(JobSummaryLevel.NONE);
   }
 
   @Test
@@ -48,13 +48,13 @@ public class TestParquetOutputFormatJobSummaryLevel {
     Configuration conf = new Configuration();
 
     conf.set(ParquetOutputFormat.JOB_SUMMARY_LEVEL, "all");
-    assertEquals(JobSummaryLevel.ALL, ParquetOutputFormat.getJobSummaryLevel(conf));
+    assertThat(ParquetOutputFormat.getJobSummaryLevel(conf)).isEqualTo(JobSummaryLevel.ALL);
 
     conf.set(ParquetOutputFormat.JOB_SUMMARY_LEVEL, "common_only");
-    assertEquals(JobSummaryLevel.COMMON_ONLY, ParquetOutputFormat.getJobSummaryLevel(conf));
+    assertThat(ParquetOutputFormat.getJobSummaryLevel(conf)).isEqualTo(JobSummaryLevel.COMMON_ONLY);
 
     conf.set(ParquetOutputFormat.JOB_SUMMARY_LEVEL, "none");
-    assertEquals(JobSummaryLevel.NONE, ParquetOutputFormat.getJobSummaryLevel(conf));
+    assertThat(ParquetOutputFormat.getJobSummaryLevel(conf)).isEqualTo(JobSummaryLevel.NONE);
   }
 
   @Test
@@ -63,6 +63,6 @@ public class TestParquetOutputFormatJobSummaryLevel {
 
     conf.set(ParquetOutputFormat.JOB_SUMMARY_LEVEL, "common_only");
     conf.set(ParquetOutputFormat.ENABLE_JOB_SUMMARY, "false");
-    assertEquals(JobSummaryLevel.COMMON_ONLY, ParquetOutputFormat.getJobSummaryLevel(conf));
+    assertThat(ParquetOutputFormat.getJobSummaryLevel(conf)).isEqualTo(JobSummaryLevel.COMMON_ONLY);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetReader.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetReader.java
@@ -21,8 +21,8 @@ package org.apache.parquet.hadoop;
 import static org.apache.parquet.filter2.predicate.FilterApi.in;
 import static org.apache.parquet.filter2.predicate.FilterApi.longColumn;
 import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
@@ -184,22 +183,22 @@ public class TestParquetReader {
   public void testCurrentRowIndex() throws Exception {
     ParquetReader<Group> reader = PhoneBookWriter.createReader(file, FilterCompat.NOOP, allocator);
     // Fetch row index without processing any row.
-    assertEquals(reader.getCurrentRowIndex(), -1);
+    assertThat(reader.getCurrentRowIndex()).isEqualTo(-1);
     reader.read();
-    assertEquals(reader.getCurrentRowIndex(), 0);
+    assertThat(reader.getCurrentRowIndex()).isEqualTo(0);
     // calling the same API again and again should return same result.
-    assertEquals(reader.getCurrentRowIndex(), 0);
+    assertThat(reader.getCurrentRowIndex()).isEqualTo(0);
 
     reader.read();
-    assertEquals(reader.getCurrentRowIndex(), 1);
-    assertEquals(reader.getCurrentRowIndex(), 1);
+    assertThat(reader.getCurrentRowIndex()).isEqualTo(1);
+    assertThat(reader.getCurrentRowIndex()).isEqualTo(1);
     long expectedCurrentRowIndex = 2L;
     while (reader.read() != null) {
-      assertEquals(reader.getCurrentRowIndex(), expectedCurrentRowIndex);
+      assertThat(reader.getCurrentRowIndex()).isEqualTo(expectedCurrentRowIndex);
       expectedCurrentRowIndex++;
     }
     // reader.read() returned null and so reader doesn't have any more rows.
-    assertEquals(reader.getCurrentRowIndex(), -1);
+    assertThat(reader.getCurrentRowIndex()).isEqualTo(-1);
   }
 
   @Test
@@ -209,28 +208,30 @@ public class TestParquetReader {
         ParquetFileReader.open(HadoopInputFile.fromPath(file, new Configuration()))) {
       expectedRowGroups = fileReader.getRowGroups().size();
     }
-    assertTrue("expected multiple row groups for this test", expectedRowGroups > 1);
+    assertThat(expectedRowGroups)
+        .as("expected multiple row groups for this test")
+        .isGreaterThan(1);
 
     try (ParquetReader<Group> reader = PhoneBookWriter.createReader(file, FilterCompat.NOOP, allocator)) {
       // before reading anything, returns -1
-      assertEquals(-1, reader.getCurrentRowGroupIndex());
+      assertThat(reader.getCurrentRowGroupIndex()).isEqualTo(-1);
 
       reader.read();
-      assertEquals(0, reader.getCurrentRowGroupIndex());
+      assertThat(reader.getCurrentRowGroupIndex()).isEqualTo(0);
       // idempotent
-      assertEquals(0, reader.getCurrentRowGroupIndex());
+      assertThat(reader.getCurrentRowGroupIndex()).isEqualTo(0);
 
       int prevIdx = 0;
       while (reader.read() != null) {
         int idx = reader.getCurrentRowGroupIndex();
-        assertTrue(idx >= prevIdx);
-        assertTrue(idx <= prevIdx + 1);
+        assertThat(idx).isGreaterThanOrEqualTo(prevIdx);
+        assertThat(idx).isLessThanOrEqualTo(prevIdx + 1);
         prevIdx = idx;
       }
       // last row group seen should be the final one
-      assertEquals(expectedRowGroups - 1, prevIdx);
+      assertThat(prevIdx).isEqualTo(expectedRowGroups - 1);
       // after exhaustion, returns -1
-      assertEquals(-1, reader.getCurrentRowGroupIndex());
+      assertThat(reader.getCurrentRowGroupIndex()).isEqualTo(-1);
     }
   }
 
@@ -251,21 +252,21 @@ public class TestParquetReader {
     // The readUsers also validates the rowIndex for each returned row.
     List<PhoneBookWriter.User> filteredUsers1 =
         readUsers(FilterCompat.get(in(longColumn("id"), idSet)), true, true);
-    assertEquals(filteredUsers1.size(), 2L);
+    assertThat(filteredUsers1).hasSize(2);
     List<PhoneBookWriter.User> filteredUsers2 =
         readUsers(FilterCompat.get(in(longColumn("id"), idSet)), true, false);
-    assertEquals(filteredUsers2.size(), 2L);
+    assertThat(filteredUsers2).hasSize(2);
     List<PhoneBookWriter.User> filteredUsers3 =
         readUsers(FilterCompat.get(in(longColumn("id"), idSet)), false, false);
-    assertEquals(filteredUsers3.size(), 1000L);
+    assertThat(filteredUsers3).hasSize(1000);
   }
 
   @Test
   public void testNoFiltering() throws Exception {
-    assertEquals(DATA, readUsers(FilterCompat.NOOP, false, false));
-    assertEquals(DATA, readUsers(FilterCompat.NOOP, true, false));
-    assertEquals(DATA, readUsers(FilterCompat.NOOP, false, true));
-    assertEquals(DATA, readUsers(FilterCompat.NOOP, true, true));
+    assertThat(readUsers(FilterCompat.NOOP, false, false)).isEqualTo(DATA);
+    assertThat(readUsers(FilterCompat.NOOP, true, false)).isEqualTo(DATA);
+    assertThat(readUsers(FilterCompat.NOOP, false, true)).isEqualTo(DATA);
+    assertThat(readUsers(FilterCompat.NOOP, true, true)).isEqualTo(DATA);
   }
 
   private static class TestParquetReaderBuilder extends ParquetReader.Builder<Group> {
@@ -280,29 +281,30 @@ public class TestParquetReader {
   public void testParquetReaderBuilderWithInputFile() throws Exception {
     InputFile inputFile = HadoopInputFile.fromPath(file, new Configuration());
     Builder<Group> builder = new TestParquetReaderBuilder().withFile(inputFile);
-    assertEquals(DATA, PhoneBookWriter.readUsers(builder, false));
+    assertThat(PhoneBookWriter.readUsers(builder, false)).isEqualTo(DATA);
   }
 
   @Test
   public void testParquetReaderBuilderValidatesThatInputFileCanNotBeNull() throws Exception {
-    TestUtils.assertThrows("file cannot be null", NullPointerException.class, (Callable<ParquetReader<Group>>)
-        () -> new TestParquetReaderBuilder().withFile(null).build());
+    assertThatThrownBy(() -> new TestParquetReaderBuilder().withFile(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("file cannot be null");
   }
 
   @Test
   public void testParquetReaderBuilderValidatesThatInputFileIsSet() throws Exception {
-    TestUtils.assertThrows("File or Path must be set", IllegalStateException.class, (Callable<ParquetReader<Group>>)
-        () -> new TestParquetReaderBuilder().build());
+    assertThatThrownBy(() -> new TestParquetReaderBuilder().build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("File or Path must be set");
   }
 
   @Test
   public void testParquetReaderBuilderCanNotConfigurePathAndFile() throws Exception {
-    TestUtils.assertThrows(
-        "Path is already set", IllegalStateException.class, (Callable<ParquetReader<Group>>) () -> {
-          InputFile inputFile = HadoopInputFile.fromPath(file, new Configuration());
-          return ParquetReader.<Group>builder(new GroupReadSupport(), file)
-              .withFile(inputFile)
-              .build();
-        });
+    InputFile inputFile = HadoopInputFile.fromPath(file, new Configuration());
+    assertThatThrownBy(() -> ParquetReader.<Group>builder(new GroupReadSupport(), file)
+            .withFile(inputFile)
+            .build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Path is already set");
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetReaderEmptyBlock.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetReaderEmptyBlock.java
@@ -20,6 +20,7 @@ package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.filter2.predicate.FilterApi.gt;
 import static org.apache.parquet.filter2.predicate.FilterApi.intColumn;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -31,7 +32,6 @@ import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.io.InputFile;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestParquetReaderEmptyBlock {
@@ -61,11 +61,11 @@ public class TestParquetReaderEmptyBlock {
 
     // The parquet file contains only one empty row group
     ParquetMetadata readFooter = ParquetFileReader.readFooter(inputFile, options, inputFile.newStream());
-    Assert.assertEquals(1, readFooter.getBlocks().size());
+    assertThat(readFooter.getBlocks()).hasSize(1);
 
     // The empty block is skipped via readNextRowGroup()
     try (ParquetFileReader r = new ParquetFileReader(inputFile, options)) {
-      Assert.assertNull(r.readNextRowGroup());
+      assertThat(r.readNextRowGroup()).isNull();
     }
 
     // The empty block is skipped via readNextFilteredRowGroup()
@@ -76,7 +76,7 @@ public class TestParquetReaderEmptyBlock {
         .useStatsFilter(true)
         .build();
     try (ParquetFileReader r = new ParquetFileReader(inputFile, filterOptions)) {
-      Assert.assertNull(r.readNextFilteredRowGroup());
+      assertThat(r.readNextFilteredRowGroup()).isNull();
     }
   }
 
@@ -88,21 +88,21 @@ public class TestParquetReaderEmptyBlock {
 
     // The parquet file contains three row groups, the second one is empty
     ParquetMetadata readFooter = ParquetFileReader.readFooter(inputFile, options, inputFile.newStream());
-    Assert.assertEquals(3, readFooter.getBlocks().size());
+    assertThat(readFooter.getBlocks()).hasSize(3);
 
     // Second row group is empty and skipped via readNextRowGroup()
     try (ParquetFileReader r = new ParquetFileReader(inputFile, options)) {
       PageReadStore pages = null;
       pages = r.readNextRowGroup();
-      Assert.assertNotNull(pages);
-      Assert.assertEquals(1, pages.getRowCount());
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(1);
 
       pages = r.readNextRowGroup();
-      Assert.assertNotNull(pages);
-      Assert.assertEquals(3, pages.getRowCount());
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(3);
 
       pages = r.readNextRowGroup();
-      Assert.assertNull(pages);
+      assertThat(pages).isNull();
     }
 
     // Only the last row group is read via readNextFilteredRowGroup()
@@ -115,11 +115,11 @@ public class TestParquetReaderEmptyBlock {
     try (ParquetFileReader r = new ParquetFileReader(inputFile, filterOptions)) {
       PageReadStore pages = null;
       pages = r.readNextFilteredRowGroup();
-      Assert.assertNotNull(pages);
-      Assert.assertEquals(3, pages.getRowCount());
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(3);
 
       pages = r.readNextFilteredRowGroup();
-      Assert.assertNull(pages);
+      assertThat(pages).isNull();
     }
   }
 
@@ -131,21 +131,21 @@ public class TestParquetReaderEmptyBlock {
 
     // The parquet file contains four row groups, the second one and third one are empty
     ParquetMetadata readFooter = ParquetFileReader.readFooter(inputFile, options, inputFile.newStream());
-    Assert.assertEquals(4, readFooter.getBlocks().size());
+    assertThat(readFooter.getBlocks()).hasSize(4);
 
     // Second and third row groups are empty and skipped via readNextRowGroup()
     try (ParquetFileReader r = new ParquetFileReader(inputFile, options)) {
       PageReadStore pages = null;
       pages = r.readNextRowGroup();
-      Assert.assertNotNull(pages);
-      Assert.assertEquals(1, pages.getRowCount());
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(1);
 
       pages = r.readNextRowGroup();
-      Assert.assertNotNull(pages);
-      Assert.assertEquals(4, pages.getRowCount());
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(4);
 
       pages = r.readNextRowGroup();
-      Assert.assertNull(pages);
+      assertThat(pages).isNull();
     }
 
     // Only the last row group is read via readNextFilteredRowGroup()
@@ -158,11 +158,11 @@ public class TestParquetReaderEmptyBlock {
     try (ParquetFileReader r = new ParquetFileReader(inputFile, filterOptions)) {
       PageReadStore pages = null;
       pages = r.readNextFilteredRowGroup();
-      Assert.assertNotNull(pages);
-      Assert.assertEquals(4, pages.getRowCount());
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(4);
 
       pages = r.readNextFilteredRowGroup();
-      Assert.assertNull(pages);
+      assertThat(pages).isNull();
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetReaderRandomAccess.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetReaderRandomAccess.java
@@ -23,9 +23,8 @@ import static org.apache.parquet.filter2.predicate.FilterApi.longColumn;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -250,7 +249,7 @@ public class TestParquetReaderRandomAccess {
     public void assertValues(
         PageReadStore pages, List<Long> fromNumber, List<Long> toNumber, int index, int blockAmount) {
       if (index < 0 || index >= blockAmount) {
-        assertNull(pages);
+        assertThat(pages).isNull();
         return;
       }
 
@@ -261,22 +260,18 @@ public class TestParquetReaderRandomAccess {
       RecordReader<Group> recordReader = columnIO.getRecordReader(pages, new GroupRecordConverter(super.schema));
       for (long i = firstValue; i <= lastValue; i++) {
         Group group = recordReader.read();
-        assertEquals(i, group.getLong("i64", 0));
-        assertEquals((i % 2) == 0 ? 1 : 0, group.getLong("i64_flip", 0));
+        assertThat(group.getLong("i64", 0)).isEqualTo(i);
+        assertThat(group.getLong("i64_flip", 0)).isEqualTo((i % 2) == 0 ? 1 : 0);
       }
-      boolean exceptionThrown = false;
-      try {
-        recordReader.read();
-      } catch (ParquetDecodingException e) {
-        exceptionThrown = true;
-      }
-      assertTrue(exceptionThrown);
+      assertThatThrownBy(recordReader::read)
+          .isInstanceOf(ParquetDecodingException.class)
+          .hasMessageContaining("Can't read value in column");
     }
 
     public void assertFilteredValues(
         PageReadStore pages, List<Long> fromNumber, List<Long> toNumber, int index, int blockAmount) {
       if (index < 0 || index >= blockAmount) {
-        assertNull(pages);
+        assertThat(pages).isNull();
         return;
       }
 
@@ -290,20 +285,17 @@ public class TestParquetReaderRandomAccess {
       for (long i = firstValue; i <= lastValue; i++) {
         Group group = recordReader.read();
         if ((i % 2) == 0) {
-          assertEquals(i, group.getLong("i64", 0));
-          assertEquals(1, group.getLong("i64_flip", 0));
+          assertThat(group.getLong("i64", 0)).isEqualTo(i);
+          assertThat(group.getLong("i64_flip", 0)).isEqualTo(1);
         } else {
-          assertTrue(group == null || recordReader.shouldSkipCurrentRecord());
+          assertThat(group == null || recordReader.shouldSkipCurrentRecord())
+              .isTrue();
         }
       }
 
-      boolean exceptionThrown = false;
-      try {
-        recordReader.read();
-      } catch (ParquetDecodingException e) {
-        exceptionThrown = true;
-      }
-      assertTrue(exceptionThrown);
+      assertThatThrownBy(recordReader::read)
+          .isInstanceOf(ParquetDecodingException.class)
+          .hasMessageContaining("Can't read value in column");
     }
 
     protected abstract void test(

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriter.java
@@ -38,10 +38,9 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BOOLEAN;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Offset.offset;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
@@ -52,7 +51,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import net.openhft.hashing.LongHashFunction;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -103,7 +101,6 @@ import org.apache.parquet.schema.InvalidSchemaException;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -208,16 +205,16 @@ public class TestParquetWriter {
             .build();
         for (int i = 0; i < 1000; i++) {
           Group group = reader.read();
-          assertEquals(
-              "test" + (i % modulo),
-              group.getBinary("binary_field", 0).toStringUsingUTF8());
-          assertEquals(32, group.getInteger("int32_field", 0));
-          assertEquals(64l, group.getLong("int64_field", 0));
-          assertEquals(true, group.getBoolean("boolean_field", 0));
-          assertEquals(1.0f, group.getFloat("float_field", 0), 0.001);
-          assertEquals(2.0d, group.getDouble("double_field", 0), 0.001);
-          assertEquals("foo", group.getBinary("flba_field", 0).toStringUsingUTF8());
-          assertEquals(Binary.fromConstantByteArray(new byte[12]), group.getInt96("int96_field", 0));
+          assertThat(group.getBinary("binary_field", 0).toStringUsingUTF8())
+              .isEqualTo("test" + (i % modulo));
+          assertThat(group.getInteger("int32_field", 0)).isEqualTo(32);
+          assertThat(group.getLong("int64_field", 0)).isEqualTo(64l);
+          assertThat(group.getBoolean("boolean_field", 0)).isEqualTo(true);
+          assertThat(group.getFloat("float_field", 0)).isCloseTo(1.0f, offset(0.001f));
+          assertThat(group.getDouble("double_field", 0)).isCloseTo(2.0d, offset(0.001));
+          assertThat(group.getBinary("flba_field", 0).toStringUsingUTF8())
+              .isEqualTo("foo");
+          assertThat(group.getInt96("int96_field", 0)).isEqualTo(Binary.fromConstantByteArray(new byte[12]));
         }
         reader.close();
         ParquetMetadata footer = readFooter(conf, file, NO_FILTER);
@@ -226,16 +223,15 @@ public class TestParquetWriter {
             if (column.getPath().toDotString().equals("binary_field")) {
               String key = modulo + "-" + version;
               Encoding expectedEncoding = expected.get(key);
-              assertTrue(
-                  key + ":" + column.getEncodings() + " should contain " + expectedEncoding,
-                  column.getEncodings().contains(expectedEncoding));
+              assertThat(column.getEncodings())
+                  .as(key + ":" + column.getEncodings() + " should contain " + expectedEncoding)
+                  .contains(expectedEncoding);
             }
           }
         }
-        assertEquals(
-            "Object model property should be example",
-            "example",
-            footer.getFileMetaData().getKeyValueMetaData().get(ParquetWriter.OBJECT_MODEL_NAME_PROP));
+        assertThat(footer.getFileMetaData().getKeyValueMetaData().get(ParquetWriter.OBJECT_MODEL_NAME_PROP))
+            .as("Object model property should be example")
+            .isEqualTo("example");
       }
     }
   }
@@ -248,18 +244,16 @@ public class TestParquetWriter {
     final File file = temp.newFile("test.parquet");
     file.delete();
 
-    TestUtils.assertThrows(
-        "Should reject a schema with an empty group", InvalidSchemaException.class, (Callable<Void>) () -> {
-          ExampleParquetWriter.builder(new Path(file.toString()))
-              .withAllocator(allocator)
-              .withType(Types.buildMessage()
-                  .addField(new GroupType(REQUIRED, "invalid_group"))
-                  .named("invalid_message"))
-              .build();
-          return null;
-        });
+    assertThatThrownBy(() -> ExampleParquetWriter.builder(new Path(file.toString()))
+            .withAllocator(allocator)
+            .withType(Types.buildMessage()
+                .addField(new GroupType(REQUIRED, "invalid_group"))
+                .named("invalid_message"))
+            .build())
+        .isInstanceOf(InvalidSchemaException.class)
+        .hasMessageContaining("Cannot write a schema with an empty group");
 
-    assertFalse("Should not create a file when schema is rejected", file.exists());
+    assertThat(file).as("Should not create a file when schema is rejected").doesNotExist();
   }
 
   // Testing the issue of PARQUET-1531 where writing null nested rows leads to empty pages if the page row count limit
@@ -296,10 +290,12 @@ public class TestParquetWriter {
         ParquetReader.builder(new GroupReadSupport(), path).build()) {
       int readRecordCount = 0;
       for (Group group = reader.read(); group != null; group = reader.read()) {
-        assertEquals(listNull.toString(), group.toString());
+        assertThat(group).asString().isEqualTo(listNull.toString());
         ++readRecordCount;
       }
-      assertEquals("Number of written records should be equal to the read one", recordCount, readRecordCount);
+      assertThat(readRecordCount)
+          .as("Number of written records should be equal to the read one")
+          .isEqualTo(recordCount);
     }
   }
 
@@ -337,8 +333,9 @@ public class TestParquetWriter {
           .readBloomFilter(blockMetaData.getColumns().get(0));
 
       for (String name : testNames) {
-        assertTrue(bloomFilter.findHash(
-            LongHashFunction.xx(0).hashBytes(Binary.fromString(name).toByteBuffer())));
+        assertThat(bloomFilter.findHash(LongHashFunction.xx(0)
+                .hashBytes(Binary.fromString(name).toByteBuffer())))
+            .isTrue();
       }
     }
   }
@@ -403,7 +400,7 @@ public class TestParquetWriter {
         }
         // The false positive should be less than totalCount * fpp. Add 15% here for error space.
         double expectedFalsePositiveMaxCount = Math.floor(testBloomFilterCount * (testFpp * 1.15));
-        assertTrue(falsePositive < expectedFalsePositiveMaxCount && falsePositive > 0);
+        assertThat(falsePositive).isGreaterThan(0).isLessThan((int) expectedFalsePositiveMaxCount);
       }
     }
   }
@@ -447,7 +444,7 @@ public class TestParquetWriter {
       BlockMetaData blockMetaData = reader.getFooter().getBlocks().get(0);
       BloomFilter bloomFilter = reader.getBloomFilterDataReader(blockMetaData)
           .readBloomFilter(blockMetaData.getColumns().get(0));
-      assertEquals(bloomFilter.getBitsetSize(), maxBloomFilterBytes);
+      assertThat(bloomFilter.getBitsetSize()).isEqualTo(maxBloomFilterBytes);
     }
   }
 
@@ -492,16 +489,15 @@ public class TestParquetWriter {
 
       final ParquetFileReader reader =
           ParquetFileReader.open(HadoopInputFile.fromPath(filePath, new Configuration()));
-      assertEquals(1000, reader.readNextRowGroup().getRowCount());
-      assertEquals(
-          ImmutableMap.of(
+      assertThat(reader.readNextRowGroup().getRowCount()).isEqualTo(1000);
+      assertThat(reader.getFileMetaData().getKeyValueMetaData())
+          .isEqualTo(ImmutableMap.of(
               "simple-key",
               "some-value-1",
               "nested.key",
               "some-value-2",
               ParquetWriter.OBJECT_MODEL_NAME_PROP,
-              "example"),
-          reader.getFileMetaData().getKeyValueMetaData());
+              "example"));
 
       reader.close();
     }
@@ -519,11 +515,12 @@ public class TestParquetWriter {
     for (WriterVersion version : WriterVersion.values()) {
       final Path filePath = new Path(testDir.getAbsolutePath(), version.name());
 
-      Assert.assertThrows(IllegalArgumentException.class, () -> ExampleParquetWriter.builder(
-              new TestOutputFile(filePath, conf))
-          .withConf(conf)
-          .withExtraMetaData(ImmutableMap.of(ParquetWriter.OBJECT_MODEL_NAME_PROP, "some-value-3"))
-          .build());
+      assertThatThrownBy(() -> ExampleParquetWriter.builder(new TestOutputFile(filePath, conf))
+              .withConf(conf)
+              .withExtraMetaData(ImmutableMap.of(ParquetWriter.OBJECT_MODEL_NAME_PROP, "some-value-3"))
+              .build())
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Cannot overwrite metadata key " + ParquetWriter.OBJECT_MODEL_NAME_PROP);
     }
   }
 
@@ -563,7 +560,7 @@ public class TestParquetWriter {
 
     try (ParquetFileReader reader = ParquetFileReader.open(HadoopInputFile.fromPath(path, conf))) {
       ParquetMetadata footer = reader.getFooter();
-      assertEquals(expectedNumberOfBlocks, footer.getBlocks().size());
+      assertThat(footer.getBlocks()).hasSize(expectedNumberOfBlocks);
     }
   }
 
@@ -602,8 +599,8 @@ public class TestParquetWriter {
       // Verify size statistics are disabled globally
       for (BlockMetaData block : reader.getFooter().getBlocks()) {
         for (ColumnChunkMetaData column : block.getColumns()) {
-          assertTrue(column.getStatistics().isEmpty()); // Make sure there is no column statistics
-          assertNull(column.getSizeStatistics());
+          assertThat(column.getStatistics().isEmpty()).isTrue(); // Make sure there is no column statistics
+          assertThat(column.getSizeStatistics()).isNull();
         }
       }
     }
@@ -626,11 +623,11 @@ public class TestParquetWriter {
       for (BlockMetaData block : reader.getFooter().getBlocks()) {
         for (ColumnChunkMetaData column : block.getColumns()) {
           if (column.getPath().toDotString().equals("boolean_field")) {
-            assertNull(column.getSizeStatistics());
-            assertTrue(column.getStatistics().isEmpty());
+            assertThat(column.getSizeStatistics()).isNull();
+            assertThat(column.getStatistics().isEmpty()).isTrue();
           } else {
-            assertTrue(column.getSizeStatistics().isValid());
-            assertFalse(column.getStatistics().isEmpty());
+            assertThat(column.getSizeStatistics().isValid()).isTrue();
+            assertThat(column.getStatistics().isEmpty()).isFalse();
           }
         }
       }
@@ -662,7 +659,7 @@ public class TestParquetWriter {
     try (ParquetFileReader reader = ParquetFileReader.open(HadoopInputFile.fromPath(path, new Configuration()))) {
       for (BlockMetaData block : reader.getFooter().getBlocks()) {
         for (ColumnChunkMetaData column : block.getColumns()) {
-          assertTrue(column.getEncodings().contains(Encoding.BYTE_STREAM_SPLIT));
+          assertThat(column.getEncodings()).contains(Encoding.BYTE_STREAM_SPLIT);
         }
       }
     }
@@ -670,8 +667,8 @@ public class TestParquetWriter {
     try (ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), path).build()) {
       Group group = reader.read();
-      assertEquals(0.3f, group.getFloat("float_field", 0), 0.0);
-      assertEquals(42, group.getInteger("int32_field", 0));
+      assertThat(group.getFloat("float_field", 0)).isEqualTo(0.3f);
+      assertThat(group.getInteger("int32_field", 0)).isEqualTo(42);
     }
   }
 
@@ -744,10 +741,12 @@ public class TestParquetWriter {
         .build()) {
       int readRecordCount = 0;
       for (Group group = reader.read(); group != null; group = reader.read()) {
-        assertEquals(nullValue.toString(), group.toString());
+        assertThat(group).asString().isEqualTo(nullValue.toString());
         ++readRecordCount;
       }
-      assertEquals("Number of written records should be equal to the read one", recordCount, readRecordCount);
+      assertThat(readRecordCount)
+          .as("Number of written records should be equal to the read one")
+          .isEqualTo(recordCount);
     }
 
     ParquetReadOptions options = ParquetReadOptions.builder()
@@ -766,10 +765,12 @@ public class TestParquetWriter {
             fileDecryptor.getFileAAD(), ModuleCipherFactory.ModuleType.DataPageHeader, 0, 0, 0);
         PageHeader pageHeader =
             Util.readPageHeader(reader.f, columnDecryptionSetup.getMetaDataDecryptor(), dataPageHeaderAAD);
-        assertFalse(pageHeader.getData_page_header_v2().isIs_compressed());
+        assertThat(pageHeader.getData_page_header_v2().isIs_compressed())
+            .isFalse();
       } else {
         PageHeader pageHeader = Util.readPageHeader(reader.f);
-        assertFalse(pageHeader.getData_page_header_v2().isIs_compressed());
+        assertThat(pageHeader.getData_page_header_v2().isIs_compressed())
+            .isFalse();
       }
     }
   }
@@ -802,23 +803,25 @@ public class TestParquetWriter {
     }
     ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), path).build();
-    assertEquals("new", reader.read().getBinary("name", 0).toStringUsingUTF8());
-    assertEquals("writer", reader.read().getBinary("name", 0).toStringUsingUTF8());
-    assertEquals("builder", reader.read().getBinary("name", 0).toStringUsingUTF8());
-    assertEquals("without", reader.read().getBinary("name", 0).toStringUsingUTF8());
-    assertEquals("file", reader.read().getBinary("name", 0).toStringUsingUTF8());
+    assertThat(reader.read().getBinary("name", 0).toStringUsingUTF8()).isEqualTo("new");
+    assertThat(reader.read().getBinary("name", 0).toStringUsingUTF8()).isEqualTo("writer");
+    assertThat(reader.read().getBinary("name", 0).toStringUsingUTF8()).isEqualTo("builder");
+    assertThat(reader.read().getBinary("name", 0).toStringUsingUTF8()).isEqualTo("without");
+    assertThat(reader.read().getBinary("name", 0).toStringUsingUTF8()).isEqualTo("file");
   }
 
   @Test
   public void testParquetWriterBuilderOutputFileCanNotBeNull() throws IOException {
-    TestUtils.assertThrows("file cannot be null", NullPointerException.class, (Callable<ParquetWriter<Group>>)
-        () -> ExampleParquetWriter.builder().withFile(null).build());
+    assertThatThrownBy(() -> ExampleParquetWriter.builder().withFile(null).build())
+        .isInstanceOf(NullPointerException.class)
+        .hasMessage("file cannot be null");
   }
 
   @Test
   public void testParquetWriterBuilderValidatesThatOutputFileIsSet() throws IOException {
-    TestUtils.assertThrows("File or Path must be set", IllegalStateException.class, (Callable<ParquetWriter<Group>>)
-        () -> ExampleParquetWriter.builder().build());
+    assertThatThrownBy(() -> ExampleParquetWriter.builder().build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("File or Path must be set");
   }
 
   @Test
@@ -827,9 +830,10 @@ public class TestParquetWriter {
     Path path = new Path(file.getAbsolutePath());
     Configuration conf = new Configuration();
     OutputFile outputFile = new TestOutputFile(path, conf);
-    TestUtils.assertThrows(
-        "Cannot set both path and file", IllegalStateException.class, (Callable<ParquetWriter<Group>>) () ->
-            ExampleParquetWriter.builder(path).withFile(outputFile).build());
+    assertThatThrownBy(() ->
+            ExampleParquetWriter.builder(path).withFile(outputFile).build())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set both path and file");
   }
 
   @Test
@@ -860,8 +864,8 @@ public class TestParquetWriter {
     for (ColumnChunkMetaData col : footer.getBlocks().get(0).getColumns()) {
       codecs.put(col.getPath().toDotString(), col.getCodec());
     }
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(SNAPPY, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(SNAPPY);
   }
 
   @Test
@@ -888,7 +892,9 @@ public class TestParquetWriter {
 
     ParquetMetadata footer = readFooter(new Configuration(), path, NO_FILTER);
     for (ColumnChunkMetaData col : footer.getBlocks().get(0).getColumns()) {
-      assertEquals("Column " + col.getPath().toDotString() + " should use default codec", GZIP, col.getCodec());
+      assertThat(col.getCodec())
+          .as("Column " + col.getPath().toDotString() + " should use default codec")
+          .isEqualTo(GZIP);
     }
   }
 
@@ -919,9 +925,9 @@ public class TestParquetWriter {
     try (ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), path).build()) {
       Group group = reader.read();
-      assertEquals("hello", group.getBinary("col_a", 0).toStringUsingUTF8());
-      assertEquals(42, group.getInteger("col_b", 0));
-      assertNull(reader.read());
+      assertThat(group.getBinary("col_a", 0).toStringUsingUTF8()).isEqualTo("hello");
+      assertThat(group.getInteger("col_b", 0)).isEqualTo(42);
+      assertThat(reader.read()).isNull();
     }
 
     ParquetMetadata footer = readFooter(new Configuration(), path, NO_FILTER);
@@ -929,8 +935,8 @@ public class TestParquetWriter {
     for (ColumnChunkMetaData col : footer.getBlocks().get(0).getColumns()) {
       codecs.put(col.getPath().toDotString(), col.getCodec());
     }
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(SNAPPY, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(SNAPPY);
   }
 
   @Test
@@ -945,16 +951,18 @@ public class TestParquetWriter {
     Path path = new Path(file.getAbsolutePath());
 
     // ZSTD only supports levels 1-22; level 23 is invalid
-    Assert.assertThrows(BadConfigurationException.class, () -> {
-      try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(path)
-          .withAllocator(allocator)
-          .withType(schema)
-          .withCompressionCodec("col_a", ZSTD)
-          .withCompressionLevel("col_a", 23)
-          .build()) {
-        // exception expected before first write
-      }
-    });
+    assertThatThrownBy(() -> {
+          try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(path)
+              .withAllocator(allocator)
+              .withType(schema)
+              .withCompressionCodec("col_a", ZSTD)
+              .withCompressionLevel("col_a", 23)
+              .build()) {
+            // exception expected before first write
+          }
+        })
+        .isInstanceOf(BadConfigurationException.class)
+        .hasMessageContaining("23");
   }
 
   @Test
@@ -969,16 +977,18 @@ public class TestParquetWriter {
     Path path = new Path(file.getAbsolutePath());
 
     // GZIP only supports levels -1 (default) through 9; level 10 is invalid
-    Assert.assertThrows(BadConfigurationException.class, () -> {
-      try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(path)
-          .withAllocator(allocator)
-          .withType(schema)
-          .withCompressionCodec("col_a", GZIP)
-          .withCompressionLevel("col_a", 10)
-          .build()) {
-        // exception expected before first write
-      }
-    });
+    assertThatThrownBy(() -> {
+          try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(path)
+              .withAllocator(allocator)
+              .withType(schema)
+              .withCompressionCodec("col_a", GZIP)
+              .withCompressionLevel("col_a", 10)
+              .build()) {
+            // exception expected before first write
+          }
+        })
+        .isInstanceOf(BadConfigurationException.class)
+        .hasMessageContaining("10");
   }
 
   @Test
@@ -1011,16 +1021,18 @@ public class TestParquetWriter {
     // Both columns must report ZSTD in the footer
     ParquetMetadata footer = readFooter(new Configuration(), path, NO_FILTER);
     for (ColumnChunkMetaData col : footer.getBlocks().get(0).getColumns()) {
-      assertEquals("Column " + col.getPath().toDotString() + " should use ZSTD", ZSTD, col.getCodec());
+      assertThat(col.getCodec())
+          .as("Column " + col.getPath().toDotString() + " should use ZSTD")
+          .isEqualTo(ZSTD);
     }
 
     // Data must survive the round-trip at both levels
     try (ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), path).build()) {
       Group group = reader.read();
-      assertEquals("fast", group.getBinary("col_a", 0).toStringUsingUTF8());
-      assertEquals("best", group.getBinary("col_b", 0).toStringUsingUTF8());
-      assertNull(reader.read());
+      assertThat(group.getBinary("col_a", 0).toStringUsingUTF8()).isEqualTo("fast");
+      assertThat(group.getBinary("col_b", 0).toStringUsingUTF8()).isEqualTo("best");
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -1053,8 +1065,8 @@ public class TestParquetWriter {
     for (ColumnChunkMetaData col : footer.getBlocks().get(0).getColumns()) {
       codecs.put(col.getPath().toDotString(), col.getCodec());
     }
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(GZIP, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(GZIP);
   }
 
   @Test
@@ -1090,9 +1102,11 @@ public class TestParquetWriter {
       writer.close();
     }
 
-    // After closing, check whether file exists or is empty
+    // After closing, check that no data was written to the file
     FileSystem fs = file.getFileSystem(conf);
-    assertTrue(!fs.exists(file) || fs.getFileStatus(file).getLen() == 0);
+    if (fs.exists(file)) {
+      assertThat(fs.getFileStatus(file).getLen()).isZero();
+    }
   }
 
   @Test
@@ -1112,8 +1126,8 @@ public class TestParquetWriter {
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecsViaOutputFormat(schema, SNAPPY, job, path);
 
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(SNAPPY, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(SNAPPY);
   }
 
   @Test
@@ -1134,8 +1148,8 @@ public class TestParquetWriter {
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecsViaOutputFormat(schema, SNAPPY, job, path);
 
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(GZIP, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(GZIP);
   }
 
   @Test
@@ -1154,8 +1168,8 @@ public class TestParquetWriter {
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecsViaOutputFormat(schema, GZIP, job, path);
 
-    assertEquals(GZIP, codecs.get("col_a"));
-    assertEquals(GZIP, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(GZIP);
+    assertThat(codecs.get("col_b")).isEqualTo(GZIP);
   }
 
   @Test
@@ -1175,15 +1189,15 @@ public class TestParquetWriter {
     ParquetOutputFormat.setColumnCompressionLevel(job, "col_a", 1);
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecsViaOutputFormat(schema, SNAPPY, job, path);
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(SNAPPY, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(SNAPPY);
 
     try (ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), path).build()) {
       Group group = reader.read();
-      assertEquals("hello", group.getBinary("col_a", 0).toStringUsingUTF8());
-      assertEquals(42, group.getInteger("col_b", 0));
-      assertNull(reader.read());
+      assertThat(group.getBinary("col_a", 0).toStringUsingUTF8()).isEqualTo("hello");
+      assertThat(group.getInteger("col_b", 0)).isEqualTo(42);
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -1205,15 +1219,15 @@ public class TestParquetWriter {
     ParquetOutputFormat.setColumnCompressionLevel(job, "col_b", 10);
 
     Map<String, CompressionCodecName> codecs = writeAndReadCodecsViaOutputFormat(schema, ZSTD, job, path);
-    assertEquals(ZSTD, codecs.get("col_a"));
-    assertEquals(ZSTD, codecs.get("col_b"));
+    assertThat(codecs.get("col_a")).isEqualTo(ZSTD);
+    assertThat(codecs.get("col_b")).isEqualTo(ZSTD);
 
     try (ParquetReader<Group> reader =
         ParquetReader.builder(new GroupReadSupport(), path).build()) {
       Group group = reader.read();
-      assertEquals("hello", group.getBinary("col_a", 0).toStringUsingUTF8());
-      assertEquals("fast", group.getBinary("col_b", 0).toStringUsingUTF8());
-      assertNull(reader.read());
+      assertThat(group.getBinary("col_a", 0).toStringUsingUTF8()).isEqualTo("hello");
+      assertThat(group.getBinary("col_b", 0).toStringUsingUTF8()).isEqualTo("fast");
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -1303,16 +1317,15 @@ public class TestParquetWriter {
       DataPage page = pageReader.readPage();
 
       // Verify it's a V2 page (because we used PARQUET_2_0)
-      assertTrue(
-          "PARQUET_2_0 writer should produce DataPageV2 pages, got: "
-              + page.getClass().getSimpleName(),
-          page instanceof DataPageV2);
+      assertThat(page)
+          .as("PARQUET_2_0 writer should produce DataPageV2 pages, got: "
+              + page.getClass().getSimpleName())
+          .isInstanceOf(DataPageV2.class);
 
       DataPageV2 pageV2 = (DataPageV2) page;
-      assertEquals(
-          "DataPageV2.num_nulls should be the actual null count even when statistics are disabled",
-          expectedNulls,
-          pageV2.getNullCount());
+      assertThat(pageV2.getNullCount())
+          .as("DataPageV2.num_nulls should be the actual null count even when statistics are disabled")
+          .isEqualTo(expectedNulls);
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterAppendBlocks.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterAppendBlocks.java
@@ -23,6 +23,8 @@ import static org.apache.parquet.schema.OriginalType.UTF8;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,7 +35,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.Callable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
@@ -47,7 +48,6 @@ import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -135,12 +135,13 @@ public class TestParquetWriterAppendBlocks {
     while ((next = reader.read()) != null) {
       Group expectedNext = expected.removeFirst();
       // check each value; equals is not supported for simple records
-      Assert.assertEquals("Each id should match", expectedNext.getInteger("id", 0), next.getInteger("id", 0));
-      Assert.assertEquals(
-          "Each string should match", expectedNext.getString("string", 0), next.getString("string", 0));
+      assertThat(next.getInteger("id", 0)).as("Each id should match").isEqualTo(expectedNext.getInteger("id", 0));
+      assertThat(next.getString("string", 0))
+          .as("Each string should match")
+          .isEqualTo(expectedNext.getString("string", 0));
     }
 
-    Assert.assertEquals("All records should be present", 0, expected.size());
+    assertThat(expected).as("All records should be present").isEmpty();
   }
 
   /**
@@ -166,11 +167,14 @@ public class TestParquetWriterAppendBlocks {
       for (Group expectedNext : expected) {
         Group next = reader.read();
         // check each value; equals is not supported for simple records
-        Assert.assertEquals("Each id should match", expectedNext.getInteger("id", 0), next.getInteger("id", 0));
-        Assert.assertEquals(
-            "Each string should match", expectedNext.getString("string", 0), next.getString("string", 0));
+        assertThat(next.getInteger("id", 0))
+            .as("Each id should match")
+            .isEqualTo(expectedNext.getInteger("id", 0));
+        assertThat(next.getString("string", 0))
+            .as("Each string should match")
+            .isEqualTo(expectedNext.getString("string", 0));
       }
-      Assert.assertNull("No extra records should be present", reader.read());
+      assertThat(reader.read()).as("No extra records should be present").isNull();
     }
   }
 
@@ -200,33 +204,38 @@ public class TestParquetWriterAppendBlocks {
     expectedRowGroups.addAll(f1Footer.getBlocks());
     expectedRowGroups.addAll(f2Footer.getBlocks());
 
-    Assert.assertEquals(
-        "Combined should have the right number of row groups",
-        expectedRowGroups.size(),
-        combinedFooter.getBlocks().size());
+    assertThat(combinedFooter.getBlocks())
+        .as("Combined should have the right number of row groups")
+        .hasSameSizeAs(expectedRowGroups);
 
     long nextStart = 4;
     for (BlockMetaData rowGroup : combinedFooter.getBlocks()) {
       BlockMetaData expected = expectedRowGroups.removeFirst();
-      Assert.assertEquals("Row count should match", expected.getRowCount(), rowGroup.getRowCount());
-      Assert.assertEquals(
-          "Compressed size should match", expected.getCompressedSize(), rowGroup.getCompressedSize());
-      Assert.assertEquals("Total size should match", expected.getTotalByteSize(), rowGroup.getTotalByteSize());
-      Assert.assertEquals(
-          "Start pos should be at the last row group's end", nextStart, rowGroup.getStartingPos());
+      assertThat(rowGroup.getRowCount()).as("Row count should match").isEqualTo(expected.getRowCount());
+      assertThat(rowGroup.getCompressedSize())
+          .as("Compressed size should match")
+          .isEqualTo(expected.getCompressedSize());
+      assertThat(rowGroup.getTotalByteSize())
+          .as("Total size should match")
+          .isEqualTo(expected.getTotalByteSize());
+      assertThat(rowGroup.getStartingPos())
+          .as("Start pos should be at the last row group's end")
+          .isEqualTo(nextStart);
       assertColumnsEquivalent(expected.getColumns(), rowGroup.getColumns());
       nextStart = rowGroup.getStartingPos() + rowGroup.getTotalByteSize();
     }
   }
 
   public void assertColumnsEquivalent(List<ColumnChunkMetaData> expected, List<ColumnChunkMetaData> actual) {
-    Assert.assertEquals("Should have the expected columns", expected.size(), actual.size());
+    assertThat(actual).as("Should have the expected columns").hasSameSizeAs(expected);
     for (int i = 0; i < actual.size(); i += 1) {
       ColumnChunkMetaData current = actual.get(i);
       if (i != 0) {
         ColumnChunkMetaData previous = actual.get(i - 1);
         long expectedStart = previous.getStartingPos() + previous.getTotalSize();
-        Assert.assertEquals("Should start after the previous column", expectedStart, current.getStartingPos());
+        assertThat(current.getStartingPos())
+            .as("Should start after the previous column")
+            .isEqualTo(expectedStart);
       }
 
       assertColumnMetadataEquivalent(expected.get(i), current);
@@ -234,17 +243,20 @@ public class TestParquetWriterAppendBlocks {
   }
 
   public void assertColumnMetadataEquivalent(ColumnChunkMetaData expected, ColumnChunkMetaData actual) {
-    Assert.assertEquals("Should be the expected column", expected.getPath(), expected.getPath());
-    Assert.assertEquals("Primitive type should not change", expected.getType(), actual.getType());
-    Assert.assertEquals("Compression codec should not change", expected.getCodec(), actual.getCodec());
-    Assert.assertEquals("Data encodings should not change", expected.getEncodings(), actual.getEncodings());
-    Assert.assertEquals("Statistics should not change", expected.getStatistics(), actual.getStatistics());
-    Assert.assertEquals(
-        "Uncompressed size should not change",
-        expected.getTotalUncompressedSize(),
-        actual.getTotalUncompressedSize());
-    Assert.assertEquals("Compressed size should not change", expected.getTotalSize(), actual.getTotalSize());
-    Assert.assertEquals("Number of values should not change", expected.getValueCount(), actual.getValueCount());
+    assertThat(actual.getPath()).as("Should be the expected column").isEqualTo(expected.getPath());
+    assertThat(actual.getType()).as("Primitive type should not change").isEqualTo(expected.getType());
+    assertThat(actual.getCodec()).as("Compression codec should not change").isEqualTo(expected.getCodec());
+    assertThat(actual.getEncodings()).as("Data encodings should not change").isEqualTo(expected.getEncodings());
+    assertThat(actual.getStatistics()).as("Statistics should not change").isEqualTo(expected.getStatistics());
+    assertThat(actual.getTotalUncompressedSize())
+        .as("Uncompressed size should not change")
+        .isEqualTo(expected.getTotalUncompressedSize());
+    assertThat(actual.getTotalSize())
+        .as("Compressed size should not change")
+        .isEqualTo(expected.getTotalSize());
+    assertThat(actual.getValueCount())
+        .as("Number of values should not change")
+        .isEqualTo(expected.getValueCount());
   }
 
   @Test
@@ -265,10 +277,9 @@ public class TestParquetWriterAppendBlocks {
 
     ParquetMetadata footer = ParquetFileReader.readFooter(CONF, droppedColumnFile, NO_FILTER);
     for (BlockMetaData rowGroup : footer.getBlocks()) {
-      Assert.assertEquals(
-          "Should have only the string column",
-          1,
-          rowGroup.getColumns().size());
+      assertThat(rowGroup.getColumns())
+          .as("Should have only the string column")
+          .hasSize(1);
     }
 
     ParquetReader<Group> reader =
@@ -277,11 +288,12 @@ public class TestParquetWriterAppendBlocks {
     Group next;
     while ((next = reader.read()) != null) {
       Group expectedNext = expected.removeFirst();
-      Assert.assertEquals(
-          "Each string should match", expectedNext.getString("string", 0), next.getString("string", 0));
+      assertThat(next.getString("string", 0))
+          .as("Each string should match")
+          .isEqualTo(expectedNext.getString("string", 0));
     }
 
-    Assert.assertEquals("All records should be present", 0, expected.size());
+    assertThat(expected).as("All records should be present").isEmpty();
   }
 
   @Test
@@ -296,11 +308,9 @@ public class TestParquetWriterAppendBlocks {
     final ParquetFileWriter writer = new ParquetFileWriter(CONF, droppedColumnSchema, droppedColumnFile);
     writer.start();
 
-    TestUtils.assertThrows(
-        "Should complain that id column is dropped", IllegalArgumentException.class, (Callable<Void>) () -> {
-          writer.appendRowGroups(incoming, footer.getBlocks(), false);
-          return null;
-        });
+    assertThatThrownBy(() -> writer.appendRowGroups(incoming, footer.getBlocks(), false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Columns cannot be copied (missing from target schema): id");
   }
 
   @Test
@@ -319,11 +329,9 @@ public class TestParquetWriterAppendBlocks {
     final ParquetFileWriter writer = new ParquetFileWriter(CONF, fileSchema, missingColumnFile);
     writer.start();
 
-    TestUtils.assertThrows(
-        "Should complain that value column is missing", IllegalArgumentException.class, (Callable<Void>) () -> {
-          writer.appendFile(CONF, file1);
-          return null;
-        });
+    assertThatThrownBy(() -> writer.appendFile(CONF, file1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Missing column 'value'");
   }
 
   private Path newTemp() throws IOException {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterError.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterError.java
@@ -18,6 +18,9 @@
  */
 package org.apache.parquet.hadoop;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
@@ -41,7 +44,6 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.LocalOutputFile;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -91,13 +93,10 @@ public class TestParquetWriterError {
       abortedField.setBoolean(internalWriter, true);
 
       // Now try to write again - this should throw IOException
-      IOException e = Assert.assertThrows(
-          "Expected IOException when writing to an aborted writer",
-          IOException.class,
-          () -> writer.write(
-              groupFactory.newGroup().append("name", "Charlie").append("age", 25)));
-      Assert.assertTrue(
-          "Error message should mention aborted state", e.getMessage().contains("aborted"));
+      assertThatThrownBy(() -> writer.write(
+              groupFactory.newGroup().append("name", "Charlie").append("age", 25)))
+          .isInstanceOf(IOException.class)
+          .hasMessageContaining("aborted");
 
       // Close should not throw (it should silently skip flushing due to aborted state)
       writer.close();
@@ -117,10 +116,9 @@ public class TestParquetWriterError {
         .redirectError(ProcessBuilder.Redirect.INHERIT)
         .redirectOutput(ProcessBuilder.Redirect.INHERIT)
         .start();
-    Assert.assertEquals(
-        "Test process exited with a non-zero return code. See previous logs for details.",
-        0,
-        process.waitFor());
+    assertThat(process.waitFor())
+        .as("Test process exited with a non-zero return code. See previous logs for details.")
+        .isEqualTo(0);
   }
 
   /**
@@ -184,8 +182,9 @@ public class TestParquetWriterError {
         @Override
         public ByteBuffer allocate(int size) {
           if (++counter >= oomAt) {
-            Assert.assertEquals(
-                "There should not be any additional allocations after an OOM", oomAt, counter);
+            assertThat(counter)
+                .as("There should not be any additional allocations after an OOM")
+                .isEqualTo(oomAt);
             throw new OutOfMemoryError("Artificial OOM to fail write");
           }
           return super.allocate(size);
@@ -219,30 +218,30 @@ public class TestParquetWriterError {
         CompressionCodecName.LZ4_RAW
       };
       for (int cycle = 0; cycle < 50; ++cycle) {
-        try (TrackingByteBufferAllocator allocator = createAllocator(RANDOM.nextInt(100) + 1);
-            ParquetWriter<Group> writer = ExampleParquetWriter.builder(
-                    new LocalOutputFile(Paths.get(args[0])))
-                .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
-                .withType(PhoneBookWriter.getSchema())
-                .withAllocator(allocator)
-                .withCodecFactory(CodecFactory.createDirectCodecFactory(
-                    new Configuration(), allocator, ParquetProperties.DEFAULT_PAGE_SIZE))
-                // Also validating the different direct codecs which might also have issues if an OOM
-                // happens
-                .withCompressionCodec(codecs[RANDOM.nextInt(codecs.length)])
-                .build()) {
-          for (int i = 0; i < 100_000; ++i) {
-            writer.write(generateNext());
-          }
-          Assert.fail("An OOM should have been thrown");
-        } catch (OutOfMemoryError oom) {
-          Throwable[] suppressed = oom.getSuppressed();
-          // No exception should be suppressed after the expected OOM:
-          // It would mean that a close() call fails with an exception
-          if (suppressed != null && suppressed.length > 0) {
-            throw suppressed[0];
-          }
-        }
+        assertThatThrownBy(() -> {
+              try (TrackingByteBufferAllocator allocator = createAllocator(RANDOM.nextInt(100) + 1);
+                  ParquetWriter<Group> writer = ExampleParquetWriter.builder(
+                          new LocalOutputFile(Paths.get(args[0])))
+                      .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+                      .withType(PhoneBookWriter.getSchema())
+                      .withAllocator(allocator)
+                      .withCodecFactory(CodecFactory.createDirectCodecFactory(
+                          new Configuration(),
+                          allocator,
+                          ParquetProperties.DEFAULT_PAGE_SIZE))
+                      // Also validating the different direct codecs which might also have issues
+                      // if an
+                      // OOM happens
+                      .withCompressionCodec(codecs[RANDOM.nextInt(codecs.length)])
+                      .build()) {
+                for (int i = 0; i < 100_000; ++i) {
+                  writer.write(generateNext());
+                }
+              }
+            })
+            .isInstanceOf(OutOfMemoryError.class)
+            .hasMessage("Artificial OOM to fail write")
+            .hasNoSuppressedExceptions();
       }
     }
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterNewPage.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterNewPage.java
@@ -28,8 +28,8 @@ import static org.apache.parquet.format.converter.ParquetMetadataConverter.NO_FI
 import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
 import static org.apache.parquet.hadoop.metadata.CompressionCodecName.UNCOMPRESSED;
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.util.HashMap;
 import java.util.List;
@@ -102,17 +102,17 @@ public class TestParquetWriterNewPage {
             .build();
         for (int i = 0; i < 1000; i++) {
           Group group = reader.read();
-          assertEquals(
-              "test" + (i % modulo),
-              group.getBinary("binary_field", 0).toStringUsingUTF8());
-          assertEquals(32, group.getInteger("int32_field", 0));
-          assertEquals(64l, group.getLong("int64_field", 0));
-          assertEquals(true, group.getBoolean("boolean_field", 0));
-          assertEquals(1.0f, group.getFloat("float_field", 0), 0.001);
-          assertEquals(2.0d, group.getDouble("double_field", 0), 0.001);
-          assertEquals("foo", group.getBinary("flba_field", 0).toStringUsingUTF8());
-          assertEquals(Binary.fromConstantByteArray(new byte[12]), group.getInt96("int96_field", 0));
-          assertEquals(0, group.getFieldRepetitionCount("null_field"));
+          assertThat(group.getBinary("binary_field", 0).toStringUsingUTF8())
+              .isEqualTo("test" + (i % modulo));
+          assertThat(group.getInteger("int32_field", 0)).isEqualTo(32);
+          assertThat(group.getLong("int64_field", 0)).isEqualTo(64l);
+          assertThat(group.getBoolean("boolean_field", 0)).isEqualTo(true);
+          assertThat(group.getFloat("float_field", 0)).isCloseTo(1.0f, offset(0.001f));
+          assertThat(group.getDouble("double_field", 0)).isCloseTo(2.0d, offset(0.001));
+          assertThat(group.getBinary("flba_field", 0).toStringUsingUTF8())
+              .isEqualTo("foo");
+          assertThat(group.getInt96("int96_field", 0)).isEqualTo(Binary.fromConstantByteArray(new byte[12]));
+          assertThat(group.getFieldRepetitionCount("null_field")).isEqualTo(0);
         }
         reader.close();
         ParquetMetadata footer = readFooter(conf, file, NO_FILTER);
@@ -121,9 +121,9 @@ public class TestParquetWriterNewPage {
             if (column.getPath().toDotString().equals("binary_field")) {
               String key = modulo + "-" + version;
               Encoding expectedEncoding = expected.get(key);
-              assertTrue(
-                  key + ":" + column.getEncodings() + " should contain " + expectedEncoding,
-                  column.getEncodings().contains(expectedEncoding));
+              assertThat(column.getEncodings())
+                  .as(key + ":" + column.getEncodings() + " should contain " + expectedEncoding)
+                  .contains(expectedEncoding);
             }
           }
         }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterTruncation.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestParquetWriterTruncation.java
@@ -20,12 +20,11 @@ package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.schema.LogicalTypeAnnotation.stringType;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
@@ -79,8 +78,8 @@ public class TestParquetWriterTruncation {
       ColumnChunkMetaData column =
           reader.getFooter().getBlocks().get(0).getColumns().get(0);
       ColumnIndex index = reader.readColumnIndex(column);
-      assertEquals(Collections.singletonList("1234567890"), asStrings(index.getMinValues()));
-      assertEquals(Collections.singletonList("1234567891"), asStrings(index.getMaxValues()));
+      assertThat(asStrings(index.getMinValues())).containsExactly("1234567890");
+      assertThat(asStrings(index.getMaxValues())).containsExactly("1234567891");
     }
   }
 
@@ -112,8 +111,8 @@ public class TestParquetWriterTruncation {
       ColumnChunkMetaData column =
           reader.getFooter().getBlocks().get(0).getColumns().get(0);
       Statistics<?> statistics = column.getStatistics();
-      assertEquals("1234567890", new String(statistics.getMinBytes()));
-      assertEquals("1234567891", new String(statistics.getMaxBytes()));
+      assertThat(new String(statistics.getMinBytes())).isEqualTo("1234567890");
+      assertThat(new String(statistics.getMaxBytes())).isEqualTo("1234567891");
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestReadWriteEncodingStats.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestReadWriteEncodingStats.java
@@ -21,10 +21,7 @@ package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -81,7 +78,7 @@ public class TestReadWriteEncodingStats {
   @Test
   public void testReadWrite() throws Exception {
     File file = temp.newFile("encoding-stats.parquet");
-    assertTrue(file.delete());
+    assertThat(file.delete()).isTrue();
     Path path = new Path(file.toString());
 
     ParquetWriter<Group> writer = ExampleParquetWriter.builder(path)
@@ -96,29 +93,53 @@ public class TestReadWriteEncodingStats {
     writer.close();
 
     try (ParquetFileReader reader = ParquetFileReader.open(CONF, path)) {
-      assertEquals("Should have one row group", 1, reader.getRowGroups().size());
+      assertThat(reader.getRowGroups()).as("Should have one row group").hasSize(1);
       BlockMetaData rowGroup = reader.getRowGroups().get(0);
 
       ColumnChunkMetaData dictColumn = rowGroup.getColumns().get(0);
       EncodingStats dictStats = dictColumn.getEncodingStats();
-      assertNotNull("Dict column should have non-null encoding stats", dictStats);
-      assertTrue("Dict column should have a dict page", dictStats.hasDictionaryPages());
-      assertTrue("Dict column should have dict-encoded pages", dictStats.hasDictionaryEncodedPages());
-      assertFalse("Dict column should not have non-dict pages", dictStats.hasNonDictionaryEncodedPages());
+      assertThat(dictStats)
+          .as("Dict column should have non-null encoding stats")
+          .isNotNull();
+      assertThat(dictStats.hasDictionaryPages())
+          .as("Dict column should have a dict page")
+          .isTrue();
+      assertThat(dictStats.hasDictionaryEncodedPages())
+          .as("Dict column should have dict-encoded pages")
+          .isTrue();
+      assertThat(dictStats.hasNonDictionaryEncodedPages())
+          .as("Dict column should not have non-dict pages")
+          .isFalse();
 
       ColumnChunkMetaData plainColumn = rowGroup.getColumns().get(1);
       EncodingStats plainStats = plainColumn.getEncodingStats();
-      assertNotNull("Plain column should have non-null encoding stats", plainStats);
-      assertFalse("Plain column should not have a dict page", plainStats.hasDictionaryPages());
-      assertFalse("Plain column should not have dict-encoded pages", plainStats.hasDictionaryEncodedPages());
-      assertTrue("Plain column should have non-dict pages", plainStats.hasNonDictionaryEncodedPages());
+      assertThat(plainStats)
+          .as("Plain column should have non-null encoding stats")
+          .isNotNull();
+      assertThat(plainStats.hasDictionaryPages())
+          .as("Plain column should not have a dict page")
+          .isFalse();
+      assertThat(plainStats.hasDictionaryEncodedPages())
+          .as("Plain column should not have dict-encoded pages")
+          .isFalse();
+      assertThat(plainStats.hasNonDictionaryEncodedPages())
+          .as("Plain column should have non-dict pages")
+          .isTrue();
 
       ColumnChunkMetaData fallbackColumn = rowGroup.getColumns().get(2);
       EncodingStats fallbackStats = fallbackColumn.getEncodingStats();
-      assertNotNull("Fallback column should have non-null encoding stats", fallbackStats);
-      assertTrue("Fallback column should have a dict page", fallbackStats.hasDictionaryPages());
-      assertTrue("Fallback column should have dict-encoded pages", fallbackStats.hasDictionaryEncodedPages());
-      assertTrue("Fallback column should have non-dict pages", fallbackStats.hasNonDictionaryEncodedPages());
+      assertThat(fallbackStats)
+          .as("Fallback column should have non-null encoding stats")
+          .isNotNull();
+      assertThat(fallbackStats.hasDictionaryPages())
+          .as("Fallback column should have a dict page")
+          .isTrue();
+      assertThat(fallbackStats.hasDictionaryEncodedPages())
+          .as("Fallback column should have dict-encoded pages")
+          .isTrue();
+      assertThat(fallbackStats.hasNonDictionaryEncodedPages())
+          .as("Fallback column should have non-dict pages")
+          .isTrue();
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestSnappyCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestSnappyCodec.java
@@ -18,8 +18,7 @@
  */
 package org.apache.parquet.hadoop;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -78,7 +77,7 @@ public class TestSnappyCodec {
 
     // Validate that the result from the codec is the same as if we compressed the
     // buffer directly.
-    assertArrayEquals(rawCompressed, codecCompressed);
+    assertThat(codecCompressed).isEqualTo(rawCompressed);
 
     ByteArrayInputStream inputStream = new ByteArrayInputStream(codecCompressed);
     CompressionInputStream decompressor = codec.createInputStream(inputStream);
@@ -92,8 +91,8 @@ public class TestSnappyCodec {
 
     byte[] rawDecompressed = Snappy.uncompress(rawCompressed);
 
-    assertArrayEquals(input, rawDecompressed);
-    assertArrayEquals(input, codecDecompressed);
+    assertThat(rawDecompressed).isEqualTo(input);
+    assertThat(codecDecompressed).isEqualTo(input);
   }
 
   private void TestSnappy(SnappyCompressor compressor, SnappyDecompressor decompressor, String... strings)
@@ -132,7 +131,7 @@ public class TestSnappyCodec {
     int decompressedSize = decompressor.decompress(decompressedData, 0, uncompressedSize);
     assert (decompressor.finished());
 
-    assertEquals(uncompressedSize, decompressedSize);
-    assertArrayEquals(uncompressedData, decompressedData);
+    assertThat(decompressedSize).isEqualTo(uncompressedSize);
+    assertThat(decompressedData).isEqualTo(uncompressedData);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestStoreBloomFilter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestStoreBloomFilter.java
@@ -21,6 +21,7 @@ package org.apache.parquet.hadoop;
 
 import static org.apache.parquet.hadoop.ParquetFileWriter.Mode.OVERWRITE;
 import static org.apache.parquet.hadoop.TestBloomFiltering.generateDictionaryData;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -40,7 +41,6 @@ import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -88,14 +88,14 @@ public class TestStoreBloomFilter {
           // column `id` isn't fully encoded in dictionary, it will generate `BloomFilter`
           ColumnChunkMetaData idMeta = block.getColumns().get(0);
           EncodingStats idEncoding = idMeta.getEncodingStats();
-          Assert.assertTrue(idEncoding.hasNonDictionaryEncodedPages());
-          Assert.assertNotNull(reader.readBloomFilter(idMeta));
+          assertThat(idEncoding.hasNonDictionaryEncodedPages()).isTrue();
+          assertThat(reader.readBloomFilter(idMeta)).isNotNull();
 
           // column `name` is fully encoded in dictionary, it won't generate `BloomFilter`
           ColumnChunkMetaData nameMeta = block.getColumns().get(1);
           EncodingStats nameEncoding = nameMeta.getEncodingStats();
-          Assert.assertFalse(nameEncoding.hasNonDictionaryEncodedPages());
-          Assert.assertNull(reader.readBloomFilter(nameMeta));
+          assertThat(nameEncoding.hasNonDictionaryEncodedPages()).isFalse();
+          assertThat(reader.readBloomFilter(nameMeta)).isNull();
         } catch (IOException e) {
           e.printStackTrace();
         }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestUtils.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestUtils.java
@@ -18,14 +18,13 @@
  */
 package org.apache.parquet.hadoop;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
-import java.util.concurrent.Callable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.column.statistics.Statistics;
-import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 
 public class TestUtils {
 
@@ -41,27 +40,6 @@ public class TestUtils {
     }
   }
 
-  /**
-   * A convenience method to avoid a large number of @Test(expected=...) tests
-   *
-   * @param message  A String message to describe this assertion
-   * @param expected An Exception class that the Runnable should throw
-   * @param callable A Callable that is expected to throw the exception
-   */
-  public static void assertThrows(String message, Class<? extends Exception> expected, Callable callable) {
-    try {
-      callable.call();
-      Assert.fail("No exception was thrown (" + message + "), expected: " + expected.getName());
-    } catch (Exception actual) {
-      try {
-        Assert.assertEquals(message, expected, actual.getClass());
-      } catch (AssertionError e) {
-        e.addSuppressed(actual);
-        throw e;
-      }
-    }
-  }
-
   public static void assertStatsValuesEqual(Statistics<?> stats1, Statistics<?> stats2) {
     assertStatsValuesEqual(null, stats1, stats2);
   }
@@ -73,11 +51,12 @@ public class TestUtils {
       return;
     }
     if (expected == null || actual == null) {
-      Assert.assertEquals(expected, actual);
+      assertThat(actual).isEqualTo(expected);
+      return;
     }
-    Assert.assertThat(actual, CoreMatchers.instanceOf(expected.getClass()));
-    Assert.assertArrayEquals(message, expected.getMaxBytes(), actual.getMaxBytes());
-    Assert.assertArrayEquals(message, expected.getMinBytes(), actual.getMinBytes());
-    Assert.assertEquals(message, expected.getNumNulls(), actual.getNumNulls());
+    assertThat(actual).as(message).isInstanceOf(expected.getClass());
+    assertThat(actual.getMaxBytes()).as(message).isEqualTo(expected.getMaxBytes());
+    assertThat(actual.getMinBytes()).as(message).isEqualTo(expected.getMinBytes());
+    assertThat(actual.getNumNulls()).as(message).isEqualTo(expected.getNumNulls());
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestZstandardCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/TestZstandardCodec.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.hadoop;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -44,7 +46,6 @@ import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.hadoop.mapred.DeprecatedParquetOutputFormat;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestZstandardCodec {
@@ -77,7 +78,7 @@ public class TestZstandardCodec {
     (new Random()).nextBytes(data);
     BytesInput compressedData = compress(codec, BytesInput.from(data));
     byte[] decompressedData = decompress(codec, compressedData, data.length);
-    Assert.assertArrayEquals(data, decompressedData);
+    assertThat(decompressedData).isEqualTo(data);
   }
 
   private BytesInput compress(ZstandardCodec codec, BytesInput bytes) throws IOException {
@@ -104,7 +105,7 @@ public class TestZstandardCodec {
     // Clear the cache so that a new codec can be created with new configuration
     CodecFactory.CODEC_BY_NAME.clear();
     long fileSizeHighLevel = runMrWithConf(22);
-    Assert.assertTrue(fileSizeLowLevel > fileSizeHighLevel);
+    assertThat(fileSizeLowLevel).isGreaterThan(fileSizeHighLevel);
   }
 
   private long runMrWithConf(int level) throws Exception {
@@ -115,7 +116,7 @@ public class TestZstandardCodec {
     Path path = new Path(
         Files.createTempDirectory("zstd" + level).toAbsolutePath().toString());
     RunningJob mapRedJob = runMapReduceJob(CompressionCodecName.ZSTD, jobConf, conf, path);
-    Assert.assertTrue(mapRedJob.isSuccessful());
+    assertThat(mapRedJob.isSuccessful()).isTrue();
     return getFileSize(path, conf);
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/CodecConfigTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/CodecConfigTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.parquet.hadoop.codec;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapred.JobConf;
@@ -29,7 +31,6 @@ import org.apache.hadoop.mapreduce.TaskID;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.hadoop.util.ContextUtil;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CodecConfigTest {
@@ -56,12 +57,12 @@ public class CodecConfigTest {
     conf.set(ParquetOutputFormat.COMPRESSION, codecNameStr);
     TaskAttemptContext task = ContextUtil.newTaskAttemptContext(
         conf, new TaskAttemptID(new TaskID(new JobID("test", 1), false, 1), 1));
-    Assert.assertEquals(CodecConfig.from(task).getCodec(), expectedCodec);
+    assertThat(CodecConfig.from(task).getCodec()).isEqualTo(expectedCodec);
 
     // Test mapred API
     JobConf jobConf = new JobConf();
     jobConf.set(ParquetOutputFormat.COMPRESSION, codecNameStr);
-    Assert.assertEquals(CodecConfig.from(jobConf).getCodec(), expectedCodec);
+    assertThat(CodecConfig.from(jobConf).getCodec()).isEqualTo(expectedCodec);
   }
 
   public void shouldUseHadoopFlagToSetCodec(String codecClassStr, CompressionCodecName expectedCodec)
@@ -73,12 +74,12 @@ public class CodecConfigTest {
     conf.set("mapred.output.compression.codec", codecClassStr);
     TaskAttemptContext task = ContextUtil.newTaskAttemptContext(
         conf, new TaskAttemptID(new TaskID(new JobID("test", 1), false, 1), 1));
-    Assert.assertEquals(expectedCodec, CodecConfig.from(task).getCodec());
+    assertThat(CodecConfig.from(task).getCodec()).isEqualTo(expectedCodec);
 
     // Test mapred API
     JobConf jobConf = new JobConf();
     jobConf.setBoolean("mapred.output.compress", true);
     jobConf.set("mapred.output.compression.codec", codecClassStr);
-    Assert.assertEquals(CodecConfig.from(jobConf).getCodec(), expectedCodec);
+    assertThat(CodecConfig.from(jobConf).getCodec()).isEqualTo(expectedCodec);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestCompressionCodec.java
@@ -18,9 +18,8 @@
  */
 package org.apache.parquet.hadoop.codec;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
@@ -41,7 +40,6 @@ import org.apache.parquet.compression.CompressionCodecFactory.BytesInputCompress
 import org.apache.parquet.compression.CompressionCodecFactory.BytesInputDecompressor;
 import org.apache.parquet.hadoop.CodecFactory;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.junit.Assert;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -102,8 +100,8 @@ public class TestCompressionCodec {
     int decompressedSize = decompressor.decompress(decompressedData, 0, uncompressedSize);
     assert (decompressor.finished());
 
-    assertEquals(uncompressedSize, decompressedSize);
-    assertArrayEquals(uncompressedData, decompressedData);
+    assertThat(decompressedSize).isEqualTo(uncompressedSize);
+    assertThat(decompressedData).isEqualTo(uncompressedData);
   }
 
   @Test
@@ -145,7 +143,7 @@ public class TestCompressionCodec {
     }
     BytesInput compressedData = compress(codec, BytesInput.from(data));
     byte[] decompressedData = decompress(codec, compressedData, data.length);
-    Assert.assertArrayEquals(data, decompressedData);
+    assertThat(decompressedData).isEqualTo(data);
   }
 
   private BytesInput compress(CompressionCodec codec, BytesInput bytes) throws IOException {
@@ -205,7 +203,7 @@ public class TestCompressionCodec {
       BytesInput decompressed = decompressor.decompress(compressed, size);
 
       BytesInput copied = decompressed.copy(releaser);
-      Assert.assertArrayEquals(raw, copied.toByteArray());
+      assertThat(copied.toByteArray()).isEqualTo(raw);
 
       compressor.release();
       decompressor.release();
@@ -224,9 +222,8 @@ public class TestCompressionCodec {
     NonBlockedDecompressorStream decompressorStream =
         new NonBlockedDecompressorStream(new ByteArrayInputStream(new byte[0]), mockDecompressor, 1024);
 
-    assertThrows(IOException.class, () -> {
-      // Attempt to read from the stream, which should trigger the IOException.
-      decompressorStream.read(new byte[1024], 0, 1024);
-    });
+    assertThatThrownBy(() -> decompressorStream.read(new byte[1024], 0, 1024))
+        .isInstanceOf(IOException.class)
+        .hasMessage("Corrupt file: Zero bytes read during decompression.");
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestInteropReadLz4RawCodec.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/codec/TestInteropReadLz4RawCodec.java
@@ -19,8 +19,8 @@
 
 package org.apache.parquet.hadoop.codec;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
 
 import java.io.IOException;
 import org.apache.hadoop.fs.Path;
@@ -50,12 +50,12 @@ public class TestInteropReadLz4RawCodec {
         ParquetReader.builder(new GroupReadSupport(), simpleFile).build()) {
       for (int i = 0; i < expectRows; ++i) {
         Group group = reader.read();
-        assertTrue(group != null);
-        assertEquals(c0ExpectValues[i], group.getLong(0, 0));
-        assertEquals(c1ExpectValues[i], group.getString(1, 0));
-        assertEquals(c2ExpectValues[i], group.getDouble(2, 0), 0.000001);
+        assertThat(group).isNotNull();
+        assertThat(group.getLong(0, 0)).isEqualTo(c0ExpectValues[i]);
+        assertThat(group.getString(1, 0)).isEqualTo(c1ExpectValues[i]);
+        assertThat(group.getDouble(2, 0)).isCloseTo(c2ExpectValues[i], offset(0.000001));
       }
-      assertTrue(reader.read() == null);
+      assertThat(reader.read()).isNull();
     }
   }
 
@@ -76,13 +76,13 @@ public class TestInteropReadLz4RawCodec {
         ParquetReader.builder(new GroupReadSupport(), largerFile).build()) {
       for (int i = 0; i < expectRows; ++i) {
         Group group = reader.read();
-        assertTrue(group != null);
+        assertThat(group).isNotNull();
         if (i == 0 || i == 1 || i == expectRows - 2 || i == expectRows - 1) {
-          assertEquals(c0ExpectValues[index], group.getString(0, 0));
+          assertThat(group.getString(0, 0)).isEqualTo(c0ExpectValues[index]);
           index++;
         }
       }
-      assertTrue(reader.read() == null);
+      assertThat(reader.read()).isNull();
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/GroupReadSupportTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/GroupReadSupportTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.hadoop.example;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +43,7 @@ public class GroupReadSupportTest {
     MessageType fileSchema = MessageTypeParser.parseMessageType(fullSchemaStr);
 
     ReadSupport.ReadContext context = s.init(configuration, keyValueMetaData, fileSchema);
-    assertEquals(context.getRequestedSchema(), fileSchema);
+    assertThat(context.getRequestedSchema()).isEqualTo(fileSchema);
   }
 
   @Test
@@ -56,6 +56,6 @@ public class GroupReadSupportTest {
     configuration.set(ReadSupport.PARQUET_READ_SCHEMA, partialSchemaStr);
 
     ReadSupport.ReadContext context = s.init(configuration, keyValueMetaData, fileSchema);
-    assertEquals(context.getRequestedSchema(), partialSchema);
+    assertThat(context.getRequestedSchema()).isEqualTo(partialSchema);
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/TestInputOutputFormat.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/example/TestInputOutputFormat.java
@@ -19,10 +19,7 @@
 package org.apache.parquet.hadoop.example;
 
 import static java.lang.Thread.sleep;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -147,7 +144,7 @@ public class TestInputOutputFormat {
     @Override
     public org.apache.parquet.hadoop.api.ReadSupport.ReadContext init(InitContext context) {
       Set<String> counts = context.getKeyValueMetadata().get("my.count");
-      assertFalse("counts: " + counts, counts.isEmpty());
+      assertThat(counts).as("counts: " + counts).isNotEmpty();
       return super.init(context);
     }
   }
@@ -243,10 +240,10 @@ public class TestInputOutputFormat {
     while ((lineIn = in.readLine()) != null && (lineOut = out.readLine()) != null) {
       ++lineNumber;
       lineOut = lineOut.substring(lineOut.indexOf("\t") + 1);
-      assertEquals("line " + lineNumber, lineIn, lineOut);
+      assertThat(lineOut).as("line " + lineNumber).isEqualTo(lineIn);
     }
-    assertNull("line " + lineNumber, out.readLine());
-    assertNull("line " + lineNumber, lineIn);
+    assertThat(out.readLine()).as("line " + lineNumber).isNull();
+    assertThat(lineIn).as("line " + lineNumber).isNull();
     in.close();
     out.close();
   }
@@ -290,7 +287,7 @@ public class TestInputOutputFormat {
 
     File file = new File(outputPath.toString(), "part-m-00000");
     List<String> lines = Files.readAllLines(file.toPath(), StandardCharsets.UTF_8);
-    assertTrue(lines.isEmpty());
+    assertThat(lines).isEmpty();
   }
 
   @Test
@@ -337,7 +334,7 @@ public class TestInputOutputFormat {
 
     sbFound.deleteCharAt(sbFound.length() - 1);
 
-    assertEquals(String.join("\n", expected), sbFound.toString());
+    assertThat(sbFound).asString().isEqualTo(String.join("\n", expected));
   }
 
   @Test
@@ -363,12 +360,11 @@ public class TestInputOutputFormat {
   public void testReadWriteWithCounter() throws Exception {
     runMapReduceJob(CompressionCodecName.GZIP);
 
-    assertTrue(value(readJob, "parquet", "bytesread") > 0L);
-    assertTrue(value(readJob, "parquet", "bytestotal") > 0L);
-    assertEquals(
-        "bytestotal != bytesread",
-        value(readJob, "parquet", "bytestotal"),
-        value(readJob, "parquet", "bytesread"));
+    assertThat(value(readJob, "parquet", "bytesread")).isPositive();
+    assertThat(value(readJob, "parquet", "bytestotal")).isPositive();
+    assertThat(value(readJob, "parquet", "bytesread"))
+        .as("bytestotal != bytesread")
+        .isEqualTo(value(readJob, "parquet", "bytestotal"));
     // not testing the time read counter since it could be zero due to the size of data is too small
   }
 
@@ -378,9 +374,9 @@ public class TestInputOutputFormat {
     conf.set("parquet.benchmark.bytes.total", "false");
     conf.set("parquet.benchmark.bytes.read", "false");
     runMapReduceJob(CompressionCodecName.GZIP);
-    assertTrue(value(readJob, "parquet", "bytesread") == 0L);
-    assertTrue(value(readJob, "parquet", "bytestotal") == 0L);
-    assertTrue(value(readJob, "parquet", "timeread") == 0L);
+    assertThat(value(readJob, "parquet", "bytesread")).isZero();
+    assertThat(value(readJob, "parquet", "bytestotal")).isZero();
+    assertThat(value(readJob, "parquet", "timeread")).isZero();
   }
 
   private void waitForJob(Job job) throws InterruptedException, IOException {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/metadata/TestColumnChunkMetaData.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/metadata/TestColumnChunkMetaData.java
@@ -19,8 +19,7 @@
 package org.apache.parquet.hadoop.metadata;
 
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -36,8 +35,8 @@ public class TestColumnChunkMetaData {
     long big = (long) Integer.MAX_VALUE + 1;
 
     ColumnChunkMetaData md = newMD(big);
-    assertTrue(md instanceof IntColumnChunkMetaData);
-    assertEquals(big, md.getFirstDataPageOffset());
+    assertThat(md).isInstanceOf(IntColumnChunkMetaData.class);
+    assertThat(md.getFirstDataPageOffset()).isEqualTo(big);
   }
 
   @Test
@@ -45,8 +44,8 @@ public class TestColumnChunkMetaData {
     long small = 1;
 
     ColumnChunkMetaData md = newMD(small);
-    assertTrue(md instanceof IntColumnChunkMetaData);
-    assertEquals(small, md.getFirstDataPageOffset());
+    assertThat(md).isInstanceOf(IntColumnChunkMetaData.class);
+    assertThat(md.getFirstDataPageOffset()).isEqualTo(small);
   }
 
   @Test
@@ -54,8 +53,8 @@ public class TestColumnChunkMetaData {
     long veryBig = (long) Integer.MAX_VALUE * 3;
 
     ColumnChunkMetaData md = newMD(veryBig);
-    assertTrue(md instanceof LongColumnChunkMetaData);
-    assertEquals(veryBig, md.getFirstDataPageOffset());
+    assertThat(md).isInstanceOf(LongColumnChunkMetaData.class);
+    assertThat(md.getFirstDataPageOffset()).isEqualTo(veryBig);
   }
 
   @Test
@@ -63,8 +62,8 @@ public class TestColumnChunkMetaData {
     long neg = -1;
 
     ColumnChunkMetaData md = newMD(neg);
-    assertTrue(md instanceof LongColumnChunkMetaData);
-    assertEquals(neg, md.getFirstDataPageOffset());
+    assertThat(md).isInstanceOf(LongColumnChunkMetaData.class);
+    assertThat(md.getFirstDataPageOffset()).isEqualTo(neg);
   }
 
   private ColumnChunkMetaData newMD(long big) {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/metadata/TestParquetMetadata.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/metadata/TestParquetMetadata.java
@@ -26,7 +26,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LE
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -108,6 +108,6 @@ public class TestParquetMetadata {
     FileMetaData fmd = new FileMetaData(complexParquetSchema, Collections.emptyMap(), "ASF");
     String prettyJSon = ParquetMetadata.toPrettyJSON(new ParquetMetadata(fmd, Collections.emptyList()));
 
-    assertEquals(mapper.readTree(prettyJSon), expectedJson());
+    assertThat(mapper.readTree(prettyJSon)).isEqualTo(expectedJson());
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/rewrite/ParquetRewriterTest.java
@@ -26,14 +26,9 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.data.Offset.offset;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -344,14 +339,14 @@ public class ParquetRewriterTest {
 
     // Verify column encryption
     ParquetMetadata metaData = getFileMetaData(outputFile, fileDecryptionProperties);
-    assertFalse(metaData.getBlocks().isEmpty());
+    assertThat(metaData.getBlocks()).isNotEmpty();
     List<ColumnChunkMetaData> columns = metaData.getBlocks().get(0).getColumns();
     Set<String> set = new HashSet<>(List.of(encryptColumns));
     for (ColumnChunkMetaData column : columns) {
       if (set.contains(column.getPath().toDotString())) {
-        assertTrue(column.isEncrypted());
+        assertThat(column.isEncrypted()).isTrue();
       } else {
-        assertFalse(column.isEncrypted());
+        assertThat(column.isEncrypted()).isFalse();
       }
     }
 
@@ -422,14 +417,14 @@ public class ParquetRewriterTest {
         ParquetFileReader.readFooter(conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER);
     MessageType schema = pmd.getFileMetaData().getSchema();
     List<Type> fields = schema.getFields();
-    assertEquals(fields.size(), 3);
-    assertEquals(fields.get(0).getName(), "id");
-    assertEquals(fields.get(1).getName(), "name");
-    assertEquals(fields.get(2).getName(), "location");
+    assertThat(fields).hasSize(3);
+    assertThat(fields.get(0).getName()).isEqualTo("id");
+    assertThat(fields.get(1).getName()).isEqualTo("name");
+    assertThat(fields.get(2).getName()).isEqualTo("location");
     List<Type> subFields = fields.get(2).asGroupType().getFields();
-    assertEquals(subFields.size(), 2);
-    assertEquals(subFields.get(0).getName(), "lon");
-    assertEquals(subFields.get(1).getName(), "lat");
+    assertThat(subFields).hasSize(2);
+    assertThat(subFields.get(0).getName()).isEqualTo("lon");
+    assertThat(subFields.get(1).getName()).isEqualTo("lat");
 
     try (ParquetReader<Group> outReader = ParquetReader.builder(new GroupReadSupport(), new Path(outputFile))
             .withConf(conf)
@@ -441,23 +436,25 @@ public class ParquetRewriterTest {
       for (Group inRead = inReader.read(), outRead = outReader.read();
           inRead != null || outRead != null;
           inRead = inReader.read(), outRead = outReader.read()) {
-        assertNotNull(inRead);
-        assertNotNull(outRead);
+        assertThat(inRead).isNotNull();
+        assertThat(outRead).isNotNull();
 
-        assertEquals(inRead.getLong("id", 0), outRead.getLong("id", 0));
-        assertEquals(inRead.getString("name", 0), outRead.getString("name", 0));
+        assertThat(outRead.getLong("id", 0)).isEqualTo(inRead.getLong("id", 0));
+        assertThat(outRead.getString("name", 0)).isEqualTo(inRead.getString("name", 0));
 
         // location was null
         Group finalOutRead = outRead;
-        assertThrows(
-            RuntimeException.class,
-            () -> finalOutRead.getGroup("location", 0).getDouble("lat", 0));
-        assertThrows(
-            RuntimeException.class,
-            () -> finalOutRead.getGroup("location", 0).getDouble("lon", 0));
+        assertThatThrownBy(() -> finalOutRead.getGroup("location", 0).getDouble("lat", 0))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("not found");
+        assertThatThrownBy(() -> finalOutRead.getGroup("location", 0).getDouble("lon", 0))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("not found");
 
         // phone numbers was pruned
-        assertThrows(InvalidRecordException.class, () -> finalOutRead.getGroup("phoneNumbers", 0));
+        assertThatThrownBy(() -> finalOutRead.getGroup("phoneNumbers", 0))
+            .isInstanceOf(InvalidRecordException.class)
+            .hasMessageContaining("phoneNumbers not found in");
       }
     }
 
@@ -508,15 +505,15 @@ public class ParquetRewriterTest {
 
     // Verify the column is encrypted
     ParquetMetadata metaData = getFileMetaData(outputFile, fileDecryptionProperties);
-    assertFalse(metaData.getBlocks().isEmpty());
+    assertThat(metaData.getBlocks()).isNotEmpty();
     Set<String> encryptedColumns = new HashSet<>(List.of(encryptColumns));
     for (BlockMetaData blockMetaData : metaData.getBlocks()) {
       List<ColumnChunkMetaData> columns = blockMetaData.getColumns();
       for (ColumnChunkMetaData column : columns) {
         if (encryptedColumns.contains(column.getPath().toDotString())) {
-          assertTrue(column.isEncrypted());
+          assertThat(column.isEncrypted()).isTrue();
         } else {
-          assertFalse(column.isEncrypted());
+          assertThat(column.isEncrypted()).isFalse();
         }
       }
     }
@@ -570,7 +567,7 @@ public class ParquetRewriterTest {
         ParquetFileReader.readFooter(conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER);
     MessageType schema = pmd.getFileMetaData().getSchema();
     MessageType expectSchema = createSchema();
-    assertEquals(expectSchema, schema);
+    assertThat(schema).isEqualTo(expectSchema);
 
     // Verify codec has not been translated
     verifyCodec(
@@ -626,7 +623,7 @@ public class ParquetRewriterTest {
         ParquetFileReader.readFooter(conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER);
     MessageType schema = pmd.getFileMetaData().getSchema();
     MessageType expectSchema = createSchemaWithRenamed();
-    assertEquals(expectSchema, schema);
+    assertThat(schema).isEqualTo(expectSchema);
 
     verifyCodec(outputFile, ImmutableSet.of(CompressionCodecName.SNAPPY), fileDecryptionProperties); // Verify codec
     // Verify the merged data are not changed
@@ -637,15 +634,15 @@ public class ParquetRewriterTest {
     validateRowGroupRowCount();
 
     ParquetMetadata metaData = getFileMetaData(outputFile, fileDecryptionProperties);
-    assertFalse(metaData.getBlocks().isEmpty());
+    assertThat(metaData.getBlocks()).isNotEmpty();
     Set<String> encryptedColumns = new HashSet<>(List.of(encryptColumns));
     for (BlockMetaData blockMetaData : metaData.getBlocks()) {
       List<ColumnChunkMetaData> columns = blockMetaData.getColumns();
       for (ColumnChunkMetaData column : columns) {
         if (encryptedColumns.contains(column.getPath().toDotString())) {
-          assertTrue(column.isEncrypted());
+          assertThat(column.isEncrypted()).isTrue();
         } else {
-          assertFalse(column.isEncrypted());
+          assertThat(column.isEncrypted()).isFalse();
         }
       }
     }
@@ -776,7 +773,7 @@ public class ParquetRewriterTest {
     // Verify bloom filters
     Map<ColumnPath, List<BloomFilter>> inputBloomFilters = allInputBloomFilters();
     Map<ColumnPath, List<BloomFilter>> outputBloomFilters = allOutputBloomFilters(null);
-    assertEquals(inputBloomFilters, outputBloomFilters);
+    assertThat(outputBloomFilters).isEqualTo(inputBloomFilters);
   }
 
   @Test
@@ -791,16 +788,15 @@ public class ParquetRewriterTest {
 
     // Verify bloom filters
     Map<ColumnPath, List<BloomFilter>> inputBloomFilters = allInputBloomFilters();
-    assertEquals(inputBloomFilters.size(), 2);
-    assertTrue(inputBloomFilters.containsKey(ColumnPath.fromDotString("Links.Forward")));
-    assertTrue(inputBloomFilters.containsKey(ColumnPath.fromDotString("DocId")));
+    assertThat(inputBloomFilters)
+        .containsOnlyKeys(ColumnPath.fromDotString("Links.Forward"), ColumnPath.fromDotString("DocId"));
 
     Map<ColumnPath, List<BloomFilter>> outputBloomFilters = allOutputBloomFilters(null);
-    assertEquals(outputBloomFilters.size(), 1);
-    assertTrue(outputBloomFilters.containsKey(ColumnPath.fromDotString("DocId")));
+    assertThat(outputBloomFilters).hasSize(1);
+    assertThat(outputBloomFilters).containsKey(ColumnPath.fromDotString("DocId"));
 
     inputBloomFilters.remove(ColumnPath.fromDotString("Links.Forward"));
-    assertEquals(inputBloomFilters, outputBloomFilters);
+    assertThat(outputBloomFilters).isEqualTo(inputBloomFilters);
   }
 
   @Test
@@ -817,11 +813,13 @@ public class ParquetRewriterTest {
     Map<ColumnPath, List<BloomFilter>> inputBloomFilters = allInputBloomFilters();
 
     // Cannot read without FileDecryptionProperties
-    assertThrows(ParquetCryptoRuntimeException.class, () -> allOutputBloomFilters(null));
+    assertThatThrownBy(() -> allOutputBloomFilters(null))
+        .isInstanceOf(ParquetCryptoRuntimeException.class)
+        .hasMessageContaining("Null File Decryptor");
 
     FileDecryptionProperties fileDecryptionProperties = EncDecProperties.getFileDecryptionProperties();
     Map<ColumnPath, List<BloomFilter>> outputBloomFilters = allOutputBloomFilters(fileDecryptionProperties);
-    assertEquals(inputBloomFilters, outputBloomFilters);
+    assertThat(outputBloomFilters).isEqualTo(inputBloomFilters);
   }
 
   private void testSingleInputFileSetupWithBloomFilter(String... bloomFilterEnabledColumns) throws IOException {
@@ -911,14 +909,14 @@ public class ParquetRewriterTest {
 
     // Verify column encryption
     ParquetMetadata metaData = getFileMetaData(outputFile, fileDecryptionProperties);
-    assertFalse(metaData.getBlocks().isEmpty());
+    assertThat(metaData.getBlocks()).isNotEmpty();
     List<ColumnChunkMetaData> columns = metaData.getBlocks().get(0).getColumns();
     Set<String> set = ImmutableSet.of(encryptColumn);
     for (ColumnChunkMetaData column : columns) {
       if (set.contains(column.getPath().toDotString())) {
-        assertTrue(column.isEncrypted());
+        assertThat(column.isEncrypted()).isTrue();
       } else {
-        assertFalse(column.isEncrypted());
+        assertThat(column.isEncrypted()).isFalse();
       }
     }
 
@@ -930,7 +928,7 @@ public class ParquetRewriterTest {
         emptyMap()); // Verify data
     validateSchemaWithGenderColumnPruned(true); // Verify schema
     validateCreatedBy(); // Verify original.created.by
-    assertEquals(inputBloomFilters.keySet(), rBloomFilters); // Verify bloom filters
+    assertThat(rBloomFilters).isEqualTo(inputBloomFilters.keySet()); // Verify bloom filters
     verifyCodec(outputFile, ImmutableSet.of(CompressionCodecName.ZSTD), fileDecryptionProperties); // Verify codec
     validatePageIndex(ImmutableSet.of(encryptColumn), joinColumnsOverwrite, emptyMap());
   }
@@ -1035,51 +1033,52 @@ public class ParquetRewriterTest {
         inputFiles.stream().mapToInt(x -> x.getFileContent().length).sum();
     for (int i = 0; i < totalRows; i++) {
       Group groupActual = reader.read();
-      assertNotNull(groupActual);
+      assertThat(groupActual).isNotNull();
 
       if (!prunePaths.contains("DocId")) {
         if (nullifiedPaths.contains("DocId")) {
-          assertThrows(RuntimeException.class, () -> groupActual.getLong("DocId", 0));
+          assertThatThrownBy(() -> groupActual.getLong("DocId", 0))
+              .isInstanceOf(RuntimeException.class)
+              .hasMessageContaining("not found");
         } else {
-          assertEquals(
-              groupActual.getLong("DocId", 0),
-              groupsExpected.apply("DocId", i).getLong("DocId", 0));
+          assertThat(groupActual.getLong("DocId", 0))
+              .isEqualTo(groupsExpected.apply("DocId", i).getLong("DocId", 0));
         }
       }
 
       if (!prunePaths.contains("Name") && !nullifiedPaths.contains("Name")) {
         String colName = renameColumns.getOrDefault("Name", "Name");
-        assertArrayEquals(
-            groupActual.getBinary(colName, 0).getBytes(),
-            groupsExpected.apply("Name", i).getBinary("Name", 0).getBytes());
+        assertThat(groupActual.getBinary(colName, 0).getBytes())
+            .isEqualTo(groupsExpected
+                .apply("Name", i)
+                .getBinary("Name", 0)
+                .getBytes());
       }
 
       if (!prunePaths.contains("Gender") && !nullifiedPaths.contains("Gender")) {
-        assertArrayEquals(
-            groupActual.getBinary("Gender", 0).getBytes(),
-            groupsExpected.apply("Gender", i).getBinary("Gender", 0).getBytes());
+        assertThat(groupActual.getBinary("Gender", 0).getBytes())
+            .isEqualTo(groupsExpected
+                .apply("Gender", i)
+                .getBinary("Gender", 0)
+                .getBytes());
       }
 
       if (!prunePaths.contains("FloatFraction") && !nullifiedPaths.contains("FloatFraction")) {
-        assertEquals(
-            groupActual.getFloat("FloatFraction", 0),
-            groupsExpected.apply("FloatFraction", i).getFloat("FloatFraction", 0),
-            0);
+        assertThat(groupActual.getFloat("FloatFraction", 0))
+            .isCloseTo(groupsExpected.apply("FloatFraction", i).getFloat("FloatFraction", 0), offset(0f));
       }
 
       if (!prunePaths.contains("DoubleFraction") && !nullifiedPaths.contains("DoubleFraction")) {
-        assertEquals(
-            groupActual.getDouble("DoubleFraction", 0),
-            groupsExpected.apply("DoubleFraction", i).getDouble("DoubleFraction", 0),
-            0);
+        assertThat(groupActual.getDouble("DoubleFraction", 0))
+            .isCloseTo(
+                groupsExpected.apply("DoubleFraction", i).getDouble("DoubleFraction", 0), offset(0.0));
       }
 
       Group subGroup = groupActual.getGroup("Links", 0);
 
       if (!prunePaths.contains("Links.Backward") && !nullifiedPaths.contains("Links.Backward")) {
-        assertArrayEquals(
-            subGroup.getBinary("Backward", 0).getBytes(),
-            groupsExpected
+        assertThat(subGroup.getBinary("Backward", 0).getBytes())
+            .isEqualTo(groupsExpected
                 .apply("Links", i)
                 .getGroup("Links", 0)
                 .getBinary("Backward", 0)
@@ -1088,11 +1087,12 @@ public class ParquetRewriterTest {
 
       if (!prunePaths.contains("Links.Forward")) {
         if (nullifiedPaths.contains("Links.Forward")) {
-          assertThrows(RuntimeException.class, () -> subGroup.getBinary("Forward", 0));
+          assertThatThrownBy(() -> subGroup.getBinary("Forward", 0))
+              .isInstanceOf(RuntimeException.class)
+              .hasMessageContaining("not found");
         } else {
-          assertArrayEquals(
-              subGroup.getBinary("Forward", 0).getBytes(),
-              groupsExpected
+          assertThat(subGroup.getBinary("Forward", 0).getBytes())
+              .isEqualTo(groupsExpected
                   .apply("Links", i)
                   .getGroup("Links", 0)
                   .getBinary("Forward", 0)
@@ -1129,7 +1129,7 @@ public class ParquetRewriterTest {
         codecs.add(columnChunkMetaData.getCodec());
       }
     }
-    assertEquals(expectedCodecs, codecs);
+    assertThat(codecs).isEqualTo(expectedCodecs);
   }
 
   @FunctionalInterface
@@ -1219,24 +1219,23 @@ public class ParquetRewriterTest {
         ColumnIndex outColumnIndex = outReader.readColumnIndex(outChunk);
         OffsetIndex outOffsetIndex = outReader.readOffsetIndex(outChunk);
         if (inColumnIndex != null) {
-          assertEquals(inColumnIndex.getBoundaryOrder(), outColumnIndex.getBoundaryOrder());
-          assertEquals(inColumnIndex.getMaxValues(), outColumnIndex.getMaxValues());
-          assertEquals(inColumnIndex.getMinValues(), outColumnIndex.getMinValues());
-          assertEquals(inColumnIndex.getNullCounts(), outColumnIndex.getNullCounts());
+          assertThat(outColumnIndex.getBoundaryOrder()).isEqualTo(inColumnIndex.getBoundaryOrder());
+          assertThat(outColumnIndex.getMaxValues()).containsExactlyElementsOf(inColumnIndex.getMaxValues());
+          assertThat(outColumnIndex.getMinValues()).containsExactlyElementsOf(inColumnIndex.getMinValues());
+          assertThat(outColumnIndex.getNullCounts()).containsExactlyElementsOf(inColumnIndex.getNullCounts());
         }
         if (inOffsetIndex != null) {
           List<Long> inOffsets = getOffsets(inReader, inChunk);
           List<Long> outOffsets = getOffsets(outReader, outChunk);
-          assertEquals(inOffsets.size(), outOffsets.size());
-          assertEquals(inOffsets.size(), inOffsetIndex.getPageCount());
-          assertEquals(inOffsetIndex.getPageCount(), outOffsetIndex.getPageCount());
+          assertThat(outOffsets).hasSameSizeAs(inOffsets);
+          assertThat(inOffsetIndex.getPageCount()).isEqualTo(inOffsets.size());
+          assertThat(outOffsetIndex.getPageCount()).isEqualTo(inOffsetIndex.getPageCount());
           for (int k = 0; k < inOffsetIndex.getPageCount(); k++) {
-            assertEquals(inOffsetIndex.getFirstRowIndex(k), outOffsetIndex.getFirstRowIndex(k));
-            assertEquals(
-                inOffsetIndex.getLastRowIndex(k, inBlockMeta.getRowCount()),
-                outOffsetIndex.getLastRowIndex(k, outBlockMeta.getRowCount()));
-            assertEquals(inOffsetIndex.getOffset(k), (long) inOffsets.get(k));
-            assertEquals(outOffsetIndex.getOffset(k), (long) outOffsets.get(k));
+            assertThat(outOffsetIndex.getFirstRowIndex(k)).isEqualTo(inOffsetIndex.getFirstRowIndex(k));
+            assertThat(outOffsetIndex.getLastRowIndex(k, outBlockMeta.getRowCount()))
+                .isEqualTo(inOffsetIndex.getLastRowIndex(k, inBlockMeta.getRowCount()));
+            assertThat((long) inOffsets.get(k)).isEqualTo(inOffsetIndex.getOffset(k));
+            assertThat((long) outOffsets.get(k)).isEqualTo(outOffsetIndex.getOffset(k));
           }
         }
       }
@@ -1290,23 +1289,24 @@ public class ParquetRewriterTest {
     for (EncryptionTestFile inputFile : inFiles) {
       ParquetMetadata pmd = getFileMetaData(inputFile.getFileName(), null);
       createdBySet.add(pmd.getFileMetaData().getCreatedBy());
-      assertNull(pmd.getFileMetaData().getKeyValueMetaData().get(ParquetRewriter.ORIGINAL_CREATED_BY_KEY));
+      assertThat(pmd.getFileMetaData().getKeyValueMetaData().get(ParquetRewriter.ORIGINAL_CREATED_BY_KEY))
+          .isNull();
     }
 
     // Verify created_by from input files have been deduplicated
     Object[] inputCreatedBys = createdBySet.toArray();
-    assertEquals(1, inputCreatedBys.length);
+    assertThat(inputCreatedBys).hasSize(1);
 
     // Verify created_by has been set
     FileMetaData outFMD = getFileMetaData(outputFile, null).getFileMetaData();
     final String createdBy = outFMD.getCreatedBy();
-    assertNotNull(createdBy);
-    assertEquals(createdBy, Version.FULL_VERSION);
+    assertThat(createdBy).isNotNull();
+    assertThat(createdBy).isEqualTo(Version.FULL_VERSION);
 
     // Verify original.created.by has been set
     String inputCreatedBy = (String) inputCreatedBys[0];
     String originalCreatedBy = outFMD.getKeyValueMetaData().get(ParquetRewriter.ORIGINAL_CREATED_BY_KEY);
-    assertEquals(inputCreatedBy, originalCreatedBy);
+    assertThat(originalCreatedBy).isEqualTo(inputCreatedBy);
   }
 
   private void validateRowGroupRowCount() throws Exception {
@@ -1324,7 +1324,7 @@ public class ParquetRewriterTest {
       outputRowCounts.add(blockMetaData.getRowCount());
     }
 
-    assertEquals(inputRowCounts, outputRowCounts);
+    assertThat(outputRowCounts).isEqualTo(inputRowCounts);
   }
 
   private Map<ColumnPath, List<BloomFilter>> allInputBloomFilters() throws Exception {
@@ -1416,7 +1416,7 @@ public class ParquetRewriterTest {
             conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER)
         .getFileMetaData()
         .getSchema();
-    assertEquals(expectSchema, actualSchema);
+    assertThat(actualSchema).isEqualTo(expectSchema);
   }
 
   private void addGzipInputFile() {

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/ColumnEncryptorTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/ColumnEncryptorTest.java
@@ -23,10 +23,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -137,14 +134,14 @@ public class ColumnEncryptorTest {
         EncDecProperties.getFileEncryptionProperties(encryptColumns, ParquetCipher.AES_GCM_CTR_V1, false));
 
     ParquetMetadata metaData = getParquetMetadata(EncDecProperties.getFileDecryptionProperties());
-    assertFalse(metaData.getBlocks().isEmpty());
+    assertThat(metaData.getBlocks()).isNotEmpty();
     List<ColumnChunkMetaData> columns = metaData.getBlocks().get(0).getColumns();
     Set<String> set = new HashSet<>(List.of(encryptColumns));
     for (ColumnChunkMetaData column : columns) {
       if (set.contains(column.getPath().toDotString())) {
-        assertTrue(column.isEncrypted());
+        assertThat(column.isEncrypted()).isTrue();
       } else {
-        assertFalse(column.isEncrypted());
+        assertThat(column.isEncrypted()).isFalse();
       }
     }
   }
@@ -208,21 +205,19 @@ public class ColumnEncryptorTest {
     ParquetReader<Group> reader = createReader(outputFile);
     for (int i = 0; i < numRecord; i++) {
       Group group = reader.read();
-      assertTrue(group.getLong("DocId", 0) == inputFile.getFileContent()[i].getLong("DocId", 0));
-      assertArrayEquals(
-          group.getBinary("Name", 0).getBytes(),
-          inputFile.getFileContent()[i].getString("Name", 0).getBytes(StandardCharsets.UTF_8));
-      assertArrayEquals(
-          group.getBinary("Gender", 0).getBytes(),
-          inputFile.getFileContent()[i].getString("Gender", 0).getBytes(StandardCharsets.UTF_8));
+      assertThat(group.getLong("DocId", 0)).isEqualTo(inputFile.getFileContent()[i].getLong("DocId", 0));
+      assertThat(group.getBinary("Name", 0).getBytes())
+          .isEqualTo(
+              inputFile.getFileContent()[i].getString("Name", 0).getBytes(StandardCharsets.UTF_8));
+      assertThat(group.getBinary("Gender", 0).getBytes())
+          .isEqualTo(
+              inputFile.getFileContent()[i].getString("Gender", 0).getBytes(StandardCharsets.UTF_8));
       Group subGroupInRead = group.getGroup("Links", 0);
       Group expectedSubGroup = inputFile.getFileContent()[i].getGroup("Links", 0);
-      assertArrayEquals(
-          subGroupInRead.getBinary("Forward", 0).getBytes(),
-          expectedSubGroup.getBinary("Forward", 0).getBytes());
-      assertArrayEquals(
-          subGroupInRead.getBinary("Backward", 0).getBytes(),
-          expectedSubGroup.getBinary("Backward", 0).getBytes());
+      assertThat(subGroupInRead.getBinary("Forward", 0).getBytes())
+          .isEqualTo(expectedSubGroup.getBinary("Forward", 0).getBytes());
+      assertThat(subGroupInRead.getBinary("Backward", 0).getBytes())
+          .isEqualTo(expectedSubGroup.getBinary("Backward", 0).getBytes());
     }
     reader.close();
   }
@@ -261,7 +256,7 @@ public class ColumnEncryptorTest {
           inMetaData.getBlocks().get(blockIndex).getColumns();
       List<ColumnChunkMetaData> outColumns =
           outMetaData.getBlocks().get(blockIndex).getColumns();
-      assertEquals(inColumns.size(), outColumns.size());
+      assertThat(outColumns).hasSameSizeAs(inColumns);
       validateColumns(inReader, outReader, inColumns, outColumns);
       inStore = inReader.readNextRowGroup();
       outStore = outReader.readNextRowGroup();
@@ -283,7 +278,7 @@ public class ColumnEncryptorTest {
       ColumnChunkMetaData outChunk = outColumns.get(i);
       OffsetIndex inOffsetIndex = inReader.readOffsetIndex(inChunk);
       OffsetIndex outOffsetIndex = outReader.readOffsetIndex(outChunk);
-      assertEquals(inOffsetIndex.getPageCount(), outOffsetIndex.getPageCount());
+      assertThat(outOffsetIndex.getPageCount()).isEqualTo(inOffsetIndex.getPageCount());
       if (outChunk.isEncrypted()) {
         continue;
       }
@@ -304,13 +299,13 @@ public class ColumnEncryptorTest {
       outReader.setStreamPosition(outPageOffset);
       PageHeader inPageHeader = inReader.readPageHeader();
       PageHeader outPageHeader = outReader.readPageHeader();
-      assertEquals(inPageHeader, outPageHeader);
+      assertThat(outPageHeader).isEqualTo(inPageHeader);
       DataPageHeader inHeaderV1 = inPageHeader.data_page_header;
       DataPageHeader outHeaderV1 = outPageHeader.data_page_header;
-      assertEquals(inHeaderV1, outHeaderV1);
+      assertThat(outHeaderV1).isEqualTo(inHeaderV1);
       BytesInput inPageLoad = readBlockAllocate(inReader, inPageHeader.compressed_page_size);
       BytesInput outPageLoad = readBlockAllocate(outReader, outPageHeader.compressed_page_size);
-      assertEquals(inPageLoad.toByteBuffer(), outPageLoad.toByteBuffer());
+      assertThat(outPageLoad.toByteBuffer()).isEqualTo(inPageLoad.toByteBuffer());
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/ColumnMaskerTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/ColumnMaskerTest.java
@@ -24,8 +24,8 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertArrayEquals;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -116,9 +116,9 @@ public class ColumnMaskerTest {
         .build();
     for (int i = 0; i < numRecord; i++) {
       Group group = reader.read();
-      assertArrayEquals(group.getBinary("Name", 0).getBytes(), testDocs.name[i].getBytes());
+      assertThat(group.getBinary("Name", 0).getBytes()).isEqualTo(testDocs.name[i].getBytes());
       Group subGroup = group.getGroup("Links", 0);
-      assertArrayEquals(subGroup.getBinary("Forward", 0).getBytes(), testDocs.linkForward[i].getBytes());
+      assertThat(subGroup.getBinary("Forward", 0).getBytes()).isEqualTo(testDocs.linkForward[i].getBytes());
     }
     reader.close();
   }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/ColumnPrunerTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/ColumnPrunerTest.java
@@ -24,7 +24,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -68,14 +68,14 @@ public class ColumnPrunerTest {
         ParquetFileReader.readFooter(conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER);
     MessageType schema = pmd.getFileMetaData().getSchema();
     List<Type> fields = schema.getFields();
-    assertEquals(fields.size(), 3);
-    assertEquals(fields.get(0).getName(), "DocId");
-    assertEquals(fields.get(1).getName(), "Name");
-    assertEquals(fields.get(2).getName(), "Links");
+    assertThat(fields).hasSize(3);
+    assertThat(fields.get(0).getName()).isEqualTo("DocId");
+    assertThat(fields.get(1).getName()).isEqualTo("Name");
+    assertThat(fields.get(2).getName()).isEqualTo("Links");
     List<Type> subFields = fields.get(2).asGroupType().getFields();
-    assertEquals(subFields.size(), 2);
-    assertEquals(subFields.get(0).getName(), "Backward");
-    assertEquals(subFields.get(1).getName(), "Forward");
+    assertThat(subFields).hasSize(2);
+    assertThat(subFields.get(0).getName()).isEqualTo("Backward");
+    assertThat(subFields.get(1).getName()).isEqualTo("Forward");
 
     // Verify the data are not changed for the columns not pruned
     List<String> prunePaths = List.of("Gender");
@@ -98,13 +98,13 @@ public class ColumnPrunerTest {
         ParquetFileReader.readFooter(conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER);
     MessageType schema = pmd.getFileMetaData().getSchema();
     List<Type> fields = schema.getFields();
-    assertEquals(fields.size(), 2);
-    assertEquals(fields.get(0).getName(), "DocId");
-    assertEquals(fields.get(1).getName(), "Links");
+    assertThat(fields).hasSize(2);
+    assertThat(fields.get(0).getName()).isEqualTo("DocId");
+    assertThat(fields.get(1).getName()).isEqualTo("Links");
     List<Type> subFields = fields.get(1).asGroupType().getFields();
-    assertEquals(subFields.size(), 2);
-    assertEquals(subFields.get(0).getName(), "Backward");
-    assertEquals(subFields.get(1).getName(), "Forward");
+    assertThat(subFields).hasSize(2);
+    assertThat(subFields.get(0).getName()).isEqualTo("Backward");
+    assertThat(subFields.get(1).getName()).isEqualTo("Forward");
 
     // Verify the data are not changed for the columns not pruned
     List<String> prunePaths = List.of("Name", "Gender");
@@ -135,14 +135,14 @@ public class ColumnPrunerTest {
         ParquetFileReader.readFooter(conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER);
     MessageType schema = pmd.getFileMetaData().getSchema();
     List<Type> fields = schema.getFields();
-    assertEquals(fields.size(), 4);
-    assertEquals(fields.get(0).getName(), "DocId");
-    assertEquals(fields.get(1).getName(), "Name");
-    assertEquals(fields.get(2).getName(), "Gender");
-    assertEquals(fields.get(3).getName(), "Links");
+    assertThat(fields).hasSize(4);
+    assertThat(fields.get(0).getName()).isEqualTo("DocId");
+    assertThat(fields.get(1).getName()).isEqualTo("Name");
+    assertThat(fields.get(2).getName()).isEqualTo("Gender");
+    assertThat(fields.get(3).getName()).isEqualTo("Links");
     List<Type> subFields = fields.get(3).asGroupType().getFields();
-    assertEquals(subFields.size(), 1);
-    assertEquals(subFields.get(0).getName(), "Forward");
+    assertThat(subFields).hasSize(1);
+    assertThat(subFields.get(0).getName()).isEqualTo("Forward");
 
     // Verify the data are not changed for the columns not pruned
     List<String> prunePaths = List.of("Links.Backward");
@@ -164,10 +164,10 @@ public class ColumnPrunerTest {
         ParquetFileReader.readFooter(conf, new Path(outputFile), ParquetMetadataConverter.NO_FILTER);
     MessageType schema = pmd.getFileMetaData().getSchema();
     List<Type> fields = schema.getFields();
-    assertEquals(fields.size(), 3);
-    assertEquals(fields.get(0).getName(), "DocId");
-    assertEquals(fields.get(1).getName(), "Name");
-    assertEquals(fields.get(2).getName(), "Gender");
+    assertThat(fields).hasSize(3);
+    assertThat(fields.get(0).getName()).isEqualTo("DocId");
+    assertThat(fields.get(1).getName()).isEqualTo("Name");
+    assertThat(fields.get(2).getName()).isEqualTo("Gender");
 
     // Verify the data are not changed for the columns not pruned
     List<String> prunePaths = List.of("Links");
@@ -190,21 +190,21 @@ public class ColumnPrunerTest {
     for (int i = 0; i < numRecord; i++) {
       Group group = reader.read();
       if (!prunePaths.contains("DocId")) {
-        assertEquals(1l, group.getLong("DocId", 0));
+        assertThat(group.getLong("DocId", 0)).isEqualTo(1l);
       }
       if (!prunePaths.contains("Name")) {
-        assertEquals("foo", group.getBinary("Name", 0).toStringUsingUTF8());
+        assertThat(group.getBinary("Name", 0).toStringUsingUTF8()).isEqualTo("foo");
       }
       if (!prunePaths.contains("Gender")) {
-        assertEquals("male", group.getBinary("Gender", 0).toStringUsingUTF8());
+        assertThat(group.getBinary("Gender", 0).toStringUsingUTF8()).isEqualTo("male");
       }
       if (!prunePaths.contains("Links")) {
         Group subGroup = group.getGroup("Links", 0);
         if (!prunePaths.contains("Links.Backward")) {
-          assertEquals(2l, subGroup.getLong("Backward", 0));
+          assertThat(subGroup.getLong("Backward", 0)).isEqualTo(2l);
         }
         if (!prunePaths.contains("Links.Forward")) {
-          assertEquals(3l, subGroup.getLong("Forward", 0));
+          assertThat(subGroup.getLong("Forward", 0)).isEqualTo(3l);
         }
       }
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/CompressionConverterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/CompressionConverterTest.java
@@ -24,8 +24,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -61,7 +60,6 @@ import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class CompressionConverterTest {
@@ -140,12 +138,12 @@ public class CompressionConverterTest {
         .build();
     for (int i = 0; i < numRecord; i++) {
       Group group = reader.read();
-      assertTrue(group.getLong("DocId", 0) == testDocs.docId[i]);
-      assertArrayEquals(group.getBinary("Name", 0).getBytes(), testDocs.name[i].getBytes());
-      assertArrayEquals(group.getBinary("Gender", 0).getBytes(), testDocs.gender[i].getBytes());
+      assertThat(group.getLong("DocId", 0)).isEqualTo(testDocs.docId[i]);
+      assertThat(group.getBinary("Name", 0).getBytes()).isEqualTo(testDocs.name[i].getBytes());
+      assertThat(group.getBinary("Gender", 0).getBytes()).isEqualTo(testDocs.gender[i].getBytes());
       Group subGroup = group.getGroup("Links", 0);
-      assertArrayEquals(subGroup.getBinary("Backward", 0).getBytes(), testDocs.linkBackward[i].getBytes());
-      assertArrayEquals(subGroup.getBinary("Forward", 0).getBytes(), testDocs.linkForward[i].getBytes());
+      assertThat(subGroup.getBinary("Backward", 0).getBytes()).isEqualTo(testDocs.linkBackward[i].getBytes());
+      assertThat(subGroup.getBinary("Forward", 0).getBytes()).isEqualTo(testDocs.linkForward[i].getBytes());
     }
     reader.close();
   }
@@ -153,19 +151,16 @@ public class CompressionConverterTest {
   private void validMeta(String inputFile, String outFile) throws Exception {
     ParquetMetadata inMetaData = ParquetFileReader.readFooter(conf, new Path(inputFile), NO_FILTER);
     ParquetMetadata outMetaData = ParquetFileReader.readFooter(conf, new Path(outFile), NO_FILTER);
-    Assert.assertEquals(
-        inMetaData.getFileMetaData().getSchema(),
-        outMetaData.getFileMetaData().getSchema());
-    Assert.assertEquals(
-        inMetaData.getFileMetaData().getKeyValueMetaData(),
-        outMetaData.getFileMetaData().getKeyValueMetaData());
+    assertThat(outMetaData.getFileMetaData().getSchema())
+        .isEqualTo(inMetaData.getFileMetaData().getSchema());
+    assertThat(outMetaData.getFileMetaData().getKeyValueMetaData())
+        .isEqualTo(inMetaData.getFileMetaData().getKeyValueMetaData());
   }
 
   private void validColumnIndex(String inputFile, String outFile) throws Exception {
     ParquetMetadata inMetaData = ParquetFileReader.readFooter(conf, new Path(inputFile), NO_FILTER);
     ParquetMetadata outMetaData = ParquetFileReader.readFooter(conf, new Path(outFile), NO_FILTER);
-    Assert.assertEquals(
-        inMetaData.getBlocks().size(), outMetaData.getBlocks().size());
+    assertThat(outMetaData.getBlocks()).hasSameSizeAs(inMetaData.getBlocks());
     try (TransParquetFileReader inReader = new TransParquetFileReader(
             HadoopInputFile.fromPath(new Path(inputFile), conf),
             HadoopReadOptions.builder(conf).build());
@@ -175,9 +170,7 @@ public class CompressionConverterTest {
       for (int i = 0; i < inMetaData.getBlocks().size(); i++) {
         BlockMetaData inBlockMetaData = inMetaData.getBlocks().get(i);
         BlockMetaData outBlockMetaData = outMetaData.getBlocks().get(i);
-        Assert.assertEquals(
-            inBlockMetaData.getColumns().size(),
-            outBlockMetaData.getColumns().size());
+        assertThat(outBlockMetaData.getColumns()).hasSameSizeAs(inBlockMetaData.getColumns());
         for (int j = 0; j < inBlockMetaData.getColumns().size(); j++) {
           ColumnChunkMetaData inChunk = inBlockMetaData.getColumns().get(j);
           ColumnIndex inColumnIndex = inReader.readColumnIndex(inChunk);
@@ -186,24 +179,26 @@ public class CompressionConverterTest {
           ColumnIndex outColumnIndex = outReader.readColumnIndex(outChunk);
           OffsetIndex outOffsetIndex = outReader.readOffsetIndex(outChunk);
           if (inColumnIndex != null) {
-            Assert.assertEquals(inColumnIndex.getBoundaryOrder(), outColumnIndex.getBoundaryOrder());
-            Assert.assertEquals(inColumnIndex.getMaxValues(), outColumnIndex.getMaxValues());
-            Assert.assertEquals(inColumnIndex.getMinValues(), outColumnIndex.getMinValues());
-            Assert.assertEquals(inColumnIndex.getNullCounts(), outColumnIndex.getNullCounts());
+            assertThat(outColumnIndex.getBoundaryOrder()).isEqualTo(inColumnIndex.getBoundaryOrder());
+            assertThat(outColumnIndex.getMaxValues())
+                .containsExactlyElementsOf(inColumnIndex.getMaxValues());
+            assertThat(outColumnIndex.getMinValues())
+                .containsExactlyElementsOf(inColumnIndex.getMinValues());
+            assertThat(outColumnIndex.getNullCounts())
+                .containsExactlyElementsOf(inColumnIndex.getNullCounts());
           }
           if (inOffsetIndex != null) {
             List<Long> inOffsets = getOffsets(inReader, inChunk);
             List<Long> outOffsets = getOffsets(outReader, outChunk);
-            Assert.assertEquals(inOffsets.size(), outOffsets.size());
-            Assert.assertEquals(inOffsets.size(), inOffsetIndex.getPageCount());
-            Assert.assertEquals(inOffsetIndex.getPageCount(), outOffsetIndex.getPageCount());
+            assertThat(outOffsets).hasSameSizeAs(inOffsets);
+            assertThat(inOffsetIndex.getPageCount()).isEqualTo(inOffsets.size());
+            assertThat(outOffsetIndex.getPageCount()).isEqualTo(inOffsetIndex.getPageCount());
             for (int k = 0; k < inOffsetIndex.getPageCount(); k++) {
-              Assert.assertEquals(inOffsetIndex.getFirstRowIndex(k), outOffsetIndex.getFirstRowIndex(k));
-              Assert.assertEquals(
-                  inOffsetIndex.getLastRowIndex(k, inChunk.getValueCount()),
-                  outOffsetIndex.getLastRowIndex(k, outChunk.getValueCount()));
-              Assert.assertEquals(inOffsetIndex.getOffset(k), (long) inOffsets.get(k));
-              Assert.assertEquals(outOffsetIndex.getOffset(k), (long) outOffsets.get(k));
+              assertThat(outOffsetIndex.getFirstRowIndex(k)).isEqualTo(inOffsetIndex.getFirstRowIndex(k));
+              assertThat(outOffsetIndex.getLastRowIndex(k, outChunk.getValueCount()))
+                  .isEqualTo(inOffsetIndex.getLastRowIndex(k, inChunk.getValueCount()));
+              assertThat((long) inOffsets.get(k)).isEqualTo(inOffsetIndex.getOffset(k));
+              assertThat((long) outOffsets.get(k)).isEqualTo(outOffsetIndex.getOffset(k));
             }
           }
         }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoop2ByteBufferReads.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoop2ByteBufferReads.java
@@ -21,15 +21,15 @@ package org.apache.parquet.hadoop.util;
 
 import static org.apache.parquet.hadoop.util.HadoopStreams.wrap;
 import static org.apache.parquet.hadoop.util.MockHadoopInputStream.TEST_ARRAY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.hadoop.fs.ByteBufferReadable;
 import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.parquet.hadoop.TestUtils;
 import org.apache.parquet.io.SeekableInputStream;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class TestHadoop2ByteBufferReads {
@@ -65,15 +65,15 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(8, readBuffer.position());
-    Assert.assertEquals(8, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(8);
+    assertThat(readBuffer.limit()).isEqualTo(8);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(8, readBuffer.position());
-    Assert.assertEquals(8, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(8);
+    assertThat(readBuffer.limit()).isEqualTo(8);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 8), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 8));
   }
 
   @Test
@@ -83,10 +83,8 @@ public class TestHadoop2ByteBufferReads {
     FSDataInputStream hadoopStream = new FSDataInputStream(new MockHadoopInputStream());
     final MockBufferReader reader = new MockBufferReader(hadoopStream);
 
-    TestUtils.assertThrows("Should throw EOFException", EOFException.class, () -> {
-      H2SeekableInputStream.readFully(reader, readBuffer);
-      return null;
-    });
+    assertThatThrownBy(() -> H2SeekableInputStream.readFully(reader, readBuffer))
+        .isInstanceOf(EOFException.class);
 
     // NOTE: This behavior differs from readFullyHeapBuffer because direct uses
     // several read operations that will read up to the end of the input. This
@@ -94,8 +92,8 @@ public class TestHadoop2ByteBufferReads {
     // behavior can't be implemented for the heap buffer without using the read
     // method instead of the readFully method on the underlying
     // FSDataInputStream.
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(20, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(20);
   }
 
   @Test
@@ -107,16 +105,16 @@ public class TestHadoop2ByteBufferReads {
 
     // reads all of the bytes available without EOFException
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     // trying to read 0 more bytes doesn't result in EOFException
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY));
   }
 
   @Test
@@ -127,15 +125,15 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY));
   }
 
   @Test
@@ -148,15 +146,15 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.reset();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 7), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 7));
   }
 
   @Test
@@ -168,24 +166,24 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(7, readBuffer.position());
-    Assert.assertEquals(7, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(7);
+    assertThat(readBuffer.limit()).isEqualTo(7);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(7, readBuffer.position());
-    Assert.assertEquals(7, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(7);
+    assertThat(readBuffer.limit()).isEqualTo(7);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 7), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 7));
 
     readBuffer.position(7);
     readBuffer.limit(10);
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY));
   }
 
   @Test
@@ -199,24 +197,24 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(7, readBuffer.position());
-    Assert.assertEquals(7, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(7);
+    assertThat(readBuffer.limit()).isEqualTo(7);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(7, readBuffer.position());
-    Assert.assertEquals(7, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(7);
+    assertThat(readBuffer.limit()).isEqualTo(7);
 
     readBuffer.reset();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 4), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 4));
 
     readBuffer.position(7);
     readBuffer.limit(10);
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.reset();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 7), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 7));
   }
 
   @Test
@@ -227,15 +225,15 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(8, readBuffer.position());
-    Assert.assertEquals(8, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(8);
+    assertThat(readBuffer.limit()).isEqualTo(8);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(8, readBuffer.position());
-    Assert.assertEquals(8, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(8);
+    assertThat(readBuffer.limit()).isEqualTo(8);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 8), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 8));
   }
 
   @Test
@@ -245,10 +243,8 @@ public class TestHadoop2ByteBufferReads {
     FSDataInputStream hadoopStream = new FSDataInputStream(new MockHadoopInputStream());
     final MockBufferReader reader = new MockBufferReader(hadoopStream);
 
-    TestUtils.assertThrows("Should throw EOFException", EOFException.class, () -> {
-      H2SeekableInputStream.readFully(reader, readBuffer);
-      return null;
-    });
+    assertThatThrownBy(() -> H2SeekableInputStream.readFully(reader, readBuffer))
+        .isInstanceOf(EOFException.class);
 
     // NOTE: This behavior differs from readFullyHeapBuffer because direct uses
     // several read operations that will read up to the end of the input. This
@@ -256,8 +252,8 @@ public class TestHadoop2ByteBufferReads {
     // behavior can't be implemented for the heap buffer without using the read
     // method instead of the readFully method on the underlying
     // FSDataInputStream.
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(20, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(20);
   }
 
   @Test
@@ -269,16 +265,16 @@ public class TestHadoop2ByteBufferReads {
 
     // reads all of the bytes available without EOFException
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     // trying to read 0 more bytes doesn't result in EOFException
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY));
   }
 
   @Test
@@ -289,15 +285,15 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY));
   }
 
   @Test
@@ -310,15 +306,15 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.reset();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 7), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 7));
   }
 
   @Test
@@ -330,24 +326,24 @@ public class TestHadoop2ByteBufferReads {
     H2SeekableInputStream.Reader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(7, readBuffer.position());
-    Assert.assertEquals(7, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(7);
+    assertThat(readBuffer.limit()).isEqualTo(7);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(7, readBuffer.position());
-    Assert.assertEquals(7, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(7);
+    assertThat(readBuffer.limit()).isEqualTo(7);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 7), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 7));
 
     readBuffer.position(7);
     readBuffer.limit(10);
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.flip();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY));
   }
 
   @Test
@@ -361,49 +357,49 @@ public class TestHadoop2ByteBufferReads {
     MockBufferReader reader = new MockBufferReader(hadoopStream);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(7, readBuffer.position());
-    Assert.assertEquals(7, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(7);
+    assertThat(readBuffer.limit()).isEqualTo(7);
 
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(7, readBuffer.position());
-    Assert.assertEquals(7, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(7);
+    assertThat(readBuffer.limit()).isEqualTo(7);
 
     readBuffer.reset();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 4), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 4));
 
     readBuffer.position(7);
     readBuffer.limit(10);
     H2SeekableInputStream.readFully(reader, readBuffer);
-    Assert.assertEquals(10, readBuffer.position());
-    Assert.assertEquals(10, readBuffer.limit());
+    assertThat(readBuffer.position()).isEqualTo(10);
+    assertThat(readBuffer.limit()).isEqualTo(10);
 
     readBuffer.reset();
-    Assert.assertEquals("Buffer contents should match", ByteBuffer.wrap(TEST_ARRAY, 0, 7), readBuffer);
+    assertThat(readBuffer).as("Buffer contents should match").isEqualTo(ByteBuffer.wrap(TEST_ARRAY, 0, 7));
   }
 
   @Test
   public void testCreateStreamNoByteBufferReadable() {
     final SeekableInputStream s = wrap(new FSDataInputStream(new MockHadoopInputStream()));
-    Assert.assertTrue("Wrong wrapper: " + s, s instanceof H1SeekableInputStream);
+    assertThat(s).as("Wrong wrapper: " + s).isInstanceOf(H1SeekableInputStream.class);
   }
 
   @Test
   public void testDoubleWrapNoByteBufferReadable() {
     final SeekableInputStream s = wrap(new FSDataInputStream(new FSDataInputStream(new MockHadoopInputStream())));
-    Assert.assertTrue("Wrong wrapper: " + s, s instanceof H1SeekableInputStream);
+    assertThat(s).as("Wrong wrapper: " + s).isInstanceOf(H1SeekableInputStream.class);
   }
 
   @Test
   public void testCreateStreamWithByteBufferReadable() {
     final SeekableInputStream s = wrap(new FSDataInputStream(new MockByteBufferInputStream()));
-    Assert.assertTrue("Wrong wrapper: " + s, s instanceof H2SeekableInputStream);
+    assertThat(s).as("Wrong wrapper: " + s).isInstanceOf(H2SeekableInputStream.class);
   }
 
   @Test
   public void testDoubleWrapByteBufferReadable() {
     final SeekableInputStream s =
         wrap(new FSDataInputStream(new FSDataInputStream(new MockByteBufferInputStream())));
-    Assert.assertTrue("Wrong wrapper: " + s, s instanceof H2SeekableInputStream);
+    assertThat(s).as("Wrong wrapper: " + s).isInstanceOf(H2SeekableInputStream.class);
   }
 
   /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
@@ -19,6 +19,8 @@
 package org.apache.parquet.hadoop.util;
 
 import static org.apache.hadoop.fs.FileSystemTestBinder.addFileSystemForTesting;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -40,7 +42,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.impl.FutureDataInputStreamBuilderImpl;
 import org.apache.parquet.io.SeekableInputStream;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -150,7 +151,7 @@ public class TestHadoopOpenFile {
    */
   private static void openAndRead(final HadoopInputFile inputFile) throws IOException {
     try (SeekableInputStream stream = inputFile.newStream()) {
-      Assert.assertEquals("byte read", FIRST, stream.read());
+      assertThat(stream.read()).as("byte read").isEqualTo(FIRST);
     }
   }
 
@@ -170,7 +171,9 @@ public class TestHadoopOpenFile {
     doReturn(opener).when(mockFS).openFile(path);
 
     final HadoopInputFile inputFile = fileFromStatus();
-    Assert.assertThrows(FileNotFoundException.class, inputFile::newStream);
+    assertThatThrownBy(inputFile::newStream)
+        .isInstanceOf(FileNotFoundException.class)
+        .hasMessage("file not found");
     Mockito.verify(mockFS, never()).open(path);
   }
 
@@ -191,11 +194,10 @@ public class TestHadoopOpenFile {
     // this looks up the FS binding via the status file path.
     final HadoopInputFile inputFile = fileFromStatus();
 
-    final FileNotFoundException caught = Assert.assertThrows(FileNotFoundException.class, inputFile::newStream);
-    Assert.assertSame(fileNotFound, caught);
-    final Throwable[] suppressed = caught.getSuppressed();
-    Assert.assertEquals("number of suppressed exceptions", 1, suppressed.length);
-    Assert.assertSame(illegal, suppressed[0]);
+    assertThatThrownBy(inputFile::newStream)
+        .isInstanceOf(FileNotFoundException.class)
+        .isSameAs(fileNotFound)
+        .hasSuppressedException(illegal);
   }
 
   /**
@@ -213,11 +215,10 @@ public class TestHadoopOpenFile {
     // this looks up the FS binding via the status file path.
     final HadoopInputFile inputFile = fileFromStatus();
 
-    final NullPointerException caught = Assert.assertThrows(NullPointerException.class, inputFile::newStream);
-    Assert.assertSame(npe, caught);
-    final Throwable[] suppressed = caught.getSuppressed();
-    Assert.assertEquals("number of suppressed exceptions", 1, suppressed.length);
-    Assert.assertSame(illegal, suppressed[0]);
+    assertThatThrownBy(inputFile::newStream)
+        .isInstanceOf(NullPointerException.class)
+        .isSameAs(npe)
+        .hasSuppressedException(illegal);
   }
 
   /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestSerializationUtil.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestSerializationUtil.java
@@ -18,9 +18,8 @@
  */
 package org.apache.parquet.hadoop.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,33 +37,33 @@ public class TestSerializationUtil {
 
   @Test
   public void testReadWriteObjectToConfAsBase64() throws Exception {
-    Map<Integer, String> anObject = new HashMap<Integer, String>();
+    Map<Integer, String> anObject = new HashMap<>();
     anObject.put(7, "seven");
     anObject.put(8, "eight");
 
+    Configuration confWithObject = new Configuration();
+
+    SerializationUtil.writeObjectToConfAsBase64("anobject", anObject, confWithObject);
+    Map<Integer, String> copy = SerializationUtil.readObjectFromConfAsBase64("anobject", confWithObject);
+    assertThat(copy).isEqualTo(anObject);
+
+    assertThatThrownBy(() -> {
+          Set<String> bad = SerializationUtil.readObjectFromConfAsBase64("anobject", confWithObject);
+        })
+        .isInstanceOf(ClassCastException.class)
+        .hasMessageContaining("cannot be cast to class java.util.Set");
+
     Configuration conf = new Configuration();
-
-    SerializationUtil.writeObjectToConfAsBase64("anobject", anObject, conf);
-    Map<Integer, String> copy = SerializationUtil.readObjectFromConfAsBase64("anobject", conf);
-    assertEquals(anObject, copy);
-
-    try {
-      Set<String> bad = SerializationUtil.readObjectFromConfAsBase64("anobject", conf);
-      fail("This should throw a ClassCastException");
-    } catch (ClassCastException e) {
-
-    }
-
-    conf = new Configuration();
     Object nullObj = null;
 
     SerializationUtil.writeObjectToConfAsBase64("anobject", null, conf);
     Object copyObj = SerializationUtil.readObjectFromConfAsBase64("anobject", conf);
-    assertEquals(nullObj, copyObj);
+    assertThat(copyObj).isEqualTo(nullObj);
   }
 
   @Test
   public void readObjectFromConfAsBase64UnsetKey() throws Exception {
-    assertNull(SerializationUtil.readObjectFromConfAsBase64("non-existant-key", new Configuration()));
+    assertThat(SerializationUtil.<Object>readObjectFromConfAsBase64("non-existant-key", new Configuration()))
+        .isNull();
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/wrapped/io/TestFileRangeBridge.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/wrapped/io/TestFileRangeBridge.java
@@ -18,12 +18,8 @@
 
 package org.apache.parquet.hadoop.util.wrapped.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeNoException;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThatCode;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -46,13 +42,8 @@ public class TestFileRangeBridge {
 
   @Before
   public void setUp() {
-
-    // look for the FileRange; if not found, skip
-    try {
-      this.getClass().getClassLoader().loadClass(CLASSNAME);
-    } catch (ReflectiveOperationException e) {
-      assumeNoException(e);
-    }
+    assumeThatCode(() -> this.getClass().getClassLoader().loadClass(CLASSNAME))
+        .doesNotThrowAnyException();
   }
 
   /**
@@ -71,8 +62,10 @@ public class TestFileRangeBridge {
    */
   @Test
   public void testFileRangeBridgeAvailable() throws Throwable {
-    assertNotNull("FileRangeBridge instance null", FileRangeBridge.instance());
-    assertTrue("Bridge not available", FileRangeBridge.bridgeAvailable());
+    assertThat(FileRangeBridge.instance())
+        .as("FileRangeBridge instance null")
+        .isNotNull();
+    assertThat(FileRangeBridge.bridgeAvailable()).as("Bridge not available").isTrue();
   }
 
   /**
@@ -83,14 +76,14 @@ public class TestFileRangeBridge {
     Object reference = "backref";
     FileRangeBridge.WrappedFileRange range = FileRangeBridge.instance().createFileRange(512L, 16384, reference);
     LOG.info("created range {}", range);
-    assertNotNull("null range", range);
-    assertNotNull("null range instance", range.getFileRange());
-    assertEquals("offset of " + range, 512L, range.getOffset());
-    assertEquals("length of " + range, 16384, range.getLength());
-    assertSame("backref of " + range, reference, range.getReference());
+    assertThat(range).as("null range").isNotNull();
+    assertThat(range.getFileRange()).as("null range instance").isNotNull();
+    assertThat(range.getOffset()).as("offset of " + range).isEqualTo(512L);
+    assertThat(range.getLength()).as("length of " + range).isEqualTo(16384);
+    assertThat(range.getReference()).as("backref of " + range).isSameAs(reference);
 
     // this isn't set until readVectored() is called
-    assertNull("non-null range future", range.getData());
+    assertThat(range.getData()).as("non-null range future").isNull();
   }
 
   /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/wrapped/io/TestVectorIoBridge.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/wrapped/io/TestVectorIoBridge.java
@@ -18,11 +18,9 @@
 
 package org.apache.parquet.hadoop.util.wrapped.io;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -105,7 +103,9 @@ public class TestVectorIoBridge {
   @Before
   public void setUp() throws IOException {
     // skip the tests if the VectorIoBridge is unavailable
-    assumeTrue("Bridge not available", VectorIoBridge.instance().available());
+    assumeThat(VectorIoBridge.instance().available())
+        .as("Bridge not available")
+        .isTrue();
 
     fileSystem = FileSystem.getLocal(new Configuration());
     testFilePath = fileSystem.makeQualified(vectoredPath);
@@ -132,7 +132,9 @@ public class TestVectorIoBridge {
    */
   @Test
   public void testVectorIOBridgeAvailable() throws Throwable {
-    assertTrue("VectorIoBridge not available", VectorIoBridge.bridgeAvailable());
+    assertThat(VectorIoBridge.bridgeAvailable())
+        .as("VectorIoBridge not available")
+        .isTrue();
   }
 
   /**
@@ -249,9 +251,9 @@ public class TestVectorIoBridge {
     try (FSDataInputStream in = openTestFile()) {
       final boolean streamDoesNativeVectorIo =
           VectorIoBridge.instance().hasCapability(in, VectorIoBridge.VECTOREDIO_CAPABILITY);
-      assertTrue(
-          "capability " + VectorIoBridge.VECTOREDIO_CAPABILITY + " not supported by " + in,
-          streamDoesNativeVectorIo);
+      assertThat(streamDoesNativeVectorIo)
+          .as("capability " + VectorIoBridge.VECTOREDIO_CAPABILITY + " not supported by " + in)
+          .isTrue();
     }
   }
 
@@ -289,20 +291,21 @@ public class TestVectorIoBridge {
    */
   @Test
   public void testOverlappingRanges() throws Exception {
-    verifyExceptionalVectoredRead(getSampleOverlappingRanges(), IllegalArgumentException.class);
+    verifyExceptionalVectoredRead(
+        getSampleOverlappingRanges(), IllegalArgumentException.class, "Overlapping ranges");
   }
 
   @Test
   public void testSameRanges() throws Exception {
     // Same ranges are special case of overlapping only.
-    verifyExceptionalVectoredRead(getSampleSameRanges(), IllegalArgumentException.class);
+    verifyExceptionalVectoredRead(getSampleSameRanges(), IllegalArgumentException.class, "Overlapping ranges");
   }
   /**
    * A null range is not permitted.
    */
   @Test
   public void testNullRangeList() throws Exception {
-    verifyExceptionalVectoredRead(null, NullPointerException.class);
+    verifyExceptionalVectoredRead(null, NullPointerException.class, "Null input list");
   }
 
   /**
@@ -340,7 +343,7 @@ public class TestVectorIoBridge {
 
   @Test
   public void testNegativeLengthRange() throws Exception {
-    verifyExceptionalVectoredRead(ranges(1, -50), IllegalArgumentException.class);
+    verifyExceptionalVectoredRead(ranges(1, -50), IllegalArgumentException.class, "length is negative");
   }
 
   /**
@@ -349,7 +352,7 @@ public class TestVectorIoBridge {
    */
   @Test
   public void testNegativeOffsetRange() throws Exception {
-    verifyExceptionalVectoredRead(ranges(-1, 50), IllegalArgumentException.class);
+    verifyExceptionalVectoredRead(ranges(-1, 50), IllegalArgumentException.class, "offset is negative");
   }
 
   /**
@@ -366,7 +369,9 @@ public class TestVectorIoBridge {
       in.read(res, 0, 200);
       ByteBuffer buffer = ByteBuffer.wrap(res);
       assertDatasetEquals(0, "normal_read", buffer, 200, DATASET);
-      assertEquals("Vectored read shouldn't change file pointer.", 200, in.getPos());
+      assertThat(in.getPos())
+          .as("Vectored read shouldn't change file pointer.")
+          .isEqualTo(200);
       validateVectoredReadResult(fileRanges, DATASET);
     }
   }
@@ -383,7 +388,9 @@ public class TestVectorIoBridge {
       in.read(res, 0, 200);
       ByteBuffer buffer = ByteBuffer.wrap(res);
       assertDatasetEquals(0, "normal_read", buffer, 200, DATASET);
-      assertEquals("Vectored read shouldn't change file pointer.", 200, in.getPos());
+      assertThat(in.getPos())
+          .as("Vectored read shouldn't change file pointer.")
+          .isEqualTo(200);
       readVectored(in, fileRanges);
 
       validateVectoredReadResult(fileRanges, DATASET);
@@ -413,7 +420,8 @@ public class TestVectorIoBridge {
     verifyExceptionalVectoredRead(
         getSampleNonOverlappingRanges(),
         DirectByteBufferAllocator.getInstance(),
-        UnsupportedOperationException.class);
+        UnsupportedOperationException.class,
+        "Vectored IO not available");
   }
 
   /**
@@ -422,9 +430,9 @@ public class TestVectorIoBridge {
   @Test
   public void testDirectBufferReadReportedAsUnavailable() throws Exception {
     try (FSDataInputStream in = openTestFile()) {
-      assertFalse(
-          "Direct buffer read should not be available",
-          VectorIoBridge.instance().readVectoredAvailable(in, DirectByteBufferAllocator.getInstance()));
+      assertThat(VectorIoBridge.instance().readVectoredAvailable(in, DirectByteBufferAllocator.getInstance()))
+          .as("Direct buffer read should not be available")
+          .isFalse();
     }
   }
 
@@ -456,7 +464,9 @@ public class TestVectorIoBridge {
    */
   private List<ParquetFileRange> ranges(int... args) {
     final int len = args.length;
-    assertEquals("range argument length of " + len + " is not even", 0, (len & 1));
+    assertThat((len & 1))
+        .as("range argument length of " + len + " is not even")
+        .isEqualTo(0);
     List<ParquetFileRange> fileRanges = new ArrayList<>();
     for (int i = 0; i < len; i += 2) {
       fileRanges.add(range(args[i], args[i + 1]));
@@ -502,10 +512,9 @@ public class TestVectorIoBridge {
       final int readOffset, final String operation, final ByteBuffer data, int length, byte[] originalData) {
     for (int i = 0; i < length; i++) {
       int o = readOffset + i;
-      assertEquals(
-          operation + " with read offset " + readOffset + ": data[" + i + "] != DATASET[" + o + "]",
-          originalData[o],
-          data.get());
+      assertThat(data.get())
+          .as(operation + " with read offset " + readOffset + ": data[" + i + "] != DATASET[" + o + "]")
+          .isEqualTo(originalData[o]);
     }
   }
 
@@ -542,18 +551,19 @@ public class TestVectorIoBridge {
   }
 
   /**
-   * Validate that a specific exception is be thrown during a vectored
+   * Validate that a specific exception is thrown during a vectored
    * read operation with specific input ranges.
    *
    * @param fileRanges input file ranges.
    * @param clazz type of exception expected.
+   * @param messageSubstring expected substring of the exception message
    *
    * @throws IOException any IOE raised during the read.
    */
-  protected <T extends Throwable> T verifyExceptionalVectoredRead(List<ParquetFileRange> fileRanges, Class<T> clazz)
+  protected void verifyExceptionalVectoredRead(
+      List<ParquetFileRange> fileRanges, Class<? extends Throwable> clazz, String messageSubstring)
       throws IOException {
-
-    return verifyExceptionalVectoredRead(fileRanges, allocate, clazz);
+    verifyExceptionalVectoredRead(fileRanges, allocate, clazz, messageSubstring);
   }
 
   /**
@@ -564,23 +574,20 @@ public class TestVectorIoBridge {
    * @param fileRanges input file ranges.
    * @param allocator  allocator to use.
    * @param clazz type of exception expected.
+   * @param messageSubstring expected substring of the exception message
    *
    * @throws IOException any IOE raised during the read.
    */
-  private <T extends Throwable> T verifyExceptionalVectoredRead(
-      List<ParquetFileRange> fileRanges, ByteBufferAllocator allocator, Class<T> clazz) throws IOException {
+  protected void verifyExceptionalVectoredRead(
+      List<ParquetFileRange> fileRanges,
+      ByteBufferAllocator allocator,
+      Class<? extends Throwable> clazz,
+      String messageSubstring)
+      throws IOException {
     try (FSDataInputStream in = openTestFile()) {
-      VectorIoBridge.instance().readVectoredRanges(in, fileRanges, allocator);
-      fail("expected error reading " + in);
-      // for the compiler
-      return null;
-    } catch (AssertionError e) {
-      throw e;
-    } catch (Exception e) {
-      if (!clazz.isAssignableFrom(e.getClass())) {
-        throw e;
-      }
-      return (T) e;
+      assertThatThrownBy(() -> VectorIoBridge.instance().readVectoredRanges(in, fileRanges, allocator))
+          .isInstanceOf(clazz)
+          .hasMessageContaining(messageSubstring);
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestColumnIndexes.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestColumnIndexes.java
@@ -38,7 +38,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -346,7 +346,7 @@ public class TestColumnIndexes {
 
       List<ContractViolation> violations =
           ColumnIndexValidator.checkContractViolations(HadoopInputFile.fromPath(file, new Configuration()));
-      assertTrue(violations.toString(), violations.isEmpty());
+      assertThat(violations).as(violations.toString()).isEmpty();
     } finally {
       if (file != null) {
         file.getFileSystem(new Configuration()).delete(file, false);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestFloat16ReadWriteRoundTrip.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestFloat16ReadWriteRoundTrip.java
@@ -20,13 +20,11 @@ package org.apache.parquet.statistics;
 
 import static org.apache.parquet.schema.LogicalTypeAnnotation.float16Type;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
@@ -170,8 +168,10 @@ public class TestFloat16ReadWriteRoundTrip {
         ColumnChunkMetaData column =
             reader.getFooter().getBlocks().get(0).getColumns().get(0);
         ColumnIndex index = reader.readColumnIndex(column);
-        assertEquals(Collections.singletonList(expectedValues.get(i)[0]), toFloat16List(index.getMinValues()));
-        assertEquals(Collections.singletonList(expectedValues.get(i)[1]), toFloat16List(index.getMaxValues()));
+        assertThat(toFloat16List(index.getMinValues()))
+            .containsExactly(expectedValues.get(i)[0]);
+        assertThat(toFloat16List(index.getMaxValues()))
+            .containsExactly(expectedValues.get(i)[1]);
       }
     }
   }
@@ -203,7 +203,7 @@ public class TestFloat16ReadWriteRoundTrip {
       ColumnChunkMetaData column =
           reader.getFooter().getBlocks().get(0).getColumns().get(0);
       ColumnIndex index = reader.readColumnIndex(column);
-      assertNull(index);
+      assertThat(index).isNull();
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestFloat16Statistics.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestFloat16Statistics.java
@@ -20,7 +20,7 @@ package org.apache.parquet.statistics;
 
 import static org.apache.parquet.schema.LogicalTypeAnnotation.float16Type;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY;
-import static org.junit.Assert.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -184,8 +184,8 @@ public class TestFloat16Statistics {
             reader.getFooter().getBlocks().get(0).getColumns().get(0);
         Statistics<?> statistics = column.getStatistics();
 
-        assertArrayEquals(expectedValues.get(i)[0].getBytes(), statistics.getMinBytes());
-        assertArrayEquals(expectedValues.get(i)[1].getBytes(), statistics.getMaxBytes());
+        assertThat(statistics.getMinBytes()).isEqualTo(expectedValues.get(i)[0].getBytes());
+        assertThat(statistics.getMaxBytes()).isEqualTo(expectedValues.get(i)[1].getBytes());
       }
     }
   }
@@ -239,8 +239,8 @@ public class TestFloat16Statistics {
               reader.getFooter().getBlocks().get(0).getColumns().get(0);
           Statistics<?> statistics = column.getStatistics();
 
-          assertArrayEquals(valuesInAscendingOrder[minIndex].getBytes(), statistics.getMinBytes());
-          assertArrayEquals(valuesInAscendingOrder[maxIndex].getBytes(), statistics.getMaxBytes());
+          assertThat(statistics.getMinBytes()).isEqualTo(valuesInAscendingOrder[minIndex].getBytes());
+          assertThat(statistics.getMaxBytes()).isEqualTo(valuesInAscendingOrder[maxIndex].getBytes());
         }
       }
     }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestGeometryTypeRoundTrip.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestGeometryTypeRoundTrip.java
@@ -21,6 +21,7 @@ package org.apache.parquet.statistics;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.geographyType;
 import static org.apache.parquet.schema.LogicalTypeAnnotation.geometryType;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -42,7 +43,6 @@ import org.apache.parquet.io.LocalOutputFile;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -95,22 +95,22 @@ public class TestGeometryTypeRoundTrip {
     }
 
     try (ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(path))) {
-      Assert.assertEquals(2, reader.getRecordCount());
+      assertThat(reader.getRecordCount()).isEqualTo(2);
 
       ParquetMetadata footer = reader.getFooter();
-      Assert.assertNotNull(footer);
+      assertThat(footer).isNotNull();
 
       ColumnChunkMetaData columnChunkMetaData =
           reader.getRowGroups().get(0).getColumns().get(0);
-      Assert.assertNotNull(columnChunkMetaData);
+      assertThat(columnChunkMetaData).isNotNull();
 
       GeospatialStatistics geospatialStatistics = columnChunkMetaData.getGeospatialStatistics();
-      Assert.assertNotNull(geospatialStatistics);
+      assertThat(geospatialStatistics).isNotNull();
 
-      Assert.assertEquals(1.0, geospatialStatistics.getBoundingBox().getXMin(), 0.0);
-      Assert.assertEquals(2.0, geospatialStatistics.getBoundingBox().getXMax(), 0.0);
-      Assert.assertEquals(1.0, geospatialStatistics.getBoundingBox().getYMin(), 0.0);
-      Assert.assertEquals(2.0, geospatialStatistics.getBoundingBox().getYMax(), 0.0);
+      assertThat(geospatialStatistics.getBoundingBox().getXMin()).isEqualTo(1.0);
+      assertThat(geospatialStatistics.getBoundingBox().getXMax()).isEqualTo(2.0);
+      assertThat(geospatialStatistics.getBoundingBox().getYMin()).isEqualTo(1.0);
+      assertThat(geospatialStatistics.getBoundingBox().getYMax()).isEqualTo(2.0);
     }
   }
 
@@ -148,17 +148,17 @@ public class TestGeometryTypeRoundTrip {
     }
 
     try (ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(path))) {
-      Assert.assertEquals(2, reader.getRecordCount());
+      assertThat(reader.getRecordCount()).isEqualTo(2);
 
       ParquetMetadata footer = reader.getFooter();
-      Assert.assertNotNull(footer);
+      assertThat(footer).isNotNull();
 
       ColumnChunkMetaData columnChunkMetaData =
           reader.getRowGroups().get(0).getColumns().get(0);
-      Assert.assertNotNull(columnChunkMetaData);
+      assertThat(columnChunkMetaData).isNotNull();
 
       GeospatialStatistics geospatialStatistics = columnChunkMetaData.getGeospatialStatistics();
-      Assert.assertNull(geospatialStatistics);
+      assertThat(geospatialStatistics).isNull();
     }
   }
 
@@ -201,27 +201,35 @@ public class TestGeometryTypeRoundTrip {
 
     // Read and verify the file
     try (ParquetFileReader reader = ParquetFileReader.open(new LocalInputFile(path))) {
-      Assert.assertEquals(3, reader.getRecordCount());
+      assertThat(reader.getRecordCount()).isEqualTo(3);
 
       ParquetMetadata footer = reader.getFooter();
-      Assert.assertNotNull(footer);
+      assertThat(footer).isNotNull();
 
       ColumnChunkMetaData columnChunkMetaData =
           reader.getRowGroups().get(0).getColumns().get(0);
-      Assert.assertNotNull(columnChunkMetaData);
+      assertThat(columnChunkMetaData).isNotNull();
 
       // The key verification - when invalid geometry data is present,
       // geospatial statistics should omit the invalid data
       GeospatialStatistics geospatialStatistics = columnChunkMetaData.getGeospatialStatistics();
-      Assert.assertNotNull("Geospatial statistics should omit the corrupt geometry", geospatialStatistics);
+      assertThat(geospatialStatistics)
+          .as("Geospatial statistics should omit the corrupt geometry")
+          .isNotNull();
 
       // further check fields in the GeospatialStatistics
-      Assert.assertTrue("Geospatial statistics should be valid", geospatialStatistics.isValid());
-      Assert.assertNotNull("Bounding box should not be null", geospatialStatistics.getBoundingBox());
-      Assert.assertNotNull("Geospatial types should not be null", geospatialStatistics.getGeospatialTypes());
-      Assert.assertTrue(
-          "Geospatial types should be valid",
-          geospatialStatistics.getGeospatialTypes().isValid());
+      assertThat(geospatialStatistics.isValid())
+          .as("Geospatial statistics should be valid")
+          .isTrue();
+      assertThat(geospatialStatistics.getBoundingBox())
+          .as("Bounding box should not be null")
+          .isNotNull();
+      assertThat(geospatialStatistics.getGeospatialTypes())
+          .as("Geospatial types should not be null")
+          .isNotNull();
+      assertThat(geospatialStatistics.getGeospatialTypes().isValid())
+          .as("Geospatial types should be valid")
+          .isTrue();
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestIeee754TotalOrderE2E.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestIeee754TotalOrderE2E.java
@@ -23,9 +23,7 @@ import static org.apache.parquet.filter2.predicate.FilterApi.doubleColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.eq;
 import static org.apache.parquet.filter2.predicate.FilterApi.floatColumn;
 import static org.apache.parquet.filter2.predicate.FilterApi.notEq;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -282,23 +280,23 @@ public class TestIeee754TotalOrderE2E {
   }
 
   private static void assertFloatBits(List<Float> values, int... expectedBits) {
-    assertEquals(expectedBits.length, values.size());
+    assertThat(values).hasSameSizeAs(expectedBits);
     for (int i = 0; i < expectedBits.length; i++) {
-      assertEquals(expectedBits[i], Float.floatToRawIntBits(values.get(i)));
+      assertThat(Float.floatToRawIntBits(values.get(i))).isEqualTo(expectedBits[i]);
     }
   }
 
   private static void assertDoubleBits(List<Double> values, long... expectedBits) {
-    assertEquals(expectedBits.length, values.size());
+    assertThat(values).hasSameSizeAs(expectedBits);
     for (int i = 0; i < expectedBits.length; i++) {
-      assertEquals(expectedBits[i], Double.doubleToRawLongBits(values.get(i)));
+      assertThat(Double.doubleToRawLongBits(values.get(i))).isEqualTo(expectedBits[i]);
     }
   }
 
   private static void assertFloat16Bits(List<Binary> values, int... expectedBits) {
-    assertEquals(expectedBits.length, values.size());
+    assertThat(values).hasSameSizeAs(expectedBits);
     for (int i = 0; i < expectedBits.length; i++) {
-      assertEquals(expectedBits[i], values.get(i).get2BytesLittleEndian());
+      assertThat(values.get(i).get2BytesLittleEndian()).isEqualTo((short) expectedBits[i]);
     }
   }
 
@@ -311,37 +309,38 @@ public class TestIeee754TotalOrderE2E {
       ColumnChunkMetaData column = block.getColumns().get(0);
 
       // Verify column order is IEEE 754
-      assertEquals(
-          ColumnOrder.ieee754TotalOrder(), column.getPrimitiveType().columnOrder());
+      assertThat(column.getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.ieee754TotalOrder());
 
       // Verify statistics
       Statistics<?> stats = column.getStatistics();
-      assertNotNull(stats);
-      assertTrue("nan_count should be set", stats.isNanCountSet());
-      assertEquals("nan_count should be 2", 2, stats.getNanCount());
+      assertThat(stats).isNotNull();
+      assertThat(stats.isNanCountSet()).as("nan_count should be set").isTrue();
+      assertThat(stats.getNanCount()).as("nan_count should be 2").isEqualTo(2);
 
       // Min/max should exclude NaN
       FloatStatistics floatStats = (FloatStatistics) stats;
-      assertEquals(1.0f, floatStats.getMin(), 0.0f);
-      assertEquals(5.0f, floatStats.getMax(), 0.0f);
+      assertThat(floatStats.getMin()).isEqualTo(1.0f);
+      assertThat(floatStats.getMax()).isEqualTo(5.0f);
 
       // Verify column index
       ColumnIndex columnIndex = reader.readColumnIndex(column);
-      assertNotNull("ColumnIndex should not be null for IEEE 754 with NaN", columnIndex);
+      assertThat(columnIndex)
+          .as("ColumnIndex should not be null for IEEE 754 with NaN")
+          .isNotNull();
       List<Long> nanCounts = columnIndex.getNanCounts();
-      assertNotNull("nan_counts should be set in column index", nanCounts);
+      assertThat(nanCounts).as("nan_counts should be set in column index").isNotNull();
       // All values in one page, so one entry with nan_count = 2
-      assertEquals(1, nanCounts.size());
-      assertEquals(Long.valueOf(2), nanCounts.get(0));
+      assertThat(nanCounts).hasSize(1);
+      assertThat(nanCounts.get(0)).isEqualTo(Long.valueOf(2));
 
       // Verify min/max in column index exclude NaN
       List<ByteBuffer> minValues = columnIndex.getMinValues();
       List<ByteBuffer> maxValues = columnIndex.getMaxValues();
-      assertEquals(1, minValues.size());
+      assertThat(minValues).hasSize(1);
       float ciMin = minValues.get(0).order(ByteOrder.LITTLE_ENDIAN).getFloat(0);
       float ciMax = maxValues.get(0).order(ByteOrder.LITTLE_ENDIAN).getFloat(0);
-      assertEquals(1.0f, ciMin, 0.0f);
-      assertEquals(5.0f, ciMax, 0.0f);
+      assertThat(ciMin).isEqualTo(1.0f);
+      assertThat(ciMax).isEqualTo(5.0f);
     }
   }
 
@@ -354,23 +353,22 @@ public class TestIeee754TotalOrderE2E {
       BlockMetaData block = reader.getFooter().getBlocks().get(0);
       ColumnChunkMetaData column = block.getColumns().get(0);
 
-      assertEquals(
-          ColumnOrder.ieee754TotalOrder(), column.getPrimitiveType().columnOrder());
+      assertThat(column.getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.ieee754TotalOrder());
 
       Statistics<?> stats = column.getStatistics();
-      assertTrue(stats.isNanCountSet());
-      assertEquals(3, stats.getNanCount());
+      assertThat(stats.isNanCountSet()).isTrue();
+      assertThat(stats.getNanCount()).isEqualTo(3);
 
       DoubleStatistics doubleStats = (DoubleStatistics) stats;
-      assertEquals(-10.0, doubleStats.getMin(), 0.0);
-      assertEquals(20.0, doubleStats.getMax(), 0.0);
+      assertThat(doubleStats.getMin()).isEqualTo(-10.0);
+      assertThat(doubleStats.getMax()).isEqualTo(20.0);
 
       ColumnIndex columnIndex = reader.readColumnIndex(column);
-      assertNotNull(columnIndex);
+      assertThat(columnIndex).isNotNull();
       List<Long> nanCounts = columnIndex.getNanCounts();
-      assertNotNull(nanCounts);
-      assertEquals(1, nanCounts.size());
-      assertEquals(Long.valueOf(3), nanCounts.get(0));
+      assertThat(nanCounts).isNotNull();
+      assertThat(nanCounts).hasSize(1);
+      assertThat(nanCounts.get(0)).isEqualTo(Long.valueOf(3));
     }
   }
 
@@ -383,12 +381,12 @@ public class TestIeee754TotalOrderE2E {
           reader.getFooter().getBlocks().get(0).getColumns().get(0);
       Statistics<?> stats = column.getStatistics();
 
-      assertTrue(stats.isNanCountSet());
-      assertEquals(0, stats.getNanCount());
+      assertThat(stats.isNanCountSet()).isTrue();
+      assertThat(stats.getNanCount()).isEqualTo(0);
 
       FloatStatistics floatStats = (FloatStatistics) stats;
-      assertEquals(1.0f, floatStats.getMin(), 0.0f);
-      assertEquals(3.0f, floatStats.getMax(), 0.0f);
+      assertThat(floatStats.getMin()).isEqualTo(1.0f);
+      assertThat(floatStats.getMax()).isEqualTo(3.0f);
     }
   }
 
@@ -401,13 +399,19 @@ public class TestIeee754TotalOrderE2E {
           reader.getFooter().getBlocks().get(0).getColumns().get(0);
       Statistics<?> stats = column.getStatistics();
 
-      assertTrue(stats.isNanCountSet());
-      assertEquals(3, stats.getNanCount());
+      assertThat(stats.isNanCountSet()).isTrue();
+      assertThat(stats.getNanCount()).isEqualTo(3);
 
-      assertTrue("All-NaN column should have min/max values", stats.hasNonNullValue());
+      assertThat(stats.hasNonNullValue())
+          .as("All-NaN column should have min/max values")
+          .isTrue();
       FloatStatistics floatStats = (FloatStatistics) stats;
-      assertTrue("All-NaN min should be NaN", Float.isNaN(floatStats.getMin()));
-      assertTrue("All-NaN max should be NaN", Float.isNaN(floatStats.getMax()));
+      assertThat(Float.isNaN(floatStats.getMin()))
+          .as("All-NaN min should be NaN")
+          .isTrue();
+      assertThat(Float.isNaN(floatStats.getMax()))
+          .as("All-NaN max should be NaN")
+          .isTrue();
     }
   }
 
@@ -512,35 +516,32 @@ public class TestIeee754TotalOrderE2E {
 
       // Verify float column
       ColumnChunkMetaData floatCol = block.getColumns().get(0);
-      assertEquals(
-          ColumnOrder.ieee754TotalOrder(), floatCol.getPrimitiveType().columnOrder());
+      assertThat(floatCol.getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.ieee754TotalOrder());
       Statistics<?> floatStats = floatCol.getStatistics();
-      assertTrue(floatStats.isNanCountSet());
-      assertEquals(1, floatStats.getNanCount());
-      assertEquals(1.0f, ((FloatStatistics) floatStats).getMin(), 0.0f);
-      assertEquals(3.0f, ((FloatStatistics) floatStats).getMax(), 0.0f);
+      assertThat(floatStats.isNanCountSet()).isTrue();
+      assertThat(floatStats.getNanCount()).isEqualTo(1);
+      assertThat(((FloatStatistics) floatStats).getMin()).isEqualTo(1.0f);
+      assertThat(((FloatStatistics) floatStats).getMax()).isEqualTo(3.0f);
 
       // Verify double column
       ColumnChunkMetaData doubleCol = block.getColumns().get(1);
-      assertEquals(
-          ColumnOrder.ieee754TotalOrder(),
-          doubleCol.getPrimitiveType().columnOrder());
+      assertThat(doubleCol.getPrimitiveType().columnOrder()).isEqualTo(ColumnOrder.ieee754TotalOrder());
       Statistics<?> doubleStats = doubleCol.getStatistics();
-      assertTrue(doubleStats.isNanCountSet());
-      assertEquals(1, doubleStats.getNanCount());
-      assertEquals(-5.0, ((DoubleStatistics) doubleStats).getMin(), 0.0);
-      assertEquals(10.0, ((DoubleStatistics) doubleStats).getMax(), 0.0);
+      assertThat(doubleStats.isNanCountSet()).isTrue();
+      assertThat(doubleStats.getNanCount()).isEqualTo(1);
+      assertThat(((DoubleStatistics) doubleStats).getMin()).isEqualTo(-5.0);
+      assertThat(((DoubleStatistics) doubleStats).getMax()).isEqualTo(10.0);
 
       // Verify column indexes for both
       ColumnIndex floatCI = reader.readColumnIndex(floatCol);
-      assertNotNull(floatCI);
-      assertNotNull(floatCI.getNanCounts());
-      assertEquals(Long.valueOf(1), floatCI.getNanCounts().get(0));
+      assertThat(floatCI).isNotNull();
+      assertThat(floatCI.getNanCounts()).isNotNull();
+      assertThat(floatCI.getNanCounts().get(0)).isEqualTo(Long.valueOf(1));
 
       ColumnIndex doubleCI = reader.readColumnIndex(doubleCol);
-      assertNotNull(doubleCI);
-      assertNotNull(doubleCI.getNanCounts());
-      assertEquals(Long.valueOf(1), doubleCI.getNanCounts().get(0));
+      assertThat(doubleCI).isNotNull();
+      assertThat(doubleCI.getNanCounts()).isNotNull();
+      assertThat(doubleCI.getNanCounts().get(0)).isEqualTo(Long.valueOf(1));
     }
   }
 }

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestSizeStatisticsRoundTrip.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestSizeStatisticsRoundTrip.java
@@ -18,10 +18,10 @@
  */
 package org.apache.parquet.statistics;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -43,7 +43,6 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -82,18 +81,18 @@ public class TestSizeStatisticsRoundTrip {
       ColumnChunkMetaData column = footer.getBlocks().get(0).getColumns().get(0);
 
       SizeStatistics sizeStatistics = column.getSizeStatistics();
-      Assert.assertEquals(Optional.of(4L), sizeStatistics.getUnencodedByteArrayDataBytes());
-      Assert.assertEquals(Collections.emptyList(), sizeStatistics.getRepetitionLevelHistogram());
-      Assert.assertEquals(Collections.emptyList(), sizeStatistics.getDefinitionLevelHistogram());
+      assertThat(sizeStatistics.getUnencodedByteArrayDataBytes()).isEqualTo(Optional.of(4L));
+      assertThat(sizeStatistics.getRepetitionLevelHistogram()).isEmpty();
+      assertThat(sizeStatistics.getDefinitionLevelHistogram()).isEmpty();
 
       ColumnIndex columnIndex = reader.readColumnIndex(column);
-      Assert.assertEquals(Collections.emptyList(), columnIndex.getRepetitionLevelHistogram());
-      Assert.assertEquals(Collections.emptyList(), columnIndex.getDefinitionLevelHistogram());
+      assertThat(columnIndex.getRepetitionLevelHistogram()).isEmpty();
+      assertThat(columnIndex.getDefinitionLevelHistogram()).isEmpty();
 
       OffsetIndex offsetIndex = reader.readOffsetIndex(column);
-      Assert.assertEquals(2, offsetIndex.getPageCount());
-      Assert.assertEquals(Optional.of(2L), offsetIndex.getUnencodedByteArrayDataBytes(0));
-      Assert.assertEquals(Optional.of(2L), offsetIndex.getUnencodedByteArrayDataBytes(1));
+      assertThat(offsetIndex.getPageCount()).isEqualTo(2);
+      assertThat(offsetIndex.getUnencodedByteArrayDataBytes(0)).isEqualTo(Optional.of(2L));
+      assertThat(offsetIndex.getUnencodedByteArrayDataBytes(1)).isEqualTo(Optional.of(2L));
     }
   }
 
@@ -140,17 +139,17 @@ public class TestSizeStatisticsRoundTrip {
       ColumnChunkMetaData column = footer.getBlocks().get(0).getColumns().get(0);
 
       SizeStatistics sizeStatistics = column.getSizeStatistics();
-      Assert.assertEquals(Optional.of(3L), sizeStatistics.getUnencodedByteArrayDataBytes());
-      Assert.assertEquals(List.of(2L, 1L), sizeStatistics.getRepetitionLevelHistogram());
-      Assert.assertEquals(List.of(0L, 0L, 0L, 3L), sizeStatistics.getDefinitionLevelHistogram());
+      assertThat(sizeStatistics.getUnencodedByteArrayDataBytes()).isEqualTo(Optional.of(3L));
+      assertThat(sizeStatistics.getRepetitionLevelHistogram()).containsExactly(2L, 1L);
+      assertThat(sizeStatistics.getDefinitionLevelHistogram()).containsExactly(0L, 0L, 0L, 3L);
 
       ColumnIndex columnIndex = reader.readColumnIndex(column);
-      Assert.assertEquals(List.of(2L, 1L), sizeStatistics.getRepetitionLevelHistogram());
-      Assert.assertEquals(List.of(0L, 0L, 0L, 3L), sizeStatistics.getDefinitionLevelHistogram());
+      assertThat(columnIndex.getRepetitionLevelHistogram()).containsExactly(2L, 1L);
+      assertThat(columnIndex.getDefinitionLevelHistogram()).containsExactly(0L, 0L, 0L, 3L);
 
       OffsetIndex offsetIndex = reader.readOffsetIndex(column);
-      Assert.assertEquals(1, offsetIndex.getPageCount());
-      Assert.assertEquals(Optional.of(3L), offsetIndex.getUnencodedByteArrayDataBytes(0));
+      assertThat(offsetIndex.getPageCount()).isEqualTo(1);
+      assertThat(offsetIndex.getUnencodedByteArrayDataBytes(0)).isEqualTo(Optional.of(3L));
     }
   }
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestStatistics.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/statistics/TestStatistics.java
@@ -28,8 +28,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT96;
 import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
@@ -68,7 +67,6 @@ import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
 import org.apache.parquet.statistics.RandomValues.RandomBinaryBase;
 import org.apache.parquet.statistics.RandomValues.RandomValueGenerator;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -144,8 +142,12 @@ public class TestStatistics {
 
     public void validate(T value) {
       if (hasNonNull) {
-        assertTrue("min should be <= all values", comparator.compare(min, value) <= 0);
-        assertTrue("min should be >= all values", comparator.compare(max, value) >= 0);
+        assertThat(comparator.compare(min, value))
+            .as("min should be <= all values")
+            .isLessThanOrEqualTo(0);
+        assertThat(comparator.compare(max, value))
+            .as("min should be >= all values")
+            .isGreaterThanOrEqualTo(0);
       }
     }
   }
@@ -258,13 +260,12 @@ public class TestStatistics {
       PrimitiveConverter converter = getValidatingConverter(page, desc.getType());
       Statistics<?> stats = getStatisticsFromPageHeader(page);
 
-      assertEquals(
-          "Statistics does not use the proper comparator",
-          desc.getPrimitiveType().comparator().getClass(),
-          stats.comparator().getClass());
+      assertThat(stats.comparator().getClass())
+          .as("Statistics does not use the proper comparator")
+          .isEqualTo(desc.getPrimitiveType().comparator().getClass());
 
       if (statisticsDisabled) {
-        Assert.assertTrue(stats.isEmpty());
+        assertThat(stats.isEmpty()).isTrue();
       }
 
       if (stats.isEmpty()) {
@@ -284,7 +285,7 @@ public class TestStatistics {
         column.consume();
       }
 
-      Assert.assertEquals(numNulls, stats.getNumNulls());
+      assertThat(stats.getNumNulls()).isEqualTo(numNulls);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Switching assertions from JUnit4-style Assert to AssertJ makes code easier to read and debug when tests fail.


### What changes are included in this PR?
This updates parquet-hadoop tests to use AssertJ checks, which provide more fluent assertions and more detailed information when assertions fails on CI.

Closes #3652 

The changes in this PR were done with the help of Claude but I manually reviewed every single LOC

### Are these changes tested?
yes, existing tests

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
