### PR TITLE
GH-3618: Migrate multiple modules to JUnit5

### DIFF
--- a/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
+++ b/parquet-arrow/src/test/java/org/apache/parquet/arrow/schema/TestSchemaConverter.java
@@ -56,7 +56,7 @@ import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * @see SchemaConverter

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/AvroTestUtil.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/AvroTestUtil.java
@@ -36,7 +36,6 @@ import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.parquet.variant.Variant;
-import org.junit.rules.TemporaryFolder;
 
 public class AvroTestUtil {
 
@@ -104,17 +103,18 @@ public class AvroTestUtil {
   }
 
   @SuppressWarnings("unchecked")
-  public static <D> File write(TemporaryFolder temp, GenericData model, Schema schema, D... data) throws IOException {
-    return write(temp, new Configuration(false), model, schema, data);
+  public static <D> File write(java.nio.file.Path tempDir, GenericData model, Schema schema, D... data)
+      throws IOException {
+    return write(tempDir, new Configuration(false), model, schema, data);
   }
 
   @SuppressWarnings("unchecked")
-  public static <D> File write(TemporaryFolder temp, Configuration conf, GenericData model, Schema schema, D... data)
+  public static <D> File write(
+      java.nio.file.Path tempDir, Configuration conf, GenericData model, Schema schema, D... data)
       throws IOException {
-    File file = temp.newFile();
-    assertThat(file.delete()).isTrue();
+    java.nio.file.Path file = tempDir.resolve("test");
 
-    try (ParquetWriter<D> writer = AvroParquetWriter.<D>builder(new Path(file.toString()))
+    try (ParquetWriter<D> writer = AvroParquetWriter.<D>builder(new Path(file.toUri()))
         .withDataModel(model)
         .withSchema(schema)
         .build()) {
@@ -123,7 +123,7 @@ public class AvroTestUtil {
       }
     }
 
-    return file;
+    return file.toFile();
   }
 
   public static Configuration conf(String name, boolean value) {

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestArrayCompatibility.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestArrayCompatibility.java
@@ -43,23 +43,23 @@ import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestArrayCompatibility extends DirectWriterTest {
 
   public static final Configuration OLD_BEHAVIOR_CONF = new Configuration();
   public static final Configuration NEW_BEHAVIOR_CONF = new Configuration();
 
-  @BeforeClass
+  @BeforeAll
   public static void setupNewBehaviorConfiguration() {
     OLD_BEHAVIOR_CONF.setBoolean(AvroSchemaConverter.ADD_LIST_ELEMENT_RECORDS, true);
     NEW_BEHAVIOR_CONF.setBoolean(AvroSchemaConverter.ADD_LIST_ELEMENT_RECORDS, false);
   }
 
   @Test
-  @Ignore(value = "Not yet supported")
+  @Disabled(value = "Not yet supported")
   public void testUnannotatedListOfPrimitives() throws Exception {
     Path test =
         writeDirect("message UnannotatedListOfPrimitives {" + "  repeated int32 list_of_ints;" + "}", rc -> {
@@ -84,7 +84,7 @@ public class TestArrayCompatibility extends DirectWriterTest {
   }
 
   @Test
-  @Ignore(value = "Not yet supported")
+  @Disabled(value = "Not yet supported")
   public void testUnannotatedListOfGroups() throws Exception {
     Path test = writeDirect(
         "message UnannotatedListOfGroups {" + "  repeated group list_of_points {"

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroDataSupplier.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroDataSupplier.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestAvroDataSupplier {
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroRecordConverter.java
@@ -31,9 +31,9 @@ import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.specific.SpecificData;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -41,13 +41,13 @@ public class TestAvroRecordConverter {
 
   private MockedStatic<AvroRecordConverter> avroRecordConverterMock;
 
-  @Before
+  @BeforeEach
   public void setup() {
     // Default to calling real methods unless overridden in specific test
     avroRecordConverterMock = Mockito.mockStatic(AvroRecordConverter.class, CALLS_REAL_METHODS);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     avroRecordConverterMock.close();
   }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroSchemaConverter.java
@@ -63,10 +63,10 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Types;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -75,17 +75,17 @@ public class TestAvroSchemaConverter {
   private static final Configuration NEW_BEHAVIOR = new Configuration(false);
   private MockedStatic<AvroRecordConverter> avroRecordConverterMock;
 
-  @Before
+  @BeforeEach
   public void setupMockito() {
     avroRecordConverterMock = Mockito.mockStatic(AvroRecordConverter.class, CALLS_REAL_METHODS);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     avroRecordConverterMock.close();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupConf() {
     NEW_BEHAVIOR.setBoolean("parquet.avro.add-list-element-records", false);
     NEW_BEHAVIOR.setBoolean("parquet.avro.write-old-list-structure", false);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroWriteSupport.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestAvroWriteSupport.java
@@ -29,7 +29,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestAvroWriteSupport {
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestBackwardCompatibility.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestBackwardCompatibility.java
@@ -27,7 +27,7 @@ import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestBackwardCompatibility {
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestByteStreamSplitE2E.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestByteStreamSplitE2E.java
@@ -21,7 +21,6 @@ package org.apache.parquet.avro;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.Lists;
-import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -34,14 +33,13 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestByteStreamSplitE2E {
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  private java.nio.file.Path tempDir;
 
   private void testWriteReadFloatingNumbers(boolean isDouble, boolean hasNull) throws IOException {
     Schema schema = Schema.createRecord("myrecord", null, null, false);
@@ -49,8 +47,8 @@ public class TestByteStreamSplitE2E {
     schema.setFields(Collections.singletonList(
         new Schema.Field("a", Schema.createUnion(Schema.create(Schema.Type.NULL), field), null, null)));
 
-    File file = temp.newFile((isDouble ? "double_" : "float_") + hasNull + ".parquet");
-    Path path = new Path(file.toString());
+    Path path = new Path(tempDir.resolve((isDouble ? "double_" : "float_") + hasNull + ".parquet")
+        .toUri());
     List<GenericRecord> expected = Lists.newArrayList();
 
     try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(path)

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestCircularReferences.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestCircularReferences.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
@@ -34,10 +35,9 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,8 +54,8 @@ public class TestCircularReferences {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestCircularReferences.class);
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  private Path tempDir;
 
   public static class Reference extends LogicalType {
     private static final String REFERENCE = "reference";
@@ -140,7 +140,7 @@ public class TestCircularReferences {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void addReferenceTypes() {
     LogicalTypes.register(Referenceable.REFERENCEABLE, new LogicalTypes.LogicalTypeFactory() {
       @Override
@@ -356,7 +356,7 @@ public class TestCircularReferences {
     parent.put("child", child);
 
     // serialization round trip
-    File data = AvroTestUtil.write(temp, model, schema, parent);
+    File data = AvroTestUtil.write(tempDir, model, schema, parent);
     List<Record> records = AvroTestUtil.read(model, schema, data);
 
     Record actual = records.get(0);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestGenericLogicalTypes.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestGenericLogicalTypes.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,25 +45,24 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * This class is based on org.apache.avro.generic.TestGenericLogicalTypes
  */
 public class TestGenericLogicalTypes {
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  private Path tempDir;
 
   public static final GenericData GENERIC = new GenericData();
   public static final LogicalType DECIMAL_9_2 = LogicalTypes.decimal(9, 2);
   public static final BigDecimal D1 = new BigDecimal("-34.34");
   public static final BigDecimal D2 = new BigDecimal("117230.00");
 
-  @BeforeClass
+  @BeforeAll
   public static void addDecimalAndUUID() {
     GENERIC.addLogicalTypeConversion(new Conversions.DecimalConversion());
     GENERIC.addLogicalTypeConversion(new Conversions.UUIDConversion());
@@ -281,10 +281,10 @@ public class TestGenericLogicalTypes {
   }
 
   private <D> File write(GenericData model, Schema schema, D... data) throws IOException {
-    return AvroTestUtil.write(temp, model, schema, data);
+    return AvroTestUtil.write(tempDir, model, schema, data);
   }
 
   private <D> File write(Configuration conf, GenericData model, Schema schema, D... data) throws IOException {
-    return AvroTestUtil.write(temp, conf, model, schema, data);
+    return AvroTestUtil.write(tempDir, conf, model, schema, data);
   }
 }

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestInputOutputFormat.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.TextOutputFormat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadVariant.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadVariant.java
@@ -59,7 +59,7 @@ import org.apache.parquet.variant.Variant;
 import org.apache.parquet.variant.VariantArrayBuilder;
 import org.apache.parquet.variant.VariantBuilder;
 import org.apache.parquet.variant.VariantObjectBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestReadVariant extends DirectWriterTest {
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWrite.java
@@ -28,7 +28,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
-import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -40,12 +39,12 @@ import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Stream;
 import org.apache.avro.Conversion;
 import org.apache.avro.Conversions;
 import org.apache.avro.LogicalType;
@@ -81,13 +80,11 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class TestReadWrite {
 
   enum Converters {
@@ -121,46 +118,88 @@ public class TestReadWrite {
     EXPLICIT
   }
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    Object[][] data = new Object[][] {
-      {Converters.COMPATIBLE, FileLocation.HADOOP, ConfigurationType.HADOOP_CONFIGURATION, CodecFactory.IMPLICIT},
-      {
-        Converters.COMPATIBLE,
-        FileLocation.HADOOP,
-        ConfigurationType.HADOOP_PARQUET_INTERFACE,
-        CodecFactory.IMPLICIT
-      },
-      {Converters.NEW, FileLocation.HADOOP, ConfigurationType.HADOOP_CONFIGURATION, CodecFactory.IMPLICIT},
-      {Converters.NEW, FileLocation.LOCAL, ConfigurationType.HADOOP_CONFIGURATION, CodecFactory.IMPLICIT},
-      {Converters.NEW, FileLocation.HADOOP, ConfigurationType.HADOOP_PARQUET_INTERFACE, CodecFactory.IMPLICIT},
-      {Converters.NEW, FileLocation.LOCAL, ConfigurationType.HADOOP_PARQUET_INTERFACE, CodecFactory.IMPLICIT},
-      {Converters.NEW, FileLocation.HADOOP, ConfigurationType.PLAIN_PARQUET_INTERFACE, CodecFactory.IMPLICIT},
-      {Converters.NEW, FileLocation.LOCAL, ConfigurationType.PLAIN_PARQUET_INTERFACE, CodecFactory.IMPLICIT},
-      {
-        Converters.COMPATIBLE,
-        FileLocation.HADOOP,
-        ConfigurationType.HADOOP_PARQUET_INTERFACE,
-        CodecFactory.EXPLICIT
-      },
-      {Converters.NEW, FileLocation.HADOOP, ConfigurationType.HADOOP_PARQUET_INTERFACE, CodecFactory.EXPLICIT},
-      {Converters.NEW, FileLocation.LOCAL, ConfigurationType.HADOOP_PARQUET_INTERFACE, CodecFactory.EXPLICIT},
-      {Converters.NEW, FileLocation.HADOOP, ConfigurationType.PLAIN_PARQUET_INTERFACE, CodecFactory.EXPLICIT},
-      {Converters.NEW, FileLocation.LOCAL, ConfigurationType.PLAIN_PARQUET_INTERFACE, CodecFactory.EXPLICIT}
-    };
-    return Arrays.asList(data);
+  @TempDir
+  private java.nio.file.Path tempDir;
+
+  static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(
+            Converters.COMPATIBLE,
+            FileLocation.HADOOP,
+            ConfigurationType.HADOOP_CONFIGURATION,
+            CodecFactory.IMPLICIT),
+        Arguments.of(
+            Converters.COMPATIBLE,
+            FileLocation.HADOOP,
+            ConfigurationType.HADOOP_PARQUET_INTERFACE,
+            CodecFactory.IMPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.HADOOP,
+            ConfigurationType.HADOOP_CONFIGURATION,
+            CodecFactory.IMPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.LOCAL,
+            ConfigurationType.HADOOP_CONFIGURATION,
+            CodecFactory.IMPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.HADOOP,
+            ConfigurationType.HADOOP_PARQUET_INTERFACE,
+            CodecFactory.IMPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.LOCAL,
+            ConfigurationType.HADOOP_PARQUET_INTERFACE,
+            CodecFactory.IMPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.HADOOP,
+            ConfigurationType.PLAIN_PARQUET_INTERFACE,
+            CodecFactory.IMPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.LOCAL,
+            ConfigurationType.PLAIN_PARQUET_INTERFACE,
+            CodecFactory.IMPLICIT),
+        Arguments.of(
+            Converters.COMPATIBLE,
+            FileLocation.HADOOP,
+            ConfigurationType.HADOOP_PARQUET_INTERFACE,
+            CodecFactory.EXPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.HADOOP,
+            ConfigurationType.HADOOP_PARQUET_INTERFACE,
+            CodecFactory.EXPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.LOCAL,
+            ConfigurationType.HADOOP_PARQUET_INTERFACE,
+            CodecFactory.EXPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.HADOOP,
+            ConfigurationType.PLAIN_PARQUET_INTERFACE,
+            CodecFactory.EXPLICIT),
+        Arguments.of(
+            Converters.NEW,
+            FileLocation.LOCAL,
+            ConfigurationType.PLAIN_PARQUET_INTERFACE,
+            CodecFactory.EXPLICIT));
   }
 
-  private final Converters converter;
-  private final FileLocation fileLocation;
-  private final ConfigurationType conf;
-  private final CodecFactory codecType;
+  private Converters converter;
+  private FileLocation fileLocation;
+  private ConfigurationType conf;
+  private CodecFactory codecType;
 
   private final Configuration testConf = new Configuration();
   private final ParquetConfiguration hadoopConfWithInterface = new HadoopParquetConfiguration();
   private final ParquetConfiguration plainParquetConf = new PlainParquetConfiguration();
 
-  public TestReadWrite(Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs) {
+  private void init(Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs) {
     this.converter = converter;
     this.fileLocation = fileLocation;
     this.conf = conf;
@@ -176,15 +215,19 @@ public class TestReadWrite {
     this.plainParquetConf.setBoolean("parquet.avro.write-old-list-structure", false);
   }
 
-  @Test
-  public void testEmptyArray() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testEmptyArray(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("array.avsc").openStream());
 
     // Write a record with an empty array.
     List<Integer> emptyArray = new ArrayList<>();
 
-    String file = createTempFile().getPath();
+    String file = createTempFile().toUri().getPath();
 
     try (ParquetWriter<GenericRecord> writer = writer(file, schema)) {
       GenericData.Record record =
@@ -200,12 +243,16 @@ public class TestReadWrite {
     }
   }
 
-  @Test
-  public void testEmptyMap() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testEmptyMap(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("map.avsc").openStream());
 
-    String file = createTempFile().getPath();
+    String file = createTempFile().toUri().getPath();
     ImmutableMap<String, Integer> emptyMap = new ImmutableMap.Builder<String, Integer>().build();
 
     try (ParquetWriter<GenericRecord> writer = writer(file, schema)) {
@@ -224,12 +271,16 @@ public class TestReadWrite {
     }
   }
 
-  @Test
-  public void testMapWithNulls() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testMapWithNulls(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema schema = new Schema.Parser()
         .parse(Resources.getResource("map_with_nulls.avsc").openStream());
 
-    Path file = new Path(createTempFile().getPath());
+    Path file = createTempFile();
 
     // Write a record with a null value
     Map<CharSequence, Integer> map = new HashMap<>();
@@ -255,13 +306,17 @@ public class TestReadWrite {
     }
   }
 
-  @Test
-  public void testMapRequiredValueWithNull() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testMapRequiredValueWithNull(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema schema = Schema.createRecord("record1", null, null, false);
     schema.setFields(Lists.newArrayList(
         new Schema.Field("mymap", Schema.createMap(Schema.create(Schema.Type.INT)), null, null)));
 
-    Path file = new Path(createTempFile().getPath());
+    Path file = createTempFile();
 
     try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(file)
         .withSchema(schema)
@@ -282,12 +337,16 @@ public class TestReadWrite {
     }
   }
 
-  @Test
-  public void testMapWithUtf8Key() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testMapWithUtf8Key(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("map.avsc").openStream());
 
-    Path file = new Path(createTempFile().getPath());
+    Path file = createTempFile();
 
     try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(file)
         .withSchema(schema)
@@ -309,11 +368,12 @@ public class TestReadWrite {
     }
   }
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
-
-  @Test
-  public void testDecimalValues() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDecimalValues(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema decimalSchema = Schema.createRecord("myrecord", null, null, false);
     Schema decimal = LogicalTypes.decimal(9, 2).addToSchema(Schema.create(Schema.Type.BYTES));
     decimalSchema.setFields(Collections.singletonList(new Schema.Field("dec", decimal, null, null)));
@@ -322,9 +382,7 @@ public class TestReadWrite {
     GenericData decimalSupport = new GenericData();
     decimalSupport.addLogicalTypeConversion(new Conversions.DecimalConversion());
 
-    File file = temp.newFile("decimal.parquet");
-    file.delete();
-    Path path = new Path(file.toString());
+    Path path = new Path(tempDir.resolve("decimal.parquet").toUri());
     List<GenericRecord> expected = Lists.newArrayList();
 
     try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(path)
@@ -362,8 +420,12 @@ public class TestReadWrite {
     assertThat(records).as("Content should match").containsExactlyElementsOf(expected);
   }
 
-  @Test
-  public void testFixedDecimalValues() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testFixedDecimalValues(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema decimalSchema = Schema.createRecord("myrecord", null, null, false);
     Schema decimal = LogicalTypes.decimal(9, 2).addToSchema(Schema.createFixed("dec", null, null, 4));
     decimalSchema.setFields(Collections.singletonList(new Schema.Field("dec", decimal, null, null)));
@@ -372,9 +434,7 @@ public class TestReadWrite {
     GenericData decimalSupport = new GenericData();
     decimalSupport.addLogicalTypeConversion(new Conversions.DecimalConversion());
 
-    File file = temp.newFile("decimal.parquet");
-    file.delete();
-    Path path = new Path(file.toString());
+    Path path = new Path(tempDir.resolve("decimal.parquet").toUri());
     List<GenericRecord> expected = Lists.newArrayList();
 
     try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(path)
@@ -412,12 +472,14 @@ public class TestReadWrite {
     assertThat(records).as("Content should match").containsExactlyElementsOf(expected);
   }
 
-  @Test
-  public void testDecimalIntegerValues() throws Exception {
-
-    File file = temp.newFile("test_decimal_integer_values.parquet");
-    file.delete();
-    Path path = new Path(file.toString());
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDecimalIntegerValues(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
+    Path path =
+        new Path(tempDir.resolve("test_decimal_integer_values.parquet").toUri());
 
     MessageType parquetSchema = new MessageType(
         "test_decimal_integer_values",
@@ -478,12 +540,15 @@ public class TestReadWrite {
     assertThat(secondSalary).as("Should be 120.3, but is " + secondSalary).isEqualTo(new BigDecimal("120.3"));
   }
 
-  @Test
-  public void testAll() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testAll(Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("all.avsc").openStream());
 
-    Path file = new Path(createTempFile().getPath());
+    Path file = createTempFile();
     List<Integer> integerArray = Arrays.asList(1, 2, 3);
     GenericData.Record nestedRecord = new GenericRecordBuilder(
             schema.getField("mynestedrecord").schema())
@@ -557,9 +622,13 @@ public class TestReadWrite {
     assertThat(nextRecord.get("myfixed")).isEqualTo(genericFixed);
   }
 
-  @Test
-  public void testAllUsingDefaultAvroSchema() throws Exception {
-    Path file = new Path(createTempFile().getPath());
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testAllUsingDefaultAvroSchema(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
+    Path file = createTempFile();
 
     // write file using Parquet APIs
     try (ParquetWriter<Map<String, Object>> parquetWriter =
@@ -778,13 +847,17 @@ public class TestReadWrite {
     }
   }
 
-  @Test
-  public void testUnionWithSingleNonNullType() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testUnionWithSingleNonNullType(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema avroSchema = Schema.createRecord("SingleStringUnionRecord", null, null, false);
     avroSchema.setFields(Collections.singletonList(
         new Schema.Field("value", Schema.createUnion(Schema.create(Schema.Type.STRING)), null, null)));
 
-    Path file = new Path(createTempFile().getPath());
+    Path file = createTempFile();
 
     // Parquet writer
     try (ParquetWriter parquetWriter = AvroParquetWriter.builder(file)
@@ -807,14 +880,18 @@ public class TestReadWrite {
     }
   }
 
-  @Test
-  public void testDuplicatedValuesWithDictionary() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDuplicatedValuesWithDictionary(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema schema = SchemaBuilder.record("spark_schema")
         .fields()
         .optionalBytes("value")
         .endRecord();
 
-    Path file = new Path(createTempFile().getPath());
+    Path file = createTempFile();
 
     String[] records = {"one", "two", "three", "three", "two", "one", "zero"};
     try (ParquetWriter<GenericData.Record> writer = AvroParquetWriter.<GenericData.Record>builder(file)
@@ -842,11 +919,15 @@ public class TestReadWrite {
     }
   }
 
-  @Test
-  public void testNestedLists() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testNestedLists(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema schema = new Schema.Parser()
         .parse(Resources.getResource("nested_array.avsc").openStream());
-    String file = createTempFile().getPath();
+    String file = createTempFile().toUri().getPath();
 
     // Parquet writer
     ParquetWriter parquetWriter = writer(file, schema);
@@ -885,14 +966,18 @@ public class TestReadWrite {
    * A test demonstrating the most simple way to write and read Parquet files
    * using Avro {@link GenericRecord}.
    */
-  @Test
-  public void testSimpleGeneric() throws IOException {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSimpleGeneric(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws IOException {
+    init(converter, fileLocation, conf, codecs);
     final Schema schema = Schema.createRecord("Person", null, "org.apache.parquet", false);
     schema.setFields(Arrays.asList(
         new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null),
         new Schema.Field("weight", Schema.create(Schema.Type.INT), null, null)));
 
-    final Path file = new Path(createTempFile().getPath());
+    final Path file = createTempFile();
 
     try (final ParquetWriter<GenericData.Record> parquetWriter = AvroParquetWriter.<GenericData.Record>builder(file)
         .withSchema(schema)
@@ -953,23 +1038,25 @@ public class TestReadWrite {
     }
   }
 
-  @Test
-  public void testParsesDataModelFromConf() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testParsesDataModelFromConf(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws Exception {
+    init(converter, fileLocation, conf, codecs);
     Schema datetimeSchema = Schema.createRecord("myrecord", null, null, false);
     Schema date = LogicalTypes.date().addToSchema(Schema.create(Schema.Type.INT));
     datetimeSchema.setFields(Collections.singletonList(new Schema.Field("date", date, null, null)));
 
-    File file = temp.newFile("datetime.parquet");
-    file.delete();
-    Path path = new Path(file.toString());
+    Path path = new Path(tempDir.resolve("datetime.parquet").toUri());
     List<GenericRecord> expected = Lists.newArrayList();
 
-    Configuration conf = new Configuration();
-    AvroWriteSupport.setAvroDataSupplier(conf, CustomDataModel.class);
+    Configuration configuration = new Configuration();
+    AvroWriteSupport.setAvroDataSupplier(configuration, CustomDataModel.class);
 
     // .withDataModel is not set; AvroWriteSupport should parse it from the Configuration
     try (ParquetWriter<GenericRecord> writer = AvroParquetWriter.<GenericRecord>builder(path)
-        .withConf(conf)
+        .withConf(configuration)
         .withSchema(datetimeSchema)
         .build()) {
 
@@ -984,11 +1071,11 @@ public class TestReadWrite {
     }
     List<GenericRecord> records = Lists.newArrayList();
 
-    AvroReadSupport.setAvroDataSupplier(conf, CustomDataModel.class);
+    AvroReadSupport.setAvroDataSupplier(configuration, CustomDataModel.class);
 
     try (ParquetReader<GenericRecord> reader = AvroParquetReader.<GenericRecord>builder(path)
         .disableCompatibility()
-        .withConf(conf)
+        .withConf(configuration)
         .build()) {
       GenericRecord rec;
       while ((rec = reader.read()) != null) {
@@ -1002,8 +1089,12 @@ public class TestReadWrite {
     assertThat(records).as("Content should match").containsExactlyElementsOf(expected);
   }
 
-  @Test
-  public void testConstructor() throws IOException {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testConstructor(
+      Converters converter, FileLocation fileLocation, ConfigurationType conf, CodecFactory codecs)
+      throws IOException {
+    init(converter, fileLocation, conf, codecs);
     String testFile =
         URI.create(Resources.getResource("strings-2.parquet").getFile()).getRawPath();
     InputFile inputFile = new LocalInputFile(Paths.get(testFile));
@@ -1020,11 +1111,8 @@ public class TestReadWrite {
     assertThat(reader).isNotNull();
   }
 
-  private File createTempFile() throws IOException {
-    File tmp = File.createTempFile(getClass().getSimpleName(), ".tmp");
-    tmp.deleteOnExit();
-    tmp.delete();
-    return tmp;
+  private Path createTempFile() {
+    return new Path(tempDir.resolve(java.util.UUID.randomUUID() + ".tmp").toUri());
   }
 
   private ParquetWriter<GenericRecord> writer(String file, Schema schema) throws IOException {

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReadWriteOldListBehavior.java
@@ -34,7 +34,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,32 +52,23 @@ import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-@RunWith(Parameterized.class)
 public class TestReadWriteOldListBehavior {
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    Object[][] data = new Object[][] {
-      {false}, // use the new converters
-      {true}
-    }; // use the old converters
-    return Arrays.asList(data);
-  }
-
-  private final boolean compat;
+  private boolean compat;
   private final Configuration testConf = new Configuration(false);
 
-  public TestReadWriteOldListBehavior(boolean compat) {
+  private void init(boolean compat) {
     this.compat = compat;
     this.testConf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, compat);
   }
 
-  @Test
-  public void testEmptyArray() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testEmptyArray(boolean compat) throws Exception {
+    init(compat);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("array.avsc").openStream());
 
@@ -103,8 +93,10 @@ public class TestReadWriteOldListBehavior {
     }
   }
 
-  @Test
-  public void testEmptyMap() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testEmptyMap(boolean compat) throws Exception {
+    init(compat);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("map.avsc").openStream());
 
@@ -129,8 +121,10 @@ public class TestReadWriteOldListBehavior {
     }
   }
 
-  @Test
-  public void testMapWithNulls() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testMapWithNulls(boolean compat) throws Exception {
+    init(compat);
     Schema schema = new Schema.Parser()
         .parse(Resources.getResource("map_with_nulls.avsc").openStream());
 
@@ -159,8 +153,10 @@ public class TestReadWriteOldListBehavior {
     }
   }
 
-  @Test
-  public void testMapRequiredValueWithNull() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testMapRequiredValueWithNull(boolean compat) throws Exception {
+    init(compat);
     Schema schema = Schema.createRecord("record1", null, null, false);
     schema.setFields(Lists.newArrayList(
         new Schema.Field("mymap", Schema.createMap(Schema.create(Schema.Type.INT)), null, null)));
@@ -185,8 +181,10 @@ public class TestReadWriteOldListBehavior {
     }
   }
 
-  @Test
-  public void testMapWithUtf8Key() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testMapWithUtf8Key(boolean compat) throws Exception {
+    init(compat);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("map.avsc").openStream());
 
@@ -211,8 +209,10 @@ public class TestReadWriteOldListBehavior {
     }
   }
 
-  @Test
-  public void testAll() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testAll(boolean compat) throws Exception {
+    init(compat);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("all.avsc").openStream());
 
@@ -288,8 +288,10 @@ public class TestReadWriteOldListBehavior {
     }
   }
 
-  @Test
-  public void testArrayWithNullValues() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testArrayWithNullValues(boolean compat) throws Exception {
+    init(compat);
     Schema schema =
         new Schema.Parser().parse(Resources.getResource("all.avsc").openStream());
 
@@ -346,8 +348,10 @@ public class TestReadWriteOldListBehavior {
         .hasMessageContaining("parquet.avro.write-old-list-structure");
   }
 
-  @Test
-  public void testAllUsingDefaultAvroSchema() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testAllUsingDefaultAvroSchema(boolean compat) throws Exception {
+    init(compat);
     File tmp = File.createTempFile(getClass().getSimpleName(), ".tmp");
     tmp.deleteOnExit();
     tmp.delete();

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectInputOutputFormat.java
@@ -42,9 +42,9 @@ import org.apache.parquet.filter.ColumnPredicates;
 import org.apache.parquet.filter.ColumnRecordFilter;
 import org.apache.parquet.filter.RecordFilter;
 import org.apache.parquet.filter.UnboundRecordFilter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -324,7 +324,7 @@ public class TestReflectInputOutputFormat {
   final Path parquetPath = new Path("target/test/hadoop/TestReflectInputOutputFormat/parquet");
   final Path outputPath = new Path("target/test/hadoop/TestReflectInputOutputFormat/out");
 
-  @Before
+  @BeforeEach
   public void createParquetFile() throws Exception {
     // set up readers and writers not in MR
     conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, false);
@@ -474,7 +474,7 @@ public class TestReflectInputOutputFormat {
     }
   }
 
-  @After
+  @AfterEach
   public void deleteOutputFile() throws IOException {
     final FileSystem fileSystem = parquetPath.getFileSystem(conf);
     fileSystem.delete(parquetPath, true);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectLogicalTypes.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectLogicalTypes.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -42,10 +43,9 @@ import org.apache.avro.reflect.AvroSchema;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.specific.SpecificData;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * This class is based on org.apache.avro.reflect.TestReflectLogicalTypes
@@ -56,12 +56,12 @@ import org.junit.rules.TemporaryFolder;
  * * record => Pair
  */
 public class TestReflectLogicalTypes {
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  private Path tempDir;
 
   public static final ReflectData REFLECT = new ReflectData();
 
-  @BeforeClass
+  @BeforeAll
   public static void addUUID() {
     REFLECT.addLogicalTypeConversion(new Conversions.UUIDConversion());
     REFLECT.addLogicalTypeConversion(new Conversions.DecimalConversion());
@@ -973,12 +973,12 @@ public class TestReflectLogicalTypes {
 
   @SuppressWarnings("unchecked")
   private <D> File write(GenericData model, Schema schema, D... data) throws IOException {
-    return AvroTestUtil.write(temp, model, schema, data);
+    return AvroTestUtil.write(tempDir, model, schema, data);
   }
 
   @SuppressWarnings("unchecked")
   private <D> File write(Configuration conf, GenericData model, Schema schema, D... data) throws IOException {
-    return AvroTestUtil.write(temp, conf, model, schema, data);
+    return AvroTestUtil.write(tempDir, conf, model, schema, data);
   }
 }
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestReflectReadWrite.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestReflectReadWrite {
 

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificInputOutputFormat.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificInputOutputFormat.java
@@ -38,9 +38,9 @@ import org.apache.parquet.filter.ColumnPredicates;
 import org.apache.parquet.filter.ColumnRecordFilter;
 import org.apache.parquet.filter.RecordFilter;
 import org.apache.parquet.filter.UnboundRecordFilter;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +125,7 @@ public class TestSpecificInputOutputFormat {
   final Path parquetPath = new Path("target/test/hadoop/TestSpecificInputOutputFormat/parquet");
   final Path outputPath = new Path("target/test/hadoop/TestSpecificInputOutputFormat/out");
 
-  @Before
+  @BeforeEach
   public void createParquetFile() throws Exception {
     final FileSystem fileSystem = parquetPath.getFileSystem(conf);
     fileSystem.delete(parquetPath, true);
@@ -267,7 +267,7 @@ public class TestSpecificInputOutputFormat {
     }
   }
 
-  @After
+  @AfterEach
   public void deleteOutputFile() throws IOException {
     final FileSystem fileSystem = parquetPath.getFileSystem(conf);
     fileSystem.delete(parquetPath, true);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificReadWrite.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestSpecificReadWrite.java
@@ -31,8 +31,6 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -43,34 +41,25 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Other tests exercise the use of Avro Generic, a dynamic data representation. This class focuses
  * on Avro Speific whose schemas are pre-compiled to POJOs with built in SerDe for faster serialization.
  */
-@RunWith(Parameterized.class)
 public class TestSpecificReadWrite {
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    Object[][] data = new Object[][] {
-      {false}, // use the new converters
-      {true}
-    }; // use the old converters
-    return Arrays.asList(data);
+  private static Configuration testConf(boolean compat) {
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, compat);
+    return conf;
   }
 
-  private final Configuration testConf = new Configuration(false);
-
-  public TestSpecificReadWrite(boolean compat) {
-    this.testConf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, compat);
-  }
-
-  @Test
-  public void testCompatReadWriteSpecific() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testCompatReadWriteSpecific(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(10, CompressionCodecName.UNCOMPRESSED, false);
     try (ParquetReader<Car> reader = new AvroParquetReader<>(testConf, path)) {
       for (int i = 0; i < 10; i++) {
@@ -82,8 +71,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testReadWriteSpecificWithDictionary() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testReadWriteSpecificWithDictionary(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(10, CompressionCodecName.UNCOMPRESSED, true);
     try (ParquetReader<Car> reader = new AvroParquetReader<>(testConf, path)) {
       for (int i = 0; i < 10; i++) {
@@ -95,8 +86,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testFilterMatchesMultiple() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testFilterMatchesMultiple(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(10, CompressionCodecName.UNCOMPRESSED, false);
     try (ParquetReader<Car> reader =
         new AvroParquetReader<>(testConf, path, column("make", equalTo("Volkswagen")))) {
@@ -108,8 +101,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testFilterMatchesMultipleBlocks() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testFilterMatchesMultipleBlocks(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(
         10000, CompressionCodecName.UNCOMPRESSED, false, DEFAULT_BLOCK_SIZE / 64, DEFAULT_PAGE_SIZE / 64);
     try (ParquetReader<Car> reader =
@@ -122,8 +117,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testFilterMatchesNoBlocks() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testFilterMatchesNoBlocks(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(
         10000, CompressionCodecName.UNCOMPRESSED, false, DEFAULT_BLOCK_SIZE / 64, DEFAULT_PAGE_SIZE / 64);
     try (ParquetReader<Car> reader = new AvroParquetReader<>(testConf, path, column("make", equalTo("Bogus")))) {
@@ -131,8 +128,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testFilterMatchesFinalBlockOnly() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testFilterMatchesFinalBlockOnly(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     File tmp = File.createTempFile(getClass().getSimpleName(), ".tmp");
     tmp.deleteOnExit();
     tmp.delete();
@@ -163,8 +162,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testFilterWithDictionary() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testFilterWithDictionary(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(1, CompressionCodecName.UNCOMPRESSED, true);
     try (ParquetReader<Car> reader =
         new AvroParquetReader<>(testConf, path, column("make", equalTo("Volkswagen")))) {
@@ -174,8 +175,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testFilterOnSubAttribute() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testFilterOnSubAttribute(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(1, CompressionCodecName.UNCOMPRESSED, false);
 
     ParquetReader<Car> reader =
@@ -192,8 +195,10 @@ public class TestSpecificReadWrite {
     assertThat(reader.read()).isNull();
   }
 
-  @Test
-  public void testProjection() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testProjection(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(1, CompressionCodecName.UNCOMPRESSED, false);
     Configuration conf = new Configuration(testConf);
 
@@ -232,8 +237,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testRepeatedRecordProjection() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testRepeatedRecordProjection(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(1, CompressionCodecName.UNCOMPRESSED, false);
     Configuration conf = new Configuration(testConf);
     Schema schema = Car.getClassSchema();
@@ -270,8 +277,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testAvroReadSchema() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testAvroReadSchema(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     Path path = writeCarsToParquetFile(1, CompressionCodecName.UNCOMPRESSED, false);
     Configuration conf = new Configuration(testConf);
     AvroReadSupport.setAvroReadSchema(conf, NewCar.SCHEMA$);
@@ -288,8 +297,10 @@ public class TestSpecificReadWrite {
     }
   }
 
-  @Test
-  public void testParsesSpecificDataModel() throws IOException {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testParsesSpecificDataModel(boolean compat) throws IOException {
+    Configuration testConf = testConf(compat);
     // SpecificRecord contains a logical type and will fail to decode unless its SpecificData model is parsed
     List<LogicalTypesTest> records = IntStream.range(0, 25)
         .mapToObj(i -> LogicalTypesTest.newBuilder()

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestStringBehavior.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestStringBehavior.java
@@ -47,29 +47,28 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestStringBehavior {
   public static Schema SCHEMA = null;
   public static BigDecimal BIG_DECIMAL = new BigDecimal("3.14");
 
-  @Rule
-  public TemporaryFolder temp = new TemporaryFolder();
+  @TempDir
+  private java.nio.file.Path tempDir;
 
-  public Path parquetFile;
+  public org.apache.hadoop.fs.Path parquetFile;
   public File avroFile;
 
-  @BeforeClass
+  @BeforeAll
   public static void readSchemaFile() throws IOException {
     TestStringBehavior.SCHEMA = new Schema.Parser()
         .parse(Resources.getResource("stringBehavior.avsc").openStream());
   }
 
-  @Before
+  @BeforeEach
   public void writeDataFiles() throws IOException {
     // convert BIG_DECIMAL to string by hand so generic can write it
     GenericRecord record = new GenericRecordBuilder(SCHEMA)
@@ -81,11 +80,7 @@ public class TestStringBehavior {
         .set("stringable_map", ImmutableMap.of(BIG_DECIMAL.toString(), 36))
         .build();
 
-    File file = temp.newFile("parquet");
-    file.delete();
-    file.deleteOnExit();
-
-    parquetFile = new Path(file.getPath());
+    parquetFile = new Path(tempDir.resolve("parquet").toUri());
     try (ParquetWriter<GenericRecord> parquet = AvroParquetWriter.<GenericRecord>builder(parquetFile)
         .withDataModel(GenericData.get())
         .withSchema(SCHEMA)
@@ -93,9 +88,7 @@ public class TestStringBehavior {
       parquet.write(record);
     }
 
-    avroFile = temp.newFile("avro");
-    avroFile.delete();
-    avroFile.deleteOnExit();
+    avroFile = tempDir.resolve("avro").toFile();
     try (DataFileWriter<GenericRecord> avro =
         new DataFileWriter<GenericRecord>(new GenericDatumWriter<>(SCHEMA)).create(SCHEMA, avroFile)) {
       avro.append(record);

--- a/parquet-avro/src/test/java/org/apache/parquet/avro/TestWriteVariant.java
+++ b/parquet-avro/src/test/java/org/apache/parquet/avro/TestWriteVariant.java
@@ -49,7 +49,7 @@ import org.apache.parquet.variant.Variant;
 import org.apache.parquet.variant.VariantArrayBuilder;
 import org.apache.parquet.variant.VariantBuilder;
 import org.apache.parquet.variant.VariantObjectBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestWriteVariant extends DirectWriterTest {
 

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/BaseCommandTest.java
@@ -20,15 +20,15 @@ package org.apache.parquet.cli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ public class BaseCommandTest {
   private Logger console = LoggerFactory.getLogger(BaseCommandTest.class);
   private TestCommand command;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     this.command = new TestCommand(this.console);
   }
@@ -90,14 +90,14 @@ public class BaseCommandTest {
   // For Windows
   @Test
   public void qualifiedPathTestForWindows() throws IOException {
-    Assume.assumeTrue(System.getProperty("os.name").toLowerCase().startsWith("win"));
+    assumeThat(System.getProperty("os.name").toLowerCase()).startsWith("win");
     Path path = this.command.qualifiedPath(WIN_FILE_PATH);
     assertThat(path.getName()).isEqualTo("test.parquet");
   }
 
   @Test
   public void qualifiedURITestForWindows() throws IOException {
-    Assume.assumeTrue(System.getProperty("os.name").toLowerCase().startsWith("win"));
+    assumeThat(System.getProperty("os.name").toLowerCase()).startsWith("win");
     URI uri = this.command.qualifiedURI(WIN_FILE_PATH);
     assertThat(uri.getPath()).isEqualTo("/C:/Test/Downloads/test.parquet");
   }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/MainTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.FileWriter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 public class MainTest {

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVFileTest.java
@@ -22,11 +22,11 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class CSVFileTest extends FileTest {
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     createTestCSVFile();
     createTestCSVFileWithDifferentSchema();

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVSchemaCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CSVSchemaCommandTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CSVSchemaCommandTest extends CSVFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CatCommandTest.java
@@ -36,7 +36,7 @@ import org.apache.parquet.proto.test.TestProtobuf;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CatCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CheckParquet251CommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/CheckParquet251CommandTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CheckParquet251CommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ColumnSizeCommandTest.java
@@ -35,7 +35,7 @@ import org.apache.parquet.hadoop.example.ExampleParquetWriter;
 import org.apache.parquet.hadoop.example.GroupWriteSupport;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ColumnSizeCommandTest extends ParquetFileTest {
 

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCSVCommandTest.java
@@ -25,7 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConvertCSVCommandTest extends CSVFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ConvertCommandTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ConvertCommandTest extends AvroFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/FileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/FileTest.java
@@ -19,12 +19,12 @@
 package org.apache.parquet.cli.commands;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.PropertyConfigurator;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.LoggingEvent;
@@ -43,11 +43,11 @@ public abstract class FileTest {
 
   static final String[] COLORS = {"RED", "BLUE", "YELLOW", "GREEN", "WHITE"};
 
-  @Rule
-  public TemporaryFolder tempFolder = new TemporaryFolder();
+  @TempDir
+  private Path tempDir;
 
   protected File getTempFolder() {
-    return this.tempFolder.getRoot();
+    return tempDir.toFile();
   }
 
   protected static Logger createLogger() {

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetFileTest.java
@@ -36,13 +36,13 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public abstract class ParquetFileTest extends FileTest {
 
   private Random rnd = new Random();
 
-  @Before
+  @BeforeEach
   public void setUp() throws IOException {
     createTestParquetFile();
   }

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetMetadataCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ParquetMetadataCommandTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ParquetMetadataCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/RewriteCommandTest.java
@@ -27,7 +27,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RewriteCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ScanCommandTest.java
@@ -25,7 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ScanCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/SchemaCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/SchemaCommandTest.java
@@ -27,7 +27,7 @@ import java.util.Arrays;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SchemaCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowBloomFilterCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowBloomFilterCommandTest.java
@@ -45,7 +45,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShowBloomFilterCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowColumnIndexTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowColumnIndexTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShowColumnIndexTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowDictionaryCommandTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShowDictionaryCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowFooterCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowFooterCommandTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShowFooterCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowGeospatialStatisticsCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowGeospatialStatisticsCommandTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShowGeospatialStatisticsCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowPagesCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowPagesCommandTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShowPagesCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowSizeStatisticsCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowSizeStatisticsCommandTest.java
@@ -24,7 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ShowSizeStatisticsCommandTest extends ParquetFileTest {
   @Test

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowVersionCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ShowVersionCommandTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Queue;
 import org.apache.parquet.Version;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.event.LoggingEvent;
 

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/ToAvroCommandTest.java
@@ -27,15 +27,16 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ToAvroCommandTest extends AvroFileTest {
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  private Path tempDir;
 
   @Test
   public void testToAvroCommandFromParquet() throws IOException {
@@ -45,8 +46,10 @@ public class ToAvroCommandTest extends AvroFileTest {
 
   @Test
   public void testToAvroCommandFromJson() throws IOException {
-    final File jsonInputFile = folder.newFile("sample.json");
-    final File avroOutputFile = folder.newFile("sample.avro");
+    final File jsonInputFile = tempDir.resolve("sample.json").toFile();
+    Files.createFile(jsonInputFile.toPath());
+    final File avroOutputFile = tempDir.resolve("sample.avro").toFile();
+    Files.createFile(avroOutputFile.toPath());
 
     // Write the json to the file, so we can read it again.
     final String inputJson = "{\"id\": 1, \"name\": \"Alice\"}\n" + "{\"id\": 2, \"name\": \"Bob\"}\n"

--- a/parquet-cli/src/test/java/org/apache/parquet/cli/commands/TransCompressionCommandTest.java
+++ b/parquet-cli/src/test/java/org/apache/parquet/cli/commands/TransCompressionCommandTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TransCompressionCommandTest extends ParquetFileTest {
 

--- a/parquet-column/pom.xml
+++ b/parquet-column/pom.xml
@@ -106,6 +106,12 @@
       <version>1.3</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-migrationsupport</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/parquet-column/src/test/java/org/apache/parquet/CorruptStatisticsTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/CorruptStatisticsTest.java
@@ -21,7 +21,7 @@ package org.apache.parquet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CorruptStatisticsTest {
 

--- a/parquet-column/src/test/java/org/apache/parquet/FixedBinaryTestUtils.java
+++ b/parquet-column/src/test/java/org/apache/parquet/FixedBinaryTestUtils.java
@@ -25,7 +25,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Some utility methods for generating Binary values that length if fixed (e.g. for FIXED_LEN_BYTE_ARRAY or INT96).

--- a/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesThreadSafetyTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/ParquetPropertiesThreadSafetyTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Field;
 import org.apache.parquet.column.values.factory.ValuesWriterFactory;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ParquetPropertiesThreadSafetyTest {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/TestColumnDescriptor.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/TestColumnDescriptor.java
@@ -21,7 +21,7 @@ package org.apache.parquet.column;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestColumnDescriptor {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/TestEncodingStats.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/TestEncodingStats.java
@@ -21,7 +21,7 @@ package org.apache.parquet.column;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestEncodingStats {
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/column/TestParquetProperties.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/TestParquetProperties.java
@@ -26,8 +26,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestParquetProperties {
 
@@ -38,7 +38,7 @@ public class TestParquetProperties {
   private ColumnDescriptor colB;
   private ColumnDescriptor colC;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     colA = SCHEMA.getColumns().get(0);
     colB = SCHEMA.getColumns().get(1);

--- a/parquet-column/src/test/java/org/apache/parquet/column/impl/TestColumnReaderImpl.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/impl/TestColumnReaderImpl.java
@@ -38,7 +38,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.PrimitiveConverter;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestColumnReaderImpl {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/impl/TestCorruptDeltaByteArrays.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/impl/TestCorruptDeltaByteArrays.java
@@ -44,7 +44,7 @@ import org.apache.parquet.column.values.dictionary.DictionaryValuesReader;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.PrimitiveConverter;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestCorruptDeltaByteArrays {

--- a/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemColumn.java
@@ -38,7 +38,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemPageStore.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/mem/TestMemPageStore.java
@@ -32,7 +32,7 @@ import org.apache.parquet.column.page.PageWriter;
 import org.apache.parquet.column.page.mem.MemPageStore;
 import org.apache.parquet.column.statistics.LongStatistics;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestSizeStatistics.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestSizeStatistics.java
@@ -25,7 +25,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSizeStatistics {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestStatistics.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestStatistics.java
@@ -42,7 +42,7 @@ import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestStatistics {
   private int[] integerArray;

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestStatisticsNanCount.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/TestStatisticsNanCount.java
@@ -28,7 +28,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestStatisticsNanCount {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/geospatial/TestBoundingBox.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/geospatial/TestBoundingBox.java
@@ -21,7 +21,7 @@ package org.apache.parquet.column.statistics.geospatial;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateXYZM;
 import org.locationtech.jts.geom.GeometryFactory;

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/geospatial/TestGeospatialStatistics.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/geospatial/TestGeospatialStatistics.java
@@ -25,7 +25,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKBWriter;
 import org.locationtech.jts.io.WKTReader;

--- a/parquet-column/src/test/java/org/apache/parquet/column/statistics/geospatial/TestGeospatialTypes.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/statistics/geospatial/TestGeospatialTypes.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.Set;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.CoordinateXYZM;
 import org.locationtech.jts.geom.GeometryCollection;

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/TestValuesReaderImpl.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/TestValuesReaderImpl.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests how {@link ValuesReader} works in case of extending it.

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bitpacking/TestBitPackingColumn.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bitpacking/TestBitPackingColumn.java
@@ -27,7 +27,7 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.ValuesWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bloomfilter/TestBlockSplitBloomFilter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bloomfilter/TestBlockSplitBloomFilter.java
@@ -30,9 +30,7 @@ import java.util.Set;
 import net.openhft.hashing.LongHashFunction;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
 
 public class TestBlockSplitBloomFilter {
 
@@ -43,9 +41,6 @@ public class TestBlockSplitBloomFilter {
     BloomFilter bloomFilter3 = new BlockSplitBloomFilter(1000);
     assertThat(bloomFilter3.getBitsetSize()).isEqualTo(1024);
   }
-
-  @Rule
-  public final TemporaryFolder temp = new TemporaryFolder();
 
   /*
    * This test is used to test basic operations including inserting, finding and

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesEndToEndTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesEndToEndTest.java
@@ -26,7 +26,7 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ByteStreamSplitValuesEndToEndTest {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesReaderTest.java
@@ -28,11 +28,9 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-@RunWith(Enclosed.class)
 public class ByteStreamSplitValuesReaderTest {
   private static <Reader extends ValuesReader> Reader makeReader(byte[] input, int length, Class<Reader> cls)
       throws Exception {
@@ -43,7 +41,8 @@ public class ByteStreamSplitValuesReaderTest {
     return reader;
   }
 
-  public static class FloatTest {
+  @Nested
+  class FloatTest {
 
     private void testReader(byte[] input, float[] values) throws Exception {
       ByteStreamSplitValuesReaderForFloat reader =
@@ -157,7 +156,8 @@ public class ByteStreamSplitValuesReaderTest {
     }
   }
 
-  public static class DoubleTest {
+  @Nested
+  class DoubleTest {
 
     private void testReader(byte[] input, double[] values) throws Exception {
       ByteStreamSplitValuesReaderForDouble reader =
@@ -230,7 +230,8 @@ public class ByteStreamSplitValuesReaderTest {
     }
   }
 
-  public static class IntegerTest {
+  @Nested
+  class IntegerTest {
     private void testReader(byte[] input, int[] values) throws Exception {
       ByteStreamSplitValuesReaderForInteger reader =
           makeReader(input, values.length, ByteStreamSplitValuesReaderForInteger.class);
@@ -260,7 +261,8 @@ public class ByteStreamSplitValuesReaderTest {
     }
   }
 
-  public static class LongTest {
+  @Nested
+  class LongTest {
     private void testReader(byte[] input, long[] values) throws Exception {
       ByteStreamSplitValuesReaderForLong reader =
           makeReader(input, values.length, ByteStreamSplitValuesReaderForLong.class);
@@ -295,8 +297,9 @@ public class ByteStreamSplitValuesReaderTest {
     }
   }
 
-  public static class FixedLenByteArrayTest {
-    private static ByteStreamSplitValuesReaderForFLBA makeReader(byte[] input, int valuesCount) throws Exception {
+  @Nested
+  class FixedLenByteArrayTest {
+    private ByteStreamSplitValuesReaderForFLBA makeReader(byte[] input, int valuesCount) throws Exception {
       ByteBuffer buffer = ByteBuffer.wrap(input);
       ByteBufferInputStream stream = ByteBufferInputStream.wrap(buffer);
       ByteStreamSplitValuesReaderForFLBA reader =

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriterTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitValuesWriterTest.java
@@ -24,16 +24,15 @@ import static org.assertj.core.data.Offset.offset;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-@RunWith(Enclosed.class)
 public class ByteStreamSplitValuesWriterTest {
 
-  public static class FloatTest {
+  @Nested
+  class FloatTest {
 
-    static float convertType(byte[] bytes) {
+    float convertType(byte[] bytes) {
       int v = 0;
       for (int i = 0; i < bytes.length; ++i) {
         v |= ((bytes[i] & 0xFF) << (i * 8));
@@ -106,9 +105,10 @@ public class ByteStreamSplitValuesWriterTest {
     }
   }
 
-  public static class DoubleTest {
+  @Nested
+  class DoubleTest {
 
-    static double convertType(byte[] bytes) {
+    double convertType(byte[] bytes) {
       long v = 0;
       for (int i = 0; i < bytes.length; ++i) {
         v |= (((long) (bytes[i] & 0xFF)) << (i * 8));
@@ -185,7 +185,8 @@ public class ByteStreamSplitValuesWriterTest {
     }
   }
 
-  public static class IntegerTest {
+  @Nested
+  class IntegerTest {
     private ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter getWriter(int capacity) {
       return new ByteStreamSplitValuesWriter.IntegerByteStreamSplitValuesWriter(
           capacity, capacity, new DirectByteBufferAllocator());
@@ -213,7 +214,8 @@ public class ByteStreamSplitValuesWriterTest {
     }
   }
 
-  public static class LongTest {
+  @Nested
+  class LongTest {
     private ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter getWriter(int capacity) {
       return new ByteStreamSplitValuesWriter.LongByteStreamSplitValuesWriter(
           capacity, capacity, new DirectByteBufferAllocator());
@@ -244,7 +246,8 @@ public class ByteStreamSplitValuesWriterTest {
     }
   }
 
-  public static class FixedLenByteArrayTest {
+  @Nested
+  class FixedLenByteArrayTest {
     private ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter getWriter(
         int length, int capacity) {
       return new ByteStreamSplitValuesWriter.FixedLenByteArrayByteStreamSplitValuesWriter(

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForIntegerTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForIntegerTest.java
@@ -29,8 +29,8 @@ import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.ParquetDecodingException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeltaBinaryPackingValuesWriterForIntegerTest {
   DeltaBinaryPackingValuesReader reader;
@@ -39,7 +39,7 @@ public class DeltaBinaryPackingValuesWriterForIntegerTest {
   private ValuesWriter writer;
   private Random random;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     blockSize = 128;
     miniBlockNum = 4;

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForLongTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/DeltaBinaryPackingValuesWriterForLongTest.java
@@ -29,8 +29,8 @@ import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.io.ParquetDecodingException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class DeltaBinaryPackingValuesWriterForLongTest {
   DeltaBinaryPackingValuesReader reader;
@@ -39,7 +39,7 @@ public class DeltaBinaryPackingValuesWriterForLongTest {
   private ValuesWriter writer;
   private Random random;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     blockSize = 128;
     miniBlockNum = 4;

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/BenchmarkIntegerOutputSize.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/BenchmarkIntegerOutputSize.java
@@ -23,7 +23,7 @@ import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BenchmarkIntegerOutputSize {
   public static int blockSize = 128;

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/BenchmarkReadingRandomIntegers.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/BenchmarkReadingRandomIntegers.java
@@ -33,10 +33,12 @@ import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesReader;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
-import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
+@EnableRuleMigrationSupport
 @AxisRange(min = 0, max = 1)
 @BenchmarkMethodChart(filePrefix = "benchmark-encoding-reading-random")
 public class BenchmarkReadingRandomIntegers {
@@ -49,7 +51,7 @@ public class BenchmarkReadingRandomIntegers {
   @Rule
   public org.junit.rules.TestRule benchmarkRun = new BenchmarkRule();
 
-  @BeforeClass
+  @BeforeAll
   public static void prepare() throws IOException {
     Random random = new Random();
     data = new int[100000 * blockSize];

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/RandomWritingBenchmarkTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/RandomWritingBenchmarkTest.java
@@ -28,10 +28,12 @@ import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriter;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesWriterForInteger;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
-import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
+@EnableRuleMigrationSupport
 @AxisRange(min = 0, max = 1)
 @BenchmarkMethodChart(filePrefix = "benchmark-encoding-writing-random")
 public class RandomWritingBenchmarkTest extends BenchMarkTest {
@@ -41,7 +43,7 @@ public class RandomWritingBenchmarkTest extends BenchMarkTest {
   @Rule
   public org.junit.rules.TestRule benchmarkRun = new BenchmarkRule();
 
-  @BeforeClass
+  @BeforeAll
   public static void prepare() {
     Random random = new Random();
     data = new int[10000 * blockSize];

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/SmallRangeWritingBenchmarkTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/delta/benchmark/SmallRangeWritingBenchmarkTest.java
@@ -25,13 +25,13 @@ import java.util.Random;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.ValuesWriter;
 import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWriter;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 @AxisRange(min = 0, max = 2)
 @BenchmarkMethodChart(filePrefix = "benchmark-encoding-writing-random-small")
 public class SmallRangeWritingBenchmarkTest extends RandomWritingBenchmarkTest {
-  @BeforeClass
+  @BeforeAll
   public static void prepare() {
     Random random = new Random();
     data = new int[100000 * blockSize];

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/deltalengthbytearray/TestDeltaLengthByteArray.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/deltalengthbytearray/TestDeltaLengthByteArray.java
@@ -26,7 +26,7 @@ import org.apache.parquet.column.values.Utils;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestDeltaLengthByteArray {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/deltalengthbytearray/benchmark/BenchmarkDeltaLengthByteArray.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/deltalengthbytearray/benchmark/BenchmarkDeltaLengthByteArray.java
@@ -31,8 +31,10 @@ import org.apache.parquet.column.values.deltalengthbytearray.DeltaLengthByteArra
 import org.apache.parquet.column.values.plain.BinaryPlainValuesReader;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
+@EnableRuleMigrationSupport
 @AxisRange(min = 0, max = 1)
 @BenchmarkMethodChart(filePrefix = "benchmark-encoding-writing-random")
 public class BenchmarkDeltaLengthByteArray {

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/deltastrings/TestDeltaByteArray.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/deltastrings/TestDeltaByteArray.java
@@ -28,7 +28,7 @@ import org.apache.parquet.column.values.Utils;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestDeltaByteArray {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/deltastrings/benchmark/BenchmarkDeltaByteArray.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/deltastrings/benchmark/BenchmarkDeltaByteArray.java
@@ -32,8 +32,10 @@ import org.apache.parquet.column.values.deltastrings.DeltaByteArrayWriter;
 import org.apache.parquet.column.values.plain.BinaryPlainValuesReader;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
 
+@EnableRuleMigrationSupport
 @AxisRange(min = 0, max = 1)
 @BenchmarkMethodChart(filePrefix = "benchmark-encoding-writing-random")
 public class BenchmarkDeltaByteArray {

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/IntListTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/IntListTest.java
@@ -20,7 +20,7 @@ package org.apache.parquet.column.values.dictionary;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class IntListTest {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
@@ -52,21 +52,21 @@ import org.apache.parquet.column.values.plain.PlainValuesReader;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class TestDictionary {
 
   private TrackingByteBufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void initAllocator() {
     allocator = TrackingByteBufferAllocator.wrap(new DirectByteBufferAllocator());
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/factory/DefaultValuesWriterFactoryTest.java
@@ -51,7 +51,7 @@ import org.apache.parquet.column.values.rle.RunLengthBitPackingHybridValuesWrite
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DefaultValuesWriterFactoryTest {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/plain/TestBinaryPlainValuesWriterReader.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/plain/TestBinaryPlainValuesWriterReader.java
@@ -26,9 +26,9 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.io.api.Binary;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link BinaryPlainValuesReader} (variable-length BINARY)
@@ -38,12 +38,12 @@ public class TestBinaryPlainValuesWriterReader {
 
   private TrackingByteBufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void initAllocator() {
     allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/plain/TestBooleanPlainValuesWriterReader.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/plain/TestBooleanPlainValuesWriterReader.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.Encoding;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link BooleanPlainValuesWriter} and {@link BooleanPlainValuesReader}

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/plain/TestFixedLenByteArrayPlainValuesWriterReader.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/plain/TestFixedLenByteArrayPlainValuesWriterReader.java
@@ -28,9 +28,9 @@ import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.io.api.Binary;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link FixedLenByteArrayPlainValuesWriter} and
@@ -43,12 +43,12 @@ public class TestFixedLenByteArrayPlainValuesWriterReader {
 
   private TrackingByteBufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void initAllocator() {
     allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/plain/TestPlainValuesWriterReader.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/plain/TestPlainValuesWriterReader.java
@@ -26,9 +26,9 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.HeapByteBufferAllocator;
 import org.apache.parquet.bytes.TrackingByteBufferAllocator;
 import org.apache.parquet.column.Encoding;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link PlainValuesWriter} and {@link PlainValuesReader} covering
@@ -38,12 +38,12 @@ public class TestPlainValuesWriterReader {
 
   private TrackingByteBufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void initAllocator() {
     allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/rle/RunLengthBitPackingHybridIntegrationTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/rle/RunLengthBitPackingHybridIntegrationTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.ByteBuffer;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RunLengthBitPackingHybridIntegrationTest {
 

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/rle/TestRunLengthBitPackingHybridEncoder.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/rle/TestRunLengthBitPackingHybridEncoder.java
@@ -27,7 +27,7 @@ import org.apache.parquet.bytes.BytesUtils;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.column.values.bitpacking.BytePacker;
 import org.apache.parquet.column.values.bitpacking.Packer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestRunLengthBitPackingHybridEncoder {
 

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/columnindex/TestRowRanges.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/columnindex/TestRowRanges.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.PrimitiveIterator;
 import org.apache.parquet.internal.column.columnindex.OffsetIndexBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link RowRanges}

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestContainsRewriter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestContainsRewriter.java
@@ -37,7 +37,7 @@ import org.apache.parquet.filter2.predicate.Operators.Contains;
 import org.apache.parquet.filter2.predicate.Operators.DoubleColumn;
 import org.apache.parquet.filter2.predicate.Operators.IntColumn;
 import org.apache.parquet.filter2.predicate.Operators.UserDefined;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestContainsRewriter {
   private static final IntColumn intColumn = intColumn("a.b.c");

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestFilterApiMethods.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestFilterApiMethods.java
@@ -52,7 +52,7 @@ import org.apache.parquet.filter2.predicate.Operators.UserDefined;
 import org.apache.parquet.filter2.predicate.Operators.UserDefinedByClass;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestFilterApiMethods {
 

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestLogicalInverseRewriter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestLogicalInverseRewriter.java
@@ -37,7 +37,7 @@ import org.apache.parquet.filter2.predicate.Operators.DoubleColumn;
 import org.apache.parquet.filter2.predicate.Operators.IntColumn;
 import org.apache.parquet.filter2.predicate.Operators.LogicalNotUserDefined;
 import org.apache.parquet.filter2.predicate.Operators.UserDefined;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestLogicalInverseRewriter {
   private static final IntColumn intColumn = intColumn("a.b.c");

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestLogicalInverter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestLogicalInverter.java
@@ -37,7 +37,7 @@ import org.apache.parquet.filter2.predicate.Operators.DoubleColumn;
 import org.apache.parquet.filter2.predicate.Operators.IntColumn;
 import org.apache.parquet.filter2.predicate.Operators.LogicalNotUserDefined;
 import org.apache.parquet.filter2.predicate.Operators.UserDefined;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestLogicalInverter {
   private static final IntColumn intColumn = intColumn("a.b.c");

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestSchemaCompatibilityValidator.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestSchemaCompatibilityValidator.java
@@ -40,7 +40,7 @@ import org.apache.parquet.filter2.predicate.Operators.LongColumn;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSchemaCompatibilityValidator {
   private static final BinaryColumn stringC = binaryColumn("c");

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestValidTypeMap.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/predicate/TestValidTypeMap.java
@@ -36,7 +36,7 @@ import org.apache.parquet.filter2.predicate.Operators.IntColumn;
 import org.apache.parquet.filter2.predicate.Operators.LongColumn;
 import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestValidTypeMap {
   public static IntColumn intColumn = intColumn("int.column");

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/recordlevel/TestIncrementallyUpdatedFilterPredicateEvaluator.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/recordlevel/TestIncrementallyUpdatedFilterPredicateEvaluator.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.apache.parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.And;
 import org.apache.parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.Or;
 import org.apache.parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.ValueInspector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestIncrementallyUpdatedFilterPredicateEvaluator {
 

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/recordlevel/TestIncrementallyUpdatedFilterPredicateResetter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/recordlevel/TestIncrementallyUpdatedFilterPredicateResetter.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.apache.parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.And;
 import org.apache.parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.Or;
 import org.apache.parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.ValueInspector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestIncrementallyUpdatedFilterPredicateResetter {
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/filter2/recordlevel/TestValueInspector.java
+++ b/parquet-column/src/test/java/org/apache/parquet/filter2/recordlevel/TestValueInspector.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import org.apache.parquet.filter2.recordlevel.IncrementallyUpdatedFilterPredicate.ValueInspector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestValueInspector {
 

--- a/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestBinaryTruncator.java
+++ b/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestBinaryTruncator.java
@@ -39,7 +39,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveStringifier;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestBoundaryOrder.java
+++ b/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestBoundaryOrder.java
@@ -34,7 +34,7 @@ import org.apache.parquet.internal.column.columnindex.ColumnIndexBuilder.ColumnI
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestColumnIndexBuilder.java
+++ b/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestColumnIndexBuilder.java
@@ -71,7 +71,7 @@ import org.apache.parquet.filter2.predicate.UserDefinedPredicate;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link ColumnIndexBuilder}.

--- a/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestColumnIndexBuilderNaN.java
+++ b/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestColumnIndexBuilderNaN.java
@@ -37,7 +37,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for ColumnIndex NaN handling under IEEE_754_TOTAL_ORDER and TYPE_DEFINED_ORDER.

--- a/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestIndexIterator.java
+++ b/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestIndexIterator.java
@@ -20,7 +20,7 @@ package org.apache.parquet.internal.column.columnindex;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for {@link IndexIterator}.

--- a/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestOffsetIndexBuilder.java
+++ b/parquet-column/src/test/java/org/apache/parquet/internal/column/columnindex/TestOffsetIndexBuilder.java
@@ -20,7 +20,7 @@ package org.apache.parquet.internal.column.columnindex;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link OffsetIndexBuilder}.

--- a/parquet-column/src/test/java/org/apache/parquet/internal/filter2/columnindex/TestColumnIndexFilter.java
+++ b/parquet-column/src/test/java/org/apache/parquet/internal/filter2/columnindex/TestColumnIndexFilter.java
@@ -77,7 +77,7 @@ import org.apache.parquet.internal.column.columnindex.TestColumnIndexBuilder.Int
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Unit tests of {@link ColumnIndexFilter}

--- a/parquet-column/src/test/java/org/apache/parquet/io/TestColumnIO.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/TestColumnIO.java
@@ -31,10 +31,8 @@ import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.parquet.column.ColumnDescriptor;
@@ -60,13 +58,12 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type;
 import org.apache.parquet.schema.Type.Repetition;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(Parameterized.class)
 public class TestColumnIO {
   private static final Logger LOG = LoggerFactory.getLogger(TestColumnIO.class);
 
@@ -140,25 +137,14 @@ public class TestColumnIO {
     "endMessage()"
   };
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() throws IOException {
-    Object[][] data = {{true}, {false}};
-    return List.of(data);
-  }
-
-  private boolean useDictionary;
-
-  public TestColumnIO(boolean useDictionary) {
-    this.useDictionary = useDictionary;
-  }
-
   @Test
   public void testSchema() {
     assertThat(schema).asString().isEqualTo(schemaString);
   }
 
-  @Test
-  public void testReadUsingRequestedSchemaWithExtraFields() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testReadUsingRequestedSchemaWithExtraFields(boolean useDictionary) {
     MessageType orginalSchema = new MessageType(
         "schema", new PrimitiveType(REQUIRED, INT32, "a"), new PrimitiveType(OPTIONAL, INT32, "b"));
     MessageType schemaWithExtraField = new MessageType(
@@ -172,12 +158,14 @@ public class TestColumnIO {
     writeGroups(
         orginalSchema,
         memPageStoreForOriginalSchema,
+        useDictionary,
         groupFactory.newGroup().append("a", 1).append("b", 2));
 
     SimpleGroupFactory groupFactory2 = new SimpleGroupFactory(schemaWithExtraField);
     writeGroups(
         schemaWithExtraField,
         memPageStoreForSchemaWithExtraField,
+        useDictionary,
         groupFactory2.newGroup().append("a", 1).append("b", 2).append("c", 3));
 
     {
@@ -196,12 +184,14 @@ public class TestColumnIO {
     }
   }
 
-  @Test
-  public void testReadUsingRequestedSchemaWithIncompatibleField() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testReadUsingRequestedSchemaWithIncompatibleField(boolean useDictionary) {
     MessageType originalSchema = new MessageType("schema", new PrimitiveType(OPTIONAL, INT32, "e"));
     MemPageStore store = new MemPageStore(1);
     SimpleGroupFactory groupFactory = new SimpleGroupFactory(originalSchema);
-    writeGroups(originalSchema, store, groupFactory.newGroup().append("e", 4));
+    writeGroups(
+        originalSchema, store, useDictionary, groupFactory.newGroup().append("e", 4));
 
     // Incompatible schema: different type
     MessageType schemaWithIncompatibleField = new MessageType("schema", new PrimitiveType(OPTIONAL, BINARY, "e"));
@@ -211,12 +201,14 @@ public class TestColumnIO {
             "The requested schema is not compatible with the file schema. incompatible types: optional binary e != optional int32 e");
   }
 
-  @Test
-  public void testReadUsingSchemaWithRequiredFieldThatWasOptional() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testReadUsingSchemaWithRequiredFieldThatWasOptional(boolean useDictionary) {
     MessageType originalSchema = new MessageType("schema", new PrimitiveType(OPTIONAL, INT32, "e"));
     MemPageStore store = new MemPageStore(1);
     SimpleGroupFactory groupFactory = new SimpleGroupFactory(originalSchema);
-    writeGroups(originalSchema, store, groupFactory.newGroup().append("e", 4));
+    writeGroups(
+        originalSchema, store, useDictionary, groupFactory.newGroup().append("e", 4));
 
     // Incompatible schema: required when it was optional
     MessageType schemaWithRequiredFieldThatWasOptional =
@@ -227,14 +219,19 @@ public class TestColumnIO {
             "The requested schema is not compatible with the file schema. incompatible types: required int32 e != optional int32 e");
   }
 
-  @Test
-  public void testReadUsingProjectedSchema() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testReadUsingProjectedSchema(boolean useDictionary) {
     MessageType orginalSchema = new MessageType(
         "schema", new PrimitiveType(REQUIRED, INT32, "a"), new PrimitiveType(REQUIRED, INT32, "b"));
     MessageType projectedSchema = new MessageType("schema", new PrimitiveType(OPTIONAL, INT32, "b"));
     MemPageStore store = new MemPageStore(1);
     SimpleGroupFactory groupFactory = new SimpleGroupFactory(orginalSchema);
-    writeGroups(orginalSchema, store, groupFactory.newGroup().append("a", 1).append("b", 2));
+    writeGroups(
+        orginalSchema,
+        store,
+        useDictionary,
+        groupFactory.newGroup().append("a", 1).append("b", 2));
 
     {
       List<Group> groups = new ArrayList<>();
@@ -275,9 +272,10 @@ public class TestColumnIO {
     return groups;
   }
 
-  private void writeGroups(MessageType writtenSchema, MemPageStore memPageStore, Group... groups) {
+  private void writeGroups(
+      MessageType writtenSchema, MemPageStore memPageStore, boolean useDictionary, Group... groups) {
     ColumnIOFactory columnIOFactory = new ColumnIOFactory(true);
-    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore);
+    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore, useDictionary);
     MessageColumnIO columnIO = columnIOFactory.getColumnIO(writtenSchema);
     RecordConsumer recordWriter = columnIO.getRecordWriter(columns);
     GroupWriter groupWriter = new GroupWriter(recordWriter, writtenSchema);
@@ -288,8 +286,9 @@ public class TestColumnIO {
     columns.flush();
   }
 
-  @Test
-  public void testColumnIO() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testColumnIO(boolean useDictionary) {
     log(schema);
     log("r1");
     log(r1);
@@ -297,7 +296,7 @@ public class TestColumnIO {
     log(r2);
 
     MemPageStore memPageStore = new MemPageStore(2);
-    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore);
+    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore, useDictionary);
 
     ColumnIOFactory columnIOFactory = new ColumnIOFactory(true);
     {
@@ -362,8 +361,9 @@ public class TestColumnIO {
     }
   }
 
-  @Test
-  public void testOneOfEach() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testOneOfEach(boolean useDictionary) {
     MessageType oneOfEachSchema = MessageTypeParser.parseMessageType(oneOfEach);
     GroupFactory gf = new SimpleGroupFactory(oneOfEachSchema);
     Group g1 = gf.newGroup()
@@ -376,11 +376,12 @@ public class TestColumnIO {
         .append("g", new NanoTime(1234, System.currentTimeMillis() * 1000))
         .append("h", Binary.fromString("abc"));
 
-    testSchema(oneOfEachSchema, List.of(g1));
+    testSchema(oneOfEachSchema, List.of(g1), useDictionary);
   }
 
-  @Test
-  public void testRequiredOfRequired() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testRequiredOfRequired(boolean useDictionary) {
     MessageType reqreqSchema = MessageTypeParser.parseMessageType(
         "message Document {\n" + "  required group foo {\n" + "    required int64 bar;\n" + "  }\n" + "}\n");
 
@@ -388,11 +389,12 @@ public class TestColumnIO {
     Group g1 = gf.newGroup();
     g1.addGroup("foo").append("bar", 2l);
 
-    testSchema(reqreqSchema, List.of(g1));
+    testSchema(reqreqSchema, List.of(g1), useDictionary);
   }
 
-  @Test
-  public void testOptionalRequiredInteraction() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testOptionalRequiredInteraction(boolean useDictionary) {
     for (int i = 0; i < 6; i++) {
       Type current = new PrimitiveType(Repetition.REQUIRED, PrimitiveTypeName.BINARY, "primitive");
       for (int j = 0; j < i; j++) {
@@ -408,7 +410,7 @@ public class TestColumnIO {
       }
       currentGroup.add(0, Binary.fromString("foo"));
       groups.add(root);
-      testSchema(groupSchema, groups);
+      testSchema(groupSchema, groups, useDictionary);
     }
     for (int i = 0; i < 6; i++) {
       Type current = new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.BINARY, "primitive");
@@ -429,7 +431,7 @@ public class TestColumnIO {
       currentDefinedGroup.add(0, Binary.fromString("foo"));
       groups.add(rootDefined);
       groups.add(rootUndefined);
-      testSchema(groupSchema, groups);
+      testSchema(groupSchema, groups, useDictionary);
     }
     for (int i = 0; i < 6; i++) {
       Type current = new PrimitiveType(Repetition.OPTIONAL, PrimitiveTypeName.BINARY, "primitive");
@@ -452,13 +454,13 @@ public class TestColumnIO {
       currentDefinedGroup.add(0, Binary.fromString("foo"));
       groups.add(rootDefined);
       groups.add(rootUndefined);
-      testSchema(groupSchema, groups);
+      testSchema(groupSchema, groups, useDictionary);
     }
   }
 
-  private void testSchema(MessageType messageSchema, List<Group> groups) {
+  private void testSchema(MessageType messageSchema, List<Group> groups, boolean useDictionary) {
     MemPageStore memPageStore = new MemPageStore(groups.size());
-    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore);
+    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore, useDictionary);
 
     ColumnIOFactory columnIOFactory = new ColumnIOFactory(true);
     MessageColumnIO columnIO = columnIOFactory.getColumnIO(messageSchema);
@@ -515,10 +517,11 @@ public class TestColumnIO {
     log("----");
   }
 
-  @Test
-  public void testPushParser() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testPushParser(boolean useDictionary) {
     MemPageStore memPageStore = new MemPageStore(1);
-    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore);
+    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore, useDictionary);
     MessageColumnIO columnIO = new ColumnIOFactory().getColumnIO(schema);
     RecordConsumer recordWriter = columnIO.getRecordWriter(columns);
     new GroupWriter(recordWriter, schema).write(r1);
@@ -530,7 +533,7 @@ public class TestColumnIO {
     recordReader.read();
   }
 
-  private ColumnWriteStoreV1 newColumnWriteStore(MemPageStore memPageStore) {
+  private ColumnWriteStoreV1 newColumnWriteStore(MemPageStore memPageStore, boolean useDictionary) {
     return new ColumnWriteStoreV1(
         memPageStore,
         ParquetProperties.builder()
@@ -540,10 +543,11 @@ public class TestColumnIO {
             .build());
   }
 
-  @Test
-  public void testEmptyField() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testEmptyField(boolean useDictionary) {
     MemPageStore memPageStore = new MemPageStore(1);
-    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore);
+    ColumnWriteStoreV1 columns = newColumnWriteStore(memPageStore, useDictionary);
     MessageColumnIO columnIO = new ColumnIOFactory(true).getColumnIO(schema);
     final RecordConsumer recordWriter = columnIO.getRecordWriter(columns);
     recordWriter.startMessage();

--- a/parquet-column/src/test/java/org/apache/parquet/io/TestFiltered.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/TestFiltered.java
@@ -44,7 +44,7 @@ import org.apache.parquet.filter.ColumnPredicates.PredicateFunction;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.io.api.RecordMaterializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestFiltered {
 

--- a/parquet-column/src/test/java/org/apache/parquet/io/ValidatingRecordConsumerTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/ValidatingRecordConsumerTest.java
@@ -28,7 +28,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ValidatingRecordConsumerTest {
 

--- a/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.parquet.io.ParquetEncodingException;
 import org.apache.parquet.io.api.TestBinary.BinaryFactory.BinaryAndOriginal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestBinary {
 

--- a/parquet-column/src/test/java/org/apache/parquet/parser/TestParquetParser.java
+++ b/parquet-column/src/test/java/org/apache/parquet/parser/TestParquetParser.java
@@ -63,7 +63,7 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Types;
 import org.apache.parquet.schema.Types.MessageTypeBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestParquetParser {
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestFloat16.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestFloat16.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestFloat16 {
   // Smallest negative value a half-precision float may have.

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestMessageType.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestMessageType.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.parquet.example.Paper;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestMessageType {
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestPrimitiveComparator.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestPrimitiveComparator.java
@@ -40,7 +40,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /*
  * This test verifies all the PrimitiveComparator implementations. The logic of all tests is the same: list the

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestPrimitiveStringifier.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestPrimitiveStringifier.java
@@ -52,7 +52,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestPrimitiveStringifier {
 

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestRepetitionType.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestRepetitionType.java
@@ -20,7 +20,7 @@ package org.apache.parquet.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestRepetitionType {
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuilders.java
@@ -58,7 +58,7 @@ import java.util.List;
 import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.Repetition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTypeBuilders {
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuildersWithLogicalTypes.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeBuildersWithLogicalTypes.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.Repetition;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTypeBuildersWithLogicalTypes {
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeUtil.java
+++ b/parquet-column/src/test/java/org/apache/parquet/schema/TestTypeUtil.java
@@ -24,7 +24,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.Type.Repetition.REPEATED;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTypeUtil {
   @Test

--- a/parquet-common/src/test/java/org/apache/parquet/SemanticVersionTest.java
+++ b/parquet-common/src/test/java/org/apache/parquet/SemanticVersionTest.java
@@ -21,7 +21,7 @@ package org.apache.parquet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class SemanticVersionTest {
   @Test

--- a/parquet-common/src/test/java/org/apache/parquet/TestPreconditions.java
+++ b/parquet-common/src/test/java/org/apache/parquet/TestPreconditions.java
@@ -21,7 +21,7 @@ package org.apache.parquet;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestPreconditions {
 

--- a/parquet-common/src/test/java/org/apache/parquet/VersionTest.java
+++ b/parquet-common/src/test/java/org/apache/parquet/VersionTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.parquet.VersionParser.ParsedVersion;
 import org.apache.parquet.VersionParser.VersionParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * This test doesn't do much, but it makes sure that the Version class

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestByteBufferInputStreams.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestByteBufferInputStreams.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public abstract class TestByteBufferInputStreams {
   static final int DATA_LENGTH = 35;

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
@@ -36,63 +36,53 @@ import java.util.List;
 import java.util.Random;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.apache.parquet.util.AutoCloseables;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 /**
  * Unit tests for the {@link BytesInput} class and its descendants.
  */
-@RunWith(Parameterized.class)
 public class TestBytesInput {
 
   private static final Random RANDOM = new Random(2024_02_20_16_28L);
   private TrackingByteBufferAllocator allocator;
-  private final ByteBufferAllocator innerAllocator;
+  private ByteBufferAllocator innerAllocator;
 
-  @Parameters(name = "{0}")
-  public static Object[][] parameters() {
-    return new Object[][] {
-      {
-        new HeapByteBufferAllocator() {
+  static Stream<Arguments> parameters() {
+    return Stream.of(
+        Arguments.of(new HeapByteBufferAllocator() {
           @Override
           public String toString() {
             return "heap-allocator";
           }
-        }
-      },
-      {
-        new DirectByteBufferAllocator() {
+        }),
+        Arguments.of(new DirectByteBufferAllocator() {
           @Override
           public String toString() {
             return "direct-allocator";
           }
-        }
-      }
-    };
+        }));
   }
 
-  public TestBytesInput(ByteBufferAllocator innerAllocator) {
+  private void initAllocator(ByteBufferAllocator innerAllocator) {
     this.innerAllocator = innerAllocator;
-  }
-
-  @Before
-  public void initAllocator() {
     allocator = TrackingByteBufferAllocator.wrap(innerAllocator);
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }
 
-  @Test
-  public void testFromSingleByteBuffer() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromSingleByteBuffer(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     Supplier<BytesInput> factory = () -> BytesInput.from(toByteBuffer(data));
@@ -102,8 +92,10 @@ public class TestBytesInput {
     validateToByteBufferIsInternal(factory);
   }
 
-  @Test
-  public void testFromMultipleByteBuffers() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromMultipleByteBuffers(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     Supplier<BytesInput> factory = () -> BytesInput.from(
@@ -115,8 +107,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromByteArray() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromByteArray(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     byte[] input = new byte[data.length + 20];
@@ -127,8 +121,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromByteArrayToByteArrayZeroCopy() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromByteArrayToByteArrayZeroCopy(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     // Full array (offset=0, length=array.length): toByteArray() returns the backing array directly
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
@@ -139,8 +135,10 @@ public class TestBytesInput {
         .isSameAs(data);
   }
 
-  @Test
-  public void testFromByteArrayToByteArraySubRange() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromByteArrayToByteArraySubRange(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     // Sub-range (offset != 0): toByteArray() must return a copy of the specified range
     byte[] input = new byte[1000];
     RANDOM.nextBytes(input);
@@ -151,8 +149,10 @@ public class TestBytesInput {
     assertThat(result).isEqualTo(expected);
   }
 
-  @Test
-  public void testFromInputStream() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromInputStream(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     byte[] input = new byte[data.length + 10];
@@ -163,8 +163,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromLargeAvailableAgnosticInputStream() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromLargeAvailableAgnosticInputStream(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     // allocate a bytes that large than
     // java.nio.channel.Channels.ReadableByteChannelImpl.TRANSFER_SIZE = 8192
     byte[] data = new byte[9 * 1024];
@@ -177,8 +179,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromByteArrayOutputStream() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromByteArrayOutputStream(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -188,8 +192,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromCapacityByteArrayOutputStreamOneSlab() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromCapacityByteArrayOutputStreamOneSlab(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     List<CapacityByteArrayOutputStream> toClose = new ArrayList<>();
@@ -213,8 +219,11 @@ public class TestBytesInput {
     }
   }
 
-  @Test
-  public void testFromCapacityByteArrayOutputStreamMultipleSlabs() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromCapacityByteArrayOutputStreamMultipleSlabs(ByteBufferAllocator innerAllocator)
+      throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     List<CapacityByteArrayOutputStream> toClose = new ArrayList<>();
@@ -234,8 +243,10 @@ public class TestBytesInput {
     }
   }
 
-  @Test
-  public void testFromInt() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromInt(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     int value = RANDOM.nextInt();
     ByteArrayOutputStream baos = new ByteArrayOutputStream(4);
     BytesUtils.writeIntLittleEndian(baos, value);
@@ -245,8 +256,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromUnsignedVarInt() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromUnsignedVarInt(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     int value = RANDOM.nextInt(Short.MAX_VALUE);
     ByteArrayOutputStream baos = new ByteArrayOutputStream(2);
     BytesUtils.writeUnsignedVarInt(value, baos);
@@ -256,8 +269,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromUnsignedVarLong() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromUnsignedVarLong(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     long value = RANDOM.nextInt(Integer.MAX_VALUE);
     ByteArrayOutputStream baos = new ByteArrayOutputStream(4);
     BytesUtils.writeUnsignedVarLong(value, baos);
@@ -267,8 +282,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromZigZagVarInt() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromZigZagVarInt(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     int value = RANDOM.nextInt() % Short.MAX_VALUE;
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     BytesUtils.writeZigZagVarInt(value, baos);
@@ -278,8 +295,10 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testFromZigZagVarLong() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testFromZigZagVarLong(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     long value = RANDOM.nextInt();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     BytesUtils.writeZigZagVarLong(value, baos);
@@ -289,16 +308,20 @@ public class TestBytesInput {
     validate(data, factory);
   }
 
-  @Test
-  public void testEmpty() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testEmpty(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[0];
     Supplier<BytesInput> factory = () -> BytesInput.empty();
 
     validate(data, factory);
   }
 
-  @Test
-  public void testConcatenatingByteBufferCollectorOneSlab() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testConcatenatingByteBufferCollectorOneSlab(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     List<ConcatenatingByteBufferCollector> toClose = new ArrayList<>();
@@ -319,8 +342,11 @@ public class TestBytesInput {
     }
   }
 
-  @Test
-  public void testConcatenatingByteBufferCollectorMultipleSlabs() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testConcatenatingByteBufferCollectorMultipleSlabs(ByteBufferAllocator innerAllocator)
+      throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     List<ConcatenatingByteBufferCollector> toClose = new ArrayList<>();
@@ -342,8 +368,10 @@ public class TestBytesInput {
     }
   }
 
-  @Test
-  public void testConcat() throws IOException {
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("parameters")
+  public void testConcat(ByteBufferAllocator innerAllocator) throws IOException {
+    initAllocator(innerAllocator);
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
 

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesUtil.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesUtil.java
@@ -21,7 +21,7 @@ package org.apache.parquet.bytes;
 import static org.apache.parquet.bytes.BytesUtils.getWidthFromMaxInt;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestBytesUtil {
 

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestCapacityByteArrayOutputStreamOverflow.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestCapacityByteArrayOutputStreamOverflow.java
@@ -22,9 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.lang.reflect.Field;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for integer overflow handling in {@link CapacityByteArrayOutputStream#addSlab(int)}.
@@ -34,12 +34,12 @@ public class TestCapacityByteArrayOutputStreamOverflow {
 
   private TrackingByteBufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void initAllocator() {
     allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestConcatenatingByteBufferCollector.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestConcatenatingByteBufferCollector.java
@@ -27,9 +27,9 @@ import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class of {@link ConcatenatingByteBufferCollector}.
@@ -38,12 +38,12 @@ public class TestConcatenatingByteBufferCollector {
 
   private TrackingByteBufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void initAllocator() {
     allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestDeprecatedBufferInputStream.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestDeprecatedBufferInputStream.java
@@ -22,141 +22,191 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the deprecated behavior of instantiating ByteBufferInputStream directly
  */
-@RunWith(Parameterized.class)
-public class TestDeprecatedBufferInputStream extends TestByteBufferInputStreams {
-  @Parameter(0)
-  public ByteBuffer data;
+public class TestDeprecatedBufferInputStream {
 
-  @Parameter(1)
-  public Integer offset;
+  abstract static class DeprecatedBufferInputStreamTestCase extends TestByteBufferInputStreams {
+    abstract ByteBuffer data();
 
-  @Parameters
-  public static List<Object[]> parameters() {
-    return Arrays.asList(
-        new Object[] {TestSingleBufferInputStream.DATA, null},
-        new Object[] {TestSingleBufferInputStream.DATA, 0},
-        new Object[] {
-          ByteBuffer.wrap(new byte[] {
-            -1, -1, -1, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-            22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34
-          }),
-          4
-        },
-        new Object[] {
-          ByteBuffer.wrap(new byte[] {
-            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-            26, 27, 28, 29, 30, 31, 32, 33, 34, -1, -1, -1
-          }),
-          0
-        },
-        new Object[] {
-          ByteBuffer.wrap(new byte[] {
-            -1, -1, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
-            23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, -1, -1
-          }),
-          3
-        });
-  }
+    abstract Integer offset();
 
-  @Override
-  protected ByteBufferInputStream newStream() {
-    if (offset == null) {
-      return new ByteBufferInputStream(data);
-    } else {
-      return new ByteBufferInputStream(data, offset, DATA_LENGTH);
+    @Override
+    protected ByteBufferInputStream newStream() {
+      if (offset() == null) {
+        return new ByteBufferInputStream(data());
+      } else {
+        return new ByteBufferInputStream(data(), offset(), DATA_LENGTH);
+      }
+    }
+
+    @Override
+    protected void checkOriginalData() {
+      assertThat(data().position()).as("Position should not change").isEqualTo(0);
+      assertThat(data().limit()).as("Limit should not change").isEqualTo(data().array().length);
+    }
+
+    @Test
+    public void testSliceData() throws Exception {
+      ByteBufferInputStream stream = newStream();
+      int length = stream.available();
+
+      List<ByteBuffer> buffers = new ArrayList<>();
+      // slice the stream into 3 8-byte buffers and 1 2-byte buffer
+      while (stream.available() > 0) {
+        int bytesToSlice = Math.min(stream.available(), 8);
+        buffers.add(stream.slice(bytesToSlice));
+      }
+
+      assertThat(stream.position()).as("Position should be at end").isEqualTo(length);
+      assertThat(buffers).as("Should produce 5 buffers").hasSize(5);
+
+      int i = 0;
+
+      ByteBuffer one = buffers.get(0);
+      assertThat(one.array()).as("Should use the same backing array").isSameAs(data().array());
+      assertThat(one.remaining()).isEqualTo(8);
+      assertThat(one.position()).isEqualTo(0);
+      assertThat(one.limit()).isEqualTo(8);
+      for (; i < 8; i += 1) {
+        assertThat((int) one.get()).as("Should produce correct values").isEqualTo(i);
+      }
+
+      ByteBuffer two = buffers.get(1);
+      assertThat(two.array()).as("Should use the same backing array").isSameAs(data().array());
+      assertThat(two.remaining()).isEqualTo(8);
+      assertThat(two.position()).isEqualTo(8);
+      assertThat(two.limit()).isEqualTo(16);
+      for (; i < 16; i += 1) {
+        assertThat((int) two.get()).as("Should produce correct values").isEqualTo(i);
+      }
+
+      // three is a copy of part of the 4th buffer
+      ByteBuffer three = buffers.get(2);
+      assertThat(three.array()).as("Should use the same backing array").isSameAs(data().array());
+      assertThat(three.remaining()).isEqualTo(8);
+      assertThat(three.position()).isEqualTo(16);
+      assertThat(three.limit()).isEqualTo(24);
+      for (; i < 24; i += 1) {
+        assertThat((int) three.get())
+            .as("Should produce correct values")
+            .isEqualTo(i);
+      }
+
+      // four should be a copy of the next 8 bytes
+      ByteBuffer four = buffers.get(3);
+      assertThat(four.array()).as("Should use the same backing array").isSameAs(data().array());
+      assertThat(four.remaining()).isEqualTo(8);
+      assertThat(four.position()).isEqualTo(24);
+      assertThat(four.limit()).isEqualTo(32);
+      for (; i < 32; i += 1) {
+        assertThat((int) four.get()).as("Should produce correct values").isEqualTo(i);
+      }
+
+      // five should be a copy of the next 8 bytes
+      ByteBuffer five = buffers.get(4);
+      assertThat(five.array()).as("Should use the same backing array").isSameAs(data().array());
+      assertThat(five.remaining()).isEqualTo(3);
+      assertThat(five.position()).isEqualTo(32);
+      assertThat(five.limit()).isEqualTo(35);
+      for (; i < 35; i += 1) {
+        assertThat((int) five.get()).as("Should produce correct values").isEqualTo(i);
+      }
+    }
+
+    @Test
+    public void testWholeSliceBuffersData() throws Exception {
+      ByteBufferInputStream stream = newStream();
+
+      List<ByteBuffer> buffers = stream.sliceBuffers(stream.available());
+      assertThat(buffers)
+          .as("Should return duplicates of all non-empty buffers")
+          .containsExactly(TestSingleBufferInputStream.DATA);
     }
   }
 
-  @Override
-  protected void checkOriginalData() {
-    assertThat(data.position()).as("Position should not change").isEqualTo(0);
-    assertThat(data.limit()).as("Limit should not change").isEqualTo(data.array().length);
-  }
-
-  @Test
-  public void testSliceData() throws Exception {
-    ByteBufferInputStream stream = newStream();
-    int length = stream.available();
-
-    List<ByteBuffer> buffers = new ArrayList<>();
-    // slice the stream into 3 8-byte buffers and 1 2-byte buffer
-    while (stream.available() > 0) {
-      int bytesToSlice = Math.min(stream.available(), 8);
-      buffers.add(stream.slice(bytesToSlice));
+  @Nested
+  class WithNullOffset extends DeprecatedBufferInputStreamTestCase {
+    @Override
+    ByteBuffer data() {
+      return TestSingleBufferInputStream.DATA;
     }
 
-    assertThat(stream.position()).as("Position should be at end").isEqualTo(length);
-    assertThat(buffers).as("Should produce 5 buffers").hasSize(5);
-
-    int i = 0;
-
-    ByteBuffer one = buffers.get(0);
-    assertThat(one.array()).as("Should use the same backing array").isSameAs(data.array());
-    assertThat(one.remaining()).isEqualTo(8);
-    assertThat(one.position()).isEqualTo(0);
-    assertThat(one.limit()).isEqualTo(8);
-    for (; i < 8; i += 1) {
-      assertThat((int) one.get()).as("Should produce correct values").isEqualTo(i);
-    }
-
-    ByteBuffer two = buffers.get(1);
-    assertThat(two.array()).as("Should use the same backing array").isSameAs(data.array());
-    assertThat(two.remaining()).isEqualTo(8);
-    assertThat(two.position()).isEqualTo(8);
-    assertThat(two.limit()).isEqualTo(16);
-    for (; i < 16; i += 1) {
-      assertThat((int) two.get()).as("Should produce correct values").isEqualTo(i);
-    }
-
-    // three is a copy of part of the 4th buffer
-    ByteBuffer three = buffers.get(2);
-    assertThat(three.array()).as("Should use the same backing array").isSameAs(data.array());
-    assertThat(three.remaining()).isEqualTo(8);
-    assertThat(three.position()).isEqualTo(16);
-    assertThat(three.limit()).isEqualTo(24);
-    for (; i < 24; i += 1) {
-      assertThat((int) three.get()).as("Should produce correct values").isEqualTo(i);
-    }
-
-    // four should be a copy of the next 8 bytes
-    ByteBuffer four = buffers.get(3);
-    assertThat(four.array()).as("Should use the same backing array").isSameAs(data.array());
-    assertThat(four.remaining()).isEqualTo(8);
-    assertThat(four.position()).isEqualTo(24);
-    assertThat(four.limit()).isEqualTo(32);
-    for (; i < 32; i += 1) {
-      assertThat((int) four.get()).as("Should produce correct values").isEqualTo(i);
-    }
-
-    // five should be a copy of the next 8 bytes
-    ByteBuffer five = buffers.get(4);
-    assertThat(five.array()).as("Should use the same backing array").isSameAs(data.array());
-    assertThat(five.remaining()).isEqualTo(3);
-    assertThat(five.position()).isEqualTo(32);
-    assertThat(five.limit()).isEqualTo(35);
-    for (; i < 35; i += 1) {
-      assertThat((int) five.get()).as("Should produce correct values").isEqualTo(i);
+    @Override
+    Integer offset() {
+      return null;
     }
   }
 
-  @Test
-  public void testWholeSliceBuffersData() throws Exception {
-    ByteBufferInputStream stream = newStream();
+  @Nested
+  class WithZeroOffset extends DeprecatedBufferInputStreamTestCase {
+    @Override
+    ByteBuffer data() {
+      return TestSingleBufferInputStream.DATA;
+    }
 
-    List<ByteBuffer> buffers = stream.sliceBuffers(stream.available());
-    assertThat(buffers)
-        .as("Should return duplicates of all non-empty buffers")
-        .containsExactly(TestSingleBufferInputStream.DATA);
+    @Override
+    Integer offset() {
+      return 0;
+    }
+  }
+
+  @Nested
+  class WithLeadingPadding extends DeprecatedBufferInputStreamTestCase {
+    private final ByteBuffer data = ByteBuffer.wrap(new byte[] {
+      -1, -1, -1, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+      25, 26, 27, 28, 29, 30, 31, 32, 33, 34
+    });
+
+    @Override
+    ByteBuffer data() {
+      return data;
+    }
+
+    @Override
+    Integer offset() {
+      return 4;
+    }
+  }
+
+  @Nested
+  class WithTrailingPadding extends DeprecatedBufferInputStreamTestCase {
+    private final ByteBuffer data = ByteBuffer.wrap(new byte[] {
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
+      29, 30, 31, 32, 33, 34, -1, -1, -1
+    });
+
+    @Override
+    ByteBuffer data() {
+      return data;
+    }
+
+    @Override
+    Integer offset() {
+      return 0;
+    }
+  }
+
+  @Nested
+  class WithLeadingAndTrailingPadding extends DeprecatedBufferInputStreamTestCase {
+    private final ByteBuffer data = ByteBuffer.wrap(new byte[] {
+      -1, -1, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+      26, 27, 28, 29, 30, 31, 32, 33, 34, -1, -1
+    });
+
+    @Override
+    ByteBuffer data() {
+      return data;
+    }
+
+    @Override
+    Integer offset() {
+      return 3;
+    }
   }
 }

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestMultiBufferInputStream.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestMultiBufferInputStream.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestMultiBufferInputStream extends TestByteBufferInputStreams {
   private static final List<ByteBuffer> DATA = List.of(

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestReusingByteBufferAllocator.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestReusingByteBufferAllocator.java
@@ -23,19 +23,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.nio.InvalidMarkException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 import java.util.function.Function;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-@RunWith(Parameterized.class)
 public class TestReusingByteBufferAllocator {
 
   private enum AllocatorType {
@@ -56,48 +51,37 @@ public class TestReusingByteBufferAllocator {
 
   private TrackingByteBufferAllocator allocator;
 
-  @Parameter
-  public ByteBufferAllocator innerAllocator;
-
-  @Parameter(1)
-  public AllocatorType type;
-
-  @Parameters(name = "{0} {1}")
-  public static List<Object[]> parameters() {
-    List<Object[]> params = new ArrayList<>();
-    for (Object allocator : new Object[] {
-      new HeapByteBufferAllocator() {
-        @Override
-        public String toString() {
-          return "HEAP";
-        }
-      },
-      new DirectByteBufferAllocator() {
-        @Override
-        public String toString() {
-          return "DIRECT";
-        }
-      }
-    }) {
-      for (Object type : AllocatorType.values()) {
-        params.add(new Object[] {allocator, type});
-      }
-    }
-    return params;
+  static Stream<Arguments> parameters() {
+    return Stream.of(
+            new HeapByteBufferAllocator() {
+              @Override
+              public String toString() {
+                return "HEAP";
+              }
+            },
+            new DirectByteBufferAllocator() {
+              @Override
+              public String toString() {
+                return "DIRECT";
+              }
+            })
+        .flatMap(innerAllocator ->
+            Stream.of(AllocatorType.values()).map(type -> Arguments.of(innerAllocator, type)));
   }
 
-  @Before
-  public void initAllocator() {
+  private void initAllocator(ByteBufferAllocator innerAllocator) {
     allocator = TrackingByteBufferAllocator.wrap(innerAllocator);
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }
 
-  @Test
-  public void normalUseCase() {
+  @ParameterizedTest(name = "{0} {1}")
+  @MethodSource("parameters")
+  public void normalUseCase(ByteBufferAllocator innerAllocator, AllocatorType type) {
+    initAllocator(innerAllocator);
     try (ReusingByteBufferAllocator reusingAllocator = type.create(allocator)) {
       assertThat(reusingAllocator.isDirect()).isEqualTo(innerAllocator.isDirect());
       for (int i = 0; i < 10; ++i) {
@@ -128,8 +112,10 @@ public class TestReusingByteBufferAllocator {
     assertThatThrownBy(buf::reset).isInstanceOf(InvalidMarkException.class);
   }
 
-  @Test
-  public void validateExceptions() {
+  @ParameterizedTest(name = "{0} {1}")
+  @MethodSource("parameters")
+  public void validateExceptions(ByteBufferAllocator innerAllocator, AllocatorType type) {
+    initAllocator(innerAllocator);
     try (ByteBufferReleaser releaser = new ByteBufferReleaser(allocator);
         ReusingByteBufferAllocator reusingAllocator = type.create(allocator)) {
       ByteBuffer fromOther = allocator.allocate(10);

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestSingleBufferInputStream.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestSingleBufferInputStream.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSingleBufferInputStream extends TestByteBufferInputStreams {
   static final ByteBuffer DATA = ByteBuffer.wrap(new byte[] {

--- a/parquet-common/src/test/java/org/apache/parquet/glob/TestGlob.java
+++ b/parquet-common/src/test/java/org/apache/parquet/glob/TestGlob.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.parquet.Strings;
 import org.apache.parquet.glob.GlobParser.GlobParseException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestGlob {
 

--- a/parquet-common/src/test/java/org/apache/parquet/glob/TestWildcardPath.java
+++ b/parquet-common/src/test/java/org/apache/parquet/glob/TestWildcardPath.java
@@ -20,7 +20,7 @@ package org.apache.parquet.glob;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestWildcardPath {
 

--- a/parquet-common/src/test/java/org/apache/parquet/io/TestDelegatingSeekableInputStream.java
+++ b/parquet-common/src/test/java/org/apache/parquet/io/TestDelegatingSeekableInputStream.java
@@ -27,7 +27,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestDelegatingSeekableInputStream {
 

--- a/parquet-common/src/test/java/org/apache/parquet/io/TestLocalInputOutput.java
+++ b/parquet-common/src/test/java/org/apache/parquet/io/TestLocalInputOutput.java
@@ -29,7 +29,7 @@ import java.nio.ReadOnlyBufferException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestLocalInputOutput {
 

--- a/parquet-common/src/test/java/org/apache/parquet/util/TestDynConstructors.java
+++ b/parquet-common/src/test/java/org/apache/parquet/util/TestDynConstructors.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.parquet.util.Concatenator.SomeCheckedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestDynConstructors {
   @Test

--- a/parquet-common/src/test/java/org/apache/parquet/util/TestDynMethods.java
+++ b/parquet-common/src/test/java/org/apache/parquet/util/TestDynMethods.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.parquet.util.Concatenator.SomeCheckedException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestDynMethods {
   @Test

--- a/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
@@ -21,7 +21,7 @@ package org.apache.parquet.bytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestBytesInput {
 

--- a/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestCapacityByteArrayOutputStream.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/bytes/TestCapacityByteArrayOutputStream.java
@@ -22,20 +22,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestCapacityByteArrayOutputStream {
 
   private TrackingByteBufferAllocator allocator;
 
-  @Before
+  @BeforeEach
   public void initAllocator() {
     allocator = TrackingByteBufferAllocator.wrap(new HeapByteBufferAllocator());
   }
 
-  @After
+  @AfterEach
   public void closeAllocator() {
     allocator.close();
   }

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestBitPacking.java
@@ -25,7 +25,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingReader;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBasedBitPackingEncoder.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBasedBitPackingEncoder.java
@@ -21,7 +21,7 @@ package org.apache.parquet.column.values.bitpacking;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.parquet.bytes.BytesUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestByteBasedBitPackingEncoder {
 

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking.java
@@ -27,7 +27,7 @@ import java.nio.ByteBuffer;
 import java.util.Random;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingReader;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestLemireBitPacking.java
+++ b/parquet-encoding/src/test/java/org/apache/parquet/column/values/bitpacking/TestLemireBitPacking.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingReader;
 import org.apache.parquet.column.values.bitpacking.BitPacking.BitPackingWriter;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
+++ b/parquet-format-structures/src/test/java/org/apache/parquet/format/TestUtil.java
@@ -28,7 +28,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.apache.parquet.format.Util.DefaultFileMetaDataConsumer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestUtil {
 

--- a/parquet-hadoop/src/test/java/org/apache/parquet/DirectWriterTest.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/DirectWriterTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.parquet;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,16 +30,15 @@ import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Rule;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 
 public class DirectWriterTest {
 
-  @Rule
-  public final TemporaryFolder tempDir = new TemporaryFolder();
+  @TempDir
+  private java.nio.file.Path tempDir;
 
   protected interface DirectWriter {
-    public void write(RecordConsumer consumer);
+    void write(RecordConsumer consumer);
   }
 
   protected Path writeDirect(String type, DirectWriter writer) throws IOException {
@@ -56,11 +54,7 @@ public class DirectWriterTest {
   }
 
   protected Path writeDirect(MessageType type, DirectWriter writer, Map<String, String> metadata) throws IOException {
-    File temp = tempDir.newFile(UUID.randomUUID().toString());
-    temp.deleteOnExit();
-    temp.delete();
-
-    Path path = new Path(temp.getPath());
+    Path path = new Path(tempDir.resolve(UUID.randomUUID().toString()).toUri());
 
     ParquetWriter<Void> parquetWriter =
         new ParquetWriter<Void>(path, new DirectWriteSupport(type, writer, metadata));

--- a/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking512VectorLE.java
+++ b/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestByteBitPacking512VectorLE.java
@@ -19,14 +19,14 @@
 package org.apache.parquet.column.values.bitpacking;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,7 @@ public class TestByteBitPacking512VectorLE {
 
   @Test
   public void unpackValuesUsingVector() {
-    Assume.assumeTrue(ParquetReadRouter.getSupportVectorFromCPUFlags() == VectorSupport.VECTOR_512);
+    assumeThat(ParquetReadRouter.getSupportVectorFromCPUFlags()).isEqualTo(VectorSupport.VECTOR_512);
     for (int i = 1; i <= 32; i++) {
       unpackValuesUsingVectorBitWidth(i);
     }
@@ -43,7 +43,7 @@ public class TestByteBitPacking512VectorLE {
 
   @Test
   public void unpackValuesUsingVectorDirectByteBuffer() {
-    Assume.assumeTrue(ParquetReadRouter.getSupportVectorFromCPUFlags() == VectorSupport.VECTOR_512);
+    assumeThat(ParquetReadRouter.getSupportVectorFromCPUFlags()).isEqualTo(VectorSupport.VECTOR_512);
     for (int i = 1; i <= 32; i++) {
       unpackValuesUsingVectorBitWidthDirect(i);
     }
@@ -51,7 +51,7 @@ public class TestByteBitPacking512VectorLE {
 
   @Test
   public void unpackValuesUsingVectorReadOnlyByteBuffer() {
-    Assume.assumeTrue(ParquetReadRouter.getSupportVectorFromCPUFlags() == VectorSupport.VECTOR_512);
+    assumeThat(ParquetReadRouter.getSupportVectorFromCPUFlags()).isEqualTo(VectorSupport.VECTOR_512);
     for (int i = 1; i <= 32; i++) {
       unpackValuesUsingVectorBitWidthReadOnly(i);
     }

--- a/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestParquetReadRouter.java
+++ b/parquet-plugins/parquet-encoding-vector/src/test/java/org/apache/parquet/column/values/bitpacking/TestParquetReadRouter.java
@@ -19,12 +19,12 @@
 package org.apache.parquet.column.values.bitpacking;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.parquet.bytes.ByteBufferInputStream;
-import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +50,7 @@ public class TestParquetReadRouter {
       ParquetReadRouter.read(bitWidth, inputStream, 0, output);
       ParquetReadRouter.readBatch(bitWidth, inputStream, 0, outputBatch);
       assertThat(outputBatch).isEqualTo(output);
-      Assume.assumeTrue(ParquetReadRouter.getSupportVectorFromCPUFlags() == VectorSupport.VECTOR_512);
+      assumeThat(ParquetReadRouter.getSupportVectorFromCPUFlags()).isEqualTo(VectorSupport.VECTOR_512);
       ParquetReadRouter.readBatchUsing512Vector(bitWidth, inputStream, 0, outputBatchVector);
       assertThat(outputBatchVector).isEqualTo(output);
     }

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoInputOutputFormatTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoInputOutputFormatTest.java
@@ -36,7 +36,7 @@ import org.apache.parquet.proto.test.TestProtobuf.FirstCustomClassMessage;
 import org.apache.parquet.proto.test.TestProtobuf.SecondCustomClassMessage;
 import org.apache.parquet.proto.utils.ReadUsingMR;
 import org.apache.parquet.proto.utils.WriteUsingMR;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProtoInputOutputFormatTest {
 

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoParquetWriterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoParquetWriterTest.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.proto.test.TestProto3;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProtoParquetWriterTest {
   @Test

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoRecordConverterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoRecordConverterTest.java
@@ -27,7 +27,7 @@ import com.google.protobuf.ByteString;
 import java.util.List;
 import org.apache.parquet.proto.test.TestProto3;
 import org.apache.parquet.proto.test.TestProtobuf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProtoRecordConverterTest {
 

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
@@ -29,7 +29,7 @@ import org.apache.parquet.proto.test.TestProtobuf;
 import org.apache.parquet.proto.test.Trees;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProtoSchemaConverterTest {
 

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaEvolutionTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaEvolutionTest.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.parquet.proto.test.TestProto3SchemaV1;
 import org.apache.parquet.proto.test.TestProto3SchemaV2;
 import org.apache.parquet.proto.test.TestProto3SchemaV3;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for backward/forward compatibility while write and read parquet using different versions of protobuf schema.

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoWriteSupportTest.java
@@ -36,7 +36,7 @@ import org.apache.parquet.io.api.RecordConsumer;
 import org.apache.parquet.proto.test.TestProto3;
 import org.apache.parquet.proto.test.TestProtobuf;
 import org.apache.parquet.proto.test.Trees;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestArrayCompatibility.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestArrayCompatibility.java
@@ -40,13 +40,13 @@ import org.apache.parquet.thrift.test.compat.ListOfSingleElementGroups;
 import org.apache.parquet.thrift.test.compat.Location;
 import org.apache.parquet.thrift.test.compat.SingleElementGroup;
 import org.apache.thrift.TBase;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 public class TestArrayCompatibility extends DirectWriterTest {
 
   @Test
-  @Ignore("Not yet supported")
+  @Disabled("Not yet supported")
   public void testUnannotatedListOfPrimitives() throws Exception {
     Path test = writeDirect(
         "message UnannotatedListOfPrimitives {" + "  repeated int32 list_of_ints;" + "}", new DirectWriter() {
@@ -66,7 +66,7 @@ public class TestArrayCompatibility extends DirectWriterTest {
   }
 
   @Test
-  @Ignore("Not yet supported")
+  @Disabled("Not yet supported")
   public void testUnannotatedListOfGroups() throws Exception {
     Path test = writeDirect(
         "message UnannotatedListOfGroups {" + "  repeated group list_of_points {"

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestBinary.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestBinary.java
@@ -20,7 +20,6 @@ package org.apache.parquet.hadoop.thrift;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
@@ -38,22 +37,17 @@ import org.apache.parquet.schema.Types;
 import org.apache.parquet.thrift.ThriftParquetReader;
 import org.apache.parquet.thrift.ThriftParquetWriter;
 import org.apache.parquet.thrift.test.binary.StringAndBinary;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestBinary {
-  @Rule
-  public TemporaryFolder tempDir = new TemporaryFolder();
+  @TempDir
+  private java.nio.file.Path tempDir;
 
   @Test
   public void testBinary() throws IOException {
     StringAndBinary expected = new StringAndBinary("test", ByteBuffer.wrap(new byte[] {-123, 20, 33}));
-    File temp = tempDir.newFile(UUID.randomUUID().toString());
-    temp.deleteOnExit();
-    temp.delete();
-
-    Path path = new Path(temp.getPath());
+    Path path = new Path(tempDir.resolve(UUID.randomUUID().toString()).toUri());
 
     ThriftParquetWriter<StringAndBinary> writer =
         new ThriftParquetWriter<StringAndBinary>(path, StringAndBinary.class, CompressionCodecName.SNAPPY);

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestCorruptThriftRecords.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestCorruptThriftRecords.java
@@ -22,7 +22,6 @@ import static org.apache.parquet.hadoop.thrift.TestInputOutputFormat.waitForJob;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,14 +41,12 @@ import org.apache.parquet.thrift.test.compat.AStructThatLooksLikeUnionV2;
 import org.apache.parquet.thrift.test.compat.StructWithAStructThatLooksLikeUnionV2;
 import org.apache.parquet.thrift.test.compat.StructWithUnionV2;
 import org.apache.parquet.thrift.test.compat.UnionV2;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestCorruptThriftRecords {
-
-  @Rule
-  public final TemporaryFolder tempDir = new TemporaryFolder();
+  @TempDir
+  private java.nio.file.Path tempDir;
 
   public static class ReadMapper<T> extends Mapper<Void, T, Void, Void> {
     public static List<Object> records;
@@ -124,7 +121,7 @@ public class TestCorruptThriftRecords {
     // generate a file with records that are corrupt according to thrift
     // by writing some structs that when interpreted as unions will be
     // unreadable
-    Path outputPath = new Path(new File(tempDir.getRoot(), "corrupt_out").getAbsolutePath());
+    Path outputPath = new Path(tempDir.resolve("corrupt_out").toUri());
     ParquetWriter<StructWithAStructThatLooksLikeUnionV2> writer =
         new ThriftParquetWriter<StructWithAStructThatLooksLikeUnionV2>(
             outputPath, StructWithAStructThatLooksLikeUnionV2.class, CompressionCodecName.UNCOMPRESSED);

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestInputOutputFormat.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestInputOutputFormat.java
@@ -47,7 +47,7 @@ import org.apache.parquet.thrift.test.compat.StructV1;
 import org.apache.parquet.thrift.test.compat.StructV2;
 import org.apache.parquet.thrift.test.compat.StructV3;
 import org.apache.thrift.TBase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestParquetToThriftReadWriteAndProjection.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestParquetToThriftReadWriteAndProjection.java
@@ -59,7 +59,7 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TIOStreamTransport;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestThriftToParquetFileWriter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/hadoop/thrift/TestThriftToParquetFileWriter.java
@@ -63,7 +63,7 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TProtocol;
 import org.apache.thrift.protocol.TProtocolFactory;
 import org.apache.thrift.transport.TIOStreamTransport;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetReadProtocol.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetReadProtocol.java
@@ -52,7 +52,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thrift.test.OneOfEach;

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetWriteProtocol.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestParquetWriteProtocol.java
@@ -52,7 +52,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
 import org.apache.thrift.TBase;
 import org.apache.thrift.TException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thrift.test.OneOfEach;

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestProtocolReadToWrite.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestProtocolReadToWrite.java
@@ -64,7 +64,7 @@ import org.apache.thrift.protocol.TCompactProtocol;
 import org.apache.thrift.protocol.TField;
 import org.apache.thrift.transport.TIOStreamTransport;
 import org.apache.thrift.transport.TTransportException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import thrift.test.OneOfEach;
 
 public class TestProtocolReadToWrite {

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftMetaData.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftMetaData.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import org.apache.parquet.thrift.struct.ThriftField;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType.StructOrUnionType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestThriftMetaData {
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftParquetReaderWriter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftParquetReaderWriter.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestThriftParquetReaderWriter {
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftRecordConverter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftRecordConverter.java
@@ -38,7 +38,7 @@ import org.apache.parquet.thrift.struct.ThriftType.StructType;
 import org.apache.parquet.thrift.test.compat.StructWithUnionV1;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TProtocol;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestThriftRecordConverter {
   @Test

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConvertVisitor.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConvertVisitor.java
@@ -35,7 +35,7 @@ import org.apache.parquet.thrift.struct.ThriftField;
 import org.apache.parquet.thrift.struct.ThriftType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType.StructOrUnionType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestThriftSchemaConvertVisitor {
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverter.java
@@ -39,7 +39,7 @@ import org.apache.parquet.thrift.test.TestLogicalType;
 import org.apache.parquet.thrift.test.compat.MapStructV2;
 import org.apache.parquet.thrift.test.compat.SetStructV2;
 import org.apache.thrift.TBase;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestThriftSchemaConverter {
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverterProjectUnion.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestThriftSchemaConverterProjectUnion.java
@@ -31,7 +31,7 @@ import org.apache.parquet.thrift.test.compat.StructWithNestedUnion;
 import org.apache.parquet.thrift.test.compat.StructWithOptionalUnionOfStructs;
 import org.apache.parquet.thrift.test.compat.UnionOfStructs;
 import org.apache.parquet.thrift.test.compat.UnionV2;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestThriftSchemaConverterProjectUnion {
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestUUIDRecordConverterFailure.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/TestUUIDRecordConverterFailure.java
@@ -27,7 +27,7 @@ import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.thrift.struct.ThriftField;
 import org.apache.parquet.thrift.struct.ThriftType;
 import org.apache.thrift.protocol.TProtocol;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 // Test to verify UUID converter support in ThriftRecordConverter.
 public class TestUUIDRecordConverterFailure {

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/TestFieldsPath.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/TestFieldsPath.java
@@ -40,7 +40,7 @@ import org.apache.parquet.thrift.struct.ThriftType.MapType;
 import org.apache.parquet.thrift.struct.ThriftType.SetType;
 import org.apache.parquet.thrift.struct.ThriftType.StringType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestFieldsPath {
   @Test

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/TestStrictFieldProjectionFilter.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/TestStrictFieldProjectionFilter.java
@@ -26,7 +26,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestStrictFieldProjectionFilter {
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/deprecated/PathGlobPatternTest.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/projection/deprecated/PathGlobPatternTest.java
@@ -20,7 +20,7 @@ package org.apache.parquet.thrift.projection.deprecated;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test using glob syntax to specify which attribute to retain

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/CompatibilityCheckerTest.java
@@ -38,7 +38,7 @@ import org.apache.parquet.thrift.test.compat.SetStructV2;
 import org.apache.parquet.thrift.test.compat.StructV1;
 import org.apache.parquet.thrift.test.compat.StructV2;
 import org.apache.parquet.thrift.test.compat.TypeChangeStructV1;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CompatibilityCheckerTest {
 

--- a/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/TestThriftType.java
+++ b/parquet-thrift/src/test/java/org/apache/parquet/thrift/struct/TestThriftType.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.LinkedList;
 import org.apache.parquet.thrift.struct.ThriftType.StructType;
 import org.apache.parquet.thrift.struct.ThriftType.StructType.StructOrUnionType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestThriftType {
 

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArray.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.LocalDate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArrayBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantArrayBuilder.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObject.java
@@ -33,7 +33,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantObjectBuilder.java
@@ -24,8 +24,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.UUID;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -277,7 +277,7 @@ public class TestVariantObjectBuilder {
   }
 
   @Test
-  @Ignore("Test uses too much memory")
+  @Disabled("Test uses too much memory")
   public void testObjectFourByteFieldIdBuilder() {
     // need more than 16777215 dictionary entries to push field id size above 3 bytes
     testObjectFieldIdSizeBuilder(16_800_000);

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantParseJson.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantParseJson.java
@@ -26,7 +26,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import java.io.IOException;
 import java.math.BigDecimal;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestVariantParseJson {
 

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalar.java
@@ -28,7 +28,7 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.UUID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalarBuilder.java
+++ b/parquet-variant/src/test/java/org/apache/parquet/variant/TestVariantScalarBuilder.java
@@ -30,7 +30,7 @@ import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.IntStream;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,19 @@
   <dependencies>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Now that these modules have been migrated to AssertJ assertions, migrating them to JUnit5 is trivial and mostly requires import changes. 
While this touches 180+ files, there are actually < 10 files that have substantial changes (mostly around parameterized testing). All the other files have pure import changes. JUnit5 doesn't support built-in class-level test parameterization and so those tests were converted to parameterize at the method level.

I'll have a second PR that will migrate parquet-hadoop to JUnit5 because that requires few more substantial changes

### What changes are included in this PR?


### Are these changes tested?
yes

### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
