### PR TITLE
MINOR: Allow callers to provide known Hadoop file lengths

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -69,7 +69,8 @@ public class HadoopInputFile implements InputFile {
    * Creates an input file using a caller-supplied file length.
    *
    * <p>The length is trusted and no file status lookup is performed. Callers must provide the exact
-   * length of the file that will be opened. The file is not validated until it is opened.
+   * length of the file that will be opened. The file system may defer checking whether the file
+   * exists until the first read. If the supplied length is incorrect, reads may fail.
    *
    * @param path file path
    * @param length exact file length in bytes

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -19,6 +19,7 @@
 
 package org.apache.parquet.hadoop.util;
 
+import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_LENGTH;
 import static org.apache.parquet.hadoop.util.wrapped.io.FutureIO.awaitFuture;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FutureDataInputStreamBuilder;
 import org.apache.hadoop.fs.Path;
 import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.SeekableInputStream;
@@ -53,12 +55,35 @@ public class HadoopInputFile implements InputFile {
   private static final String PARQUET_READ_POLICY = "parquet, vector, random, adaptive";
 
   private final FileSystem fs;
+  private final Path path;
+  private final long length;
   private final FileStatus stat;
   private final Configuration conf;
 
   public static HadoopInputFile fromPath(Path path, Configuration conf) throws IOException {
     FileSystem fs = path.getFileSystem(conf);
     return new HadoopInputFile(fs, fs.getFileStatus(path), conf);
+  }
+
+  /**
+   * Creates an input file using a caller-supplied file length.
+   *
+   * <p>The length is trusted and no file status lookup is performed. Callers must provide the exact
+   * length of the file that will be opened. The file is not validated until it is opened.
+   *
+   * @param path file path
+   * @param length exact file length in bytes
+   * @param conf configuration used to resolve the file system
+   * @return an input file that uses the supplied length
+   * @throws IllegalArgumentException if {@code length} is negative
+   * @throws IOException if the file system cannot be resolved
+   */
+  public static HadoopInputFile fromPath(Path path, long length, Configuration conf) throws IOException {
+    if (length < 0) {
+      throw new IllegalArgumentException("Invalid file length: " + length);
+    }
+    FileSystem fs = path.getFileSystem(conf);
+    return new HadoopInputFile(fs, path, length, conf);
   }
 
   public static HadoopInputFile fromPathUnchecked(Path path, Configuration conf) {
@@ -76,7 +101,17 @@ public class HadoopInputFile implements InputFile {
 
   private HadoopInputFile(FileSystem fs, FileStatus stat, Configuration conf) {
     this.fs = fs;
+    this.path = stat.getPath();
+    this.length = stat.getLen();
     this.stat = stat;
+    this.conf = conf;
+  }
+
+  private HadoopInputFile(FileSystem fs, Path path, long length, Configuration conf) {
+    this.fs = fs;
+    this.path = path;
+    this.length = length;
+    this.stat = null;
     this.conf = conf;
   }
 
@@ -85,19 +120,19 @@ public class HadoopInputFile implements InputFile {
   }
 
   public Path getPath() {
-    return stat.getPath();
+    return path;
   }
 
   @Override
   public long getLength() {
-    return stat.getLen();
+    return length;
   }
 
   /**
    * Open the file.
-   * <p>Uses {@code FileSystem.openFile()} so that
-   * the existing FileStatus can be passed down: saves a HEAD request on cloud storage.
-   * and ignored everywhere else.
+   * <p>Uses {@code FileSystem.openFile()} so that the existing FileStatus, when available, or the
+   * known file length can be passed down. File systems may use either to avoid a metadata request
+   * when opening the file.
    *
    * @return the input stream.
    *
@@ -109,20 +144,24 @@ public class HadoopInputFile implements InputFile {
   public SeekableInputStream newStream() throws IOException {
     FSDataInputStream stream;
     try {
-      // this method is async so that implementations may do async HEAD head
+      // this method is async so that implementations may do async HEAD
       // requests, such as S3A/ABFS when a file status is passed down.
-      final CompletableFuture<FSDataInputStream> future = fs.openFile(stat.getPath())
-          .withFileStatus(stat)
-          .opt(OPENFILE_READ_POLICY_KEY, PARQUET_READ_POLICY)
-          .build();
+      FutureDataInputStreamBuilder builder = fs.openFile(path).opt(OPENFILE_READ_POLICY_KEY, PARQUET_READ_POLICY);
+      if (stat != null) {
+        builder.withFileStatus(stat);
+      } else {
+        builder.opt(FS_OPTION_OPENFILE_LENGTH, Long.toString(length));
+      }
+      final CompletableFuture<FSDataInputStream> future = builder.build();
       stream = awaitFuture(future);
     } catch (RuntimeException e) {
       // S3A < 3.3.5 would raise illegal path exception if the openFile path didn't
       // equal the path in the FileStatus; Hive virtual FS could create this condition.
-      // As the path to open is derived from stat.getPath(), this condition seems
-      // near-impossible to create -but is handled here for due diligence.
+      // When a status is supplied, the path to open is derived from stat.getPath(),
+      // so this condition seems near-impossible to create -but is handled here
+      // for due diligence.
       try {
-        stream = fs.open(stat.getPath());
+        stream = fs.open(path);
       } catch (IOException | RuntimeException ex) {
         // failure on this attempt attaches the failure of the openFile() call
         // so the stack trace is preserved.
@@ -136,6 +175,6 @@ public class HadoopInputFile implements InputFile {
 
   @Override
   public String toString() {
-    return stat.getPath().toString();
+    return path.toString();
   }
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -69,7 +69,12 @@ public class HadoopInputFile implements InputFile {
    * Creates an input file using a caller-supplied file length.
    *
    * <p>The length is trusted and no file status lookup is performed. Callers must provide the exact
-   * length of the file that will be opened. The file is not validated until it is opened.
+   * length of the file that will be opened. The file system may defer checking whether the file
+   * exists until the first read. If the supplied length is incorrect, reads may fail.
+   *
+   * <p>When a {@link FileStatus} is available, prefer {@link #fromStatus(FileStatus, Configuration)}.
+   * A length alone does not preserve file-system-specific identity metadata used when opening a file
+   * (for example, S3A ETags and version IDs), so initial-open change detection may be weaker.
    *
    * @param path file path
    * @param length exact file length in bytes

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/util/HadoopInputFile.java
@@ -19,7 +19,6 @@
 
 package org.apache.parquet.hadoop.util;
 
-import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_LENGTH;
 import static org.apache.parquet.hadoop.util.wrapped.io.FutureIO.awaitFuture;
 
 import java.io.IOException;
@@ -40,6 +39,14 @@ public class HadoopInputFile implements InputFile {
    * openFile() option name for setting the read policy: {@value}.
    */
   private static final String OPENFILE_READ_POLICY_KEY = "fs.option.openfile.read.policy";
+
+  /**
+   * openFile() option name for passing a known file length: {@value}.
+   *
+   * <p>This is an optional filesystem hint, so retain the string form to support Hadoop versions before the
+   * constant was introduced.
+   */
+  private static final String OPENFILE_LENGTH_KEY = "fs.option.openfile.length";
 
   /**
    * Read policy when opening parquet files: {@value}.
@@ -155,7 +162,7 @@ public class HadoopInputFile implements InputFile {
       if (stat != null) {
         builder.withFileStatus(stat);
       } else {
-        builder.opt(FS_OPTION_OPENFILE_LENGTH, Long.toString(length));
+        builder.opt(OPENFILE_LENGTH_KEY, Long.toString(length));
       }
       final CompletableFuture<FSDataInputStream> future = builder.build();
       stream = awaitFuture(future);

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
@@ -19,6 +19,7 @@
 package org.apache.parquet.hadoop.util;
 
 import static org.apache.hadoop.fs.FileSystemTestBinder.addFileSystemForTesting;
+import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doNothing;
@@ -101,8 +102,39 @@ public class TestHadoopOpenFile {
     // this looks up the FS binding via the status file path.
     openAndRead(fileFromStatus());
 
+    assertThat(opener.getFileStatus()).as("file status").isSameAs(status);
+
     // The fallback call of open(path) never took place.
     Mockito.verify(mockFS, never()).open(path);
+  }
+
+  /**
+   * A caller-supplied length avoids a status lookup and is passed to openFile().
+   */
+  @Test
+  public void testOpenFileWithKnownLength() throws Throwable {
+    final FileSystem mockFS = prepareMockFS();
+    final FSDataInputStream in = new FSDataInputStream(new MockHadoopInputStream());
+    final StubOpenFileBuilder opener = new StubOpenFileBuilder(mockFS, path, CompletableFuture.completedFuture(in));
+    doReturn(opener).when(mockFS).openFile(path);
+
+    final HadoopInputFile inputFile = HadoopInputFile.fromPath(path, status.getLen(), conf);
+    assertThat(inputFile.getPath()).as("path").isEqualTo(path);
+    assertThat(inputFile.getLength()).as("length").isEqualTo(status.getLen());
+    openAndRead(inputFile);
+
+    Mockito.verify(mockFS, never()).getFileStatus(path);
+    assertThat(opener.getFileStatus()).as("file status").isNull();
+    assertThat(opener.getOptions().get(FS_OPTION_OPENFILE_LENGTH))
+        .as("openFile length")
+        .isEqualTo(Long.toString(status.getLen()));
+  }
+
+  @Test
+  public void testRejectsNegativeKnownLength() {
+    assertThatThrownBy(() -> HadoopInputFile.fromPath(path, -1, conf))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid file length: -1");
   }
 
   /**
@@ -273,6 +305,10 @@ public class TestHadoopOpenFile {
         final FileSystem fileSystem, Path path, final CompletableFuture<FSDataInputStream> result) {
       super(fileSystem, path);
       this.result = result;
+    }
+
+    private FileStatus getFileStatus() {
+      return getStatus();
     }
 
     @Override

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
@@ -44,7 +44,9 @@ import org.apache.hadoop.fs.impl.FutureDataInputStreamBuilderImpl;
 import org.apache.parquet.io.SeekableInputStream;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.mockito.Mockito;
 
 /**
@@ -60,6 +62,10 @@ import org.mockito.Mockito;
 public class TestHadoopOpenFile {
 
   private static final int FIRST = MockHadoopInputStream.TEST_ARRAY[0];
+
+  @Rule
+  public TemporaryFolder temp = new TemporaryFolder();
+
   private URI fsUri;
   private FileStatus status;
   private Path path;
@@ -135,6 +141,23 @@ public class TestHadoopOpenFile {
     assertThatThrownBy(() -> HadoopInputFile.fromPath(path, -1, conf))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid file length: -1");
+  }
+
+  /**
+   * Opening a nonexistent file with a caller-supplied length must fail either
+   * when opening the stream or on the first read.
+   */
+  @Test
+  public void testKnownLengthMissingFile() throws IOException {
+    final Path missingPath = new Path(new Path(temp.getRoot().toURI()), "missing.parquet");
+    final HadoopInputFile inputFile = HadoopInputFile.fromPath(missingPath, 1, conf);
+
+    assertThatThrownBy(() -> {
+          try (SeekableInputStream stream = inputFile.newStream()) {
+            stream.read();
+          }
+        })
+        .isInstanceOf(FileNotFoundException.class);
   }
 
   /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
@@ -45,6 +45,7 @@ import org.apache.parquet.io.SeekableInputStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 /**
@@ -60,6 +61,10 @@ import org.mockito.Mockito;
 public class TestHadoopOpenFile {
 
   private static final int FIRST = MockHadoopInputStream.TEST_ARRAY[0];
+
+  @TempDir
+  private java.nio.file.Path tempDir;
+
   private URI fsUri;
   private FileStatus status;
   private Path path;
@@ -135,6 +140,23 @@ public class TestHadoopOpenFile {
     assertThatThrownBy(() -> HadoopInputFile.fromPath(path, -1, conf))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid file length: -1");
+  }
+
+  /**
+   * Opening a nonexistent file with a caller-supplied length must fail either
+   * when opening the stream or on the first read.
+   */
+  @Test
+  public void testKnownLengthMissingFile() throws IOException {
+    final Path missingPath = new Path(new Path(tempDir.toUri()), "missing.parquet");
+    final HadoopInputFile inputFile = HadoopInputFile.fromPath(missingPath, 1, conf);
+
+    assertThatThrownBy(() -> {
+          try (SeekableInputStream stream = inputFile.newStream()) {
+            stream.read();
+          }
+        })
+        .isInstanceOf(FileNotFoundException.class);
   }
 
   /**

--- a/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/hadoop/util/TestHadoopOpenFile.java
@@ -19,7 +19,6 @@
 package org.apache.parquet.hadoop.util;
 
 import static org.apache.hadoop.fs.FileSystemTestBinder.addFileSystemForTesting;
-import static org.apache.hadoop.fs.Options.OpenFileOptions.FS_OPTION_OPENFILE_LENGTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doNothing;
@@ -59,6 +58,8 @@ import org.mockito.Mockito;
  * it is already used outside the hadoop codebase (e.g. google gcs).
  */
 public class TestHadoopOpenFile {
+
+  private static final String OPENFILE_LENGTH_KEY = "fs.option.openfile.length";
 
   private static final int FIRST = MockHadoopInputStream.TEST_ARRAY[0];
 
@@ -130,7 +131,7 @@ public class TestHadoopOpenFile {
 
     Mockito.verify(mockFS, never()).getFileStatus(path);
     assertThat(opener.getFileStatus()).as("file status").isNull();
-    assertThat(opener.getOptions().get(FS_OPTION_OPENFILE_LENGTH))
+    assertThat(opener.getOptions().get(OPENFILE_LENGTH_KEY))
         .as("openFile length")
         .isEqualTo(Long.toString(status.getLen()));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <spotless.version>2.46.1</spotless.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.3.5</hadoop.version>
     <parquet.format.version>2.13.0</parquet.format.version>
     <previous.version>1.17.0</previous.version>
     <thrift.executable>thrift</thrift.executable>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <spotless.version>3.8.0</spotless.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
-    <hadoop.version>3.3.0</hadoop.version>
+    <hadoop.version>3.3.5</hadoop.version>
     <previous.version>1.18.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>${thrift.executable}</format.thrift.executable>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <spotless.version>3.8.0</spotless.version>
     <shade.prefix>shaded.parquet</shade.prefix>
     <!-- Guarantees no newer classes/methods/constants are used by parquet. -->
-    <hadoop.version>3.3.5</hadoop.version>
+    <hadoop.version>3.3.0</hadoop.version>
     <previous.version>1.18.0</previous.version>
     <thrift.executable>thrift</thrift.executable>
     <format.thrift.executable>${thrift.executable}</format.thrift.executable>


### PR DESCRIPTION
In an earlier PR @steveloughran suggested that callers who already knew the length of a file (such as Iceberg) could supply that value when opening a file and save at least on metadata lookup.  This is the result of me working through that idea with codex, not sure if it's what was originally intended.

It does bump the hadoop dependency from 3.3.0 to 3.3.5.  I assume that's safe, but calling it out just in case.


CODEX summary follows
------
Metadata-aware callers may already know a Parquet file's exact length from a catalog, manifest, or prior listing. `HadoopInputFile.fromPath(Path, Configuration)` currently performs `getFileStatus()` unconditionally, discarding that knowledge and potentially adding a remote metadata request before the file can be read.

This adds a length-aware factory that trusts the caller-provided value and passes it to Hadoop's `openFile()` API. The API is format-neutral, but it enables table formats and other metadata-aware readers to avoid the status lookup when they can guarantee the length. Existing path- and status-based construction retain their current behavior. This follows up on the known-length optimization discussed in #3395.

The change also raises the Hadoop baseline from 3.3.0 to 3.3.5, where `FS_OPTION_OPENFILE_LENGTH` was standardized and supported by S3A.

Summary:

- Add `HadoopInputFile.fromPath(Path, long, Configuration)`.
- Preserve `FileStatus` as the preferred open hint when one is already available.
- Otherwise pass the known length through `FS_OPTION_OPENFILE_LENGTH`.
- Reject negative lengths and document that the supplied length is trusted without validation.

Testing:

- `./mvnw -pl parquet-hadoop -Dtest=TestHadoopOpenFile test`
- `./mvnw -q -pl parquet-hadoop -DskipTests spotless:check`
