### PR TITLE
GH-3618: Ban JUnit4 imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,13 @@
 
         <plugin>
           <artifactId>maven-enforcer-plugin</artifactId>
+          <dependencies>
+            <dependency>
+              <groupId>de.skuzzle.enforcer</groupId>
+              <artifactId>restrict-imports-enforcer-rule</artifactId>
+              <version>3.0.0</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <id>enforce-banned-dependencies</id>
@@ -324,6 +331,34 @@
                       <exclude>org.slf4j:slf4j-reload4j:*:*:compile</exclude>
                     </excludes>
                   </bannedDependencies>
+                </rules>
+                <fail>true</fail>
+              </configuration>
+            </execution>
+            <execution>
+              <id>enforce-banned-junit4-imports</id>
+              <phase>process-test-sources</phase>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <RestrictImports>
+                    <reason>Use JUnit 5 (org.junit.jupiter.*) and AssertJ instead of JUnit 4</reason>
+                    <includeTestCode>true</includeTestCode>
+                    <bannedImports>
+                      <bannedImport>org.junit.**</bannedImport>
+                      <bannedImport>junit.framework.**</bannedImport>
+                    </bannedImports>
+                    <allowedImports>
+                      <allowedImport>org.junit.jupiter.**</allowedImport>
+                      <allowedImport>org.junit.platform.**</allowedImport>
+                    </allowedImports>
+                    <!-- Benchmark tests rely on JUnit 4 @Rule via junit-benchmarks with jupiter migration support -->
+                    <exclusions>
+                      <exclusion>org.apache.parquet.column.values.**.benchmark.**</exclusion>
+                    </exclusions>
+                  </RestrictImports>
                 </rules>
                 <fail>true</fail>
               </configuration>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
This bans JUnit4 imports and forces people to use JUnit5 + AssertJ

### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?
no

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
