### PR TITLE
PARQUET: Restore LICENSE and NOTICE files in packaged JARs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -485,14 +485,6 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-remote-resources-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
           <argLine>${extraJavaTestArgs}</argLine>


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Part of #3687

ASF [release policy](https://www.apache.org/legal/release-policy.html#licensing-documentation) requires JARs to include `LICENSE` and `NOTICE` under `META-INF`.
Note that this PR only adds the `LICENSE` and `NOTICE` files back to the jars. We still need to follow up and validate the content of those files.

#### Background
The shared ASF Maven parent (`org.apache:apache:39`) configures `maven-remote-resources-plugin` to generate `LICENSE` and `NOTICE` files and include them in each project’s JAR.

For example, `parquet-avro` and `parquet-cli` provide both files directly, while several other modules provide only one or neither. This results in inconsistent licensing metadata across the published JARs.

The `skip=true` configuration was introduced in [#284](https://github.com/apache/parquet-java/pull/284) ([commit 57694790](https://github.com/apache/parquet-java/commit/57694790f8ca0e1a4f3ac76fbd25a6dd13041e03)) as part of the Cascading 3 changes.

### What changes are included in this PR?
Remove `skip=true` from `maven-remote-resources-plugin`

### Are these changes tested?
Yes manually.

59 local JARs total:
- 15 main
- 15 test
- 15 source
- 13 Javadoc
- 1 CLI runtime

Build all jars and validate each contains both `LICENSE` and `NOTICE`:
```
(
  set -euo pipefail

  ./mvnw clean verify source:jar-no-fork javadoc:jar -DskipTests

  expected=59
  count=0

  while IFS= read -r -d '' jar_file; do
    contents=$(jar tf "$jar_file")

    grep -qx 'META-INF/LICENSE' <<<"$contents" ||
      { echo "Missing META-INF/LICENSE: $jar_file"; exit 1; }

    grep -qx 'META-INF/NOTICE' <<<"$contents" ||
      { echo "Missing META-INF/NOTICE: $jar_file"; exit 1; }

    count=$((count + 1))
  done < <(
    # Exclude maven-shade-plugin backups and the local-only JMH uber-JAR;
    # neither is attached or published by Maven.
    find . -path '*/target/*.jar' -type f \
      ! -name 'original-*' \
      ! -name 'parquet-benchmarks.jar' \
      -print0
  )

  [[ "$count" -eq "$expected" ]] ||
    { echo "Expected $expected published JARs, found $count"; exit 1; }

  echo "Verified $count published JARs"
)
```

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:41 min
[INFO] Finished at: 2026-07-26T12:24:50-07:00
[INFO] ------------------------------------------------------------------------
Verified 59 published JARs
```

### Are there any user-facing changes?
No

<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
