### PR TITLE
GH-3691: Add RAT excludes file

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -1,0 +1,41 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+.github/PULL_REQUEST_TEMPLATE.md
+**/*.parquet
+**/*.avro
+**/*.json
+**/*.avsc
+**/*.iml
+**/*.log
+**/*.md.vm
+**/.classpath
+**/.project
+**/.settings/**
+**/build/**
+**/target/**
+.git/**
+.gitignore
+.gitmodules
+.idea/**
+*/jdiff/*.xml
+licenses/**
+protobuf_install/**
+thrift-*/**
+thrift-*.tar.gz
+**/dependency-reduced-pom.xml
+**/*.rej

--- a/pom.xml
+++ b/pom.xml
@@ -560,32 +560,7 @@
         </executions>
         <configuration>
           <consoleOutput>true</consoleOutput>
-          <excludes>
-            <exclude>.github/PULL_REQUEST_TEMPLATE.md</exclude>
-            <exclude>**/*.parquet</exclude>
-            <exclude>**/*.avro</exclude>
-            <exclude>**/*.json</exclude>
-            <exclude>**/*.avsc</exclude>
-            <exclude>**/*.iml</exclude>
-            <exclude>**/*.log</exclude>
-            <exclude>**/*.md.vm</exclude>
-            <exclude>**/.classpath</exclude>
-            <exclude>**/.project</exclude>
-            <exclude>**/.settings/**</exclude>
-            <exclude>**/build/**</exclude>
-            <exclude>**/target/**</exclude>
-            <exclude>.git/**</exclude>
-            <exclude>.gitignore</exclude>
-            <exclude>.gitmodules</exclude>
-            <exclude>.idea/**</exclude>
-            <exclude>*/jdiff/*.xml</exclude>
-            <exclude>licenses/**</exclude>
-            <exclude>protobuf_install/**</exclude>
-            <exclude>thrift-${thrift.version}/**</exclude>
-            <exclude>thrift-${thrift.version}.tar.gz</exclude>
-            <exclude>**/dependency-reduced-pom.xml</exclude>
-            <exclude>**/*.rej</exclude>
-          </excludes>
+          <excludesFile>${maven.multiModuleProjectDirectory}/.rat-excludes</excludesFile>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If you're new to Parquet-Java, information on how to contribute can be found here: https://parquet.apache.org/docs/contribution-guidelines/contributing

Please open a GitHub issue for this pull request: https://github.com/apache/parquet-java/issues/new/choose
and format pull request title as below:

    GH-${GITHUB_ISSUE_ID}: ${SUMMARY}

or simply use the title below if it is a minor issue:

    MINOR: ${SUMMARY}

-->

### Rationale for this change
Part of #3691

Use `.rat-excludes` file

### What changes are included in this PR?
- Move Apache RAT exclusions from `pom.xml` to `.rat-excludes`.
- Keep the inherited RAT version unchanged.

### Are these changes tested?
Yes, with `./mvnw -DskipTests apache-rat:check`

### Are there any user-facing changes?
No


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
