### PR TITLE
MINOR: Respect ByteBuffer offset in Binary equality

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -538,7 +538,7 @@ public abstract class Binary implements Comparable<Binary>, Serializable {
 
     @Override
     boolean equals(ByteBuffer otherBytes, int otherOffset, int otherLength) {
-      return Binary.equals(value, 0, length, otherBytes, otherOffset, otherLength);
+      return Binary.equals(value, offset, length, otherBytes, otherOffset, otherLength);
     }
 
     @Override

--- a/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
@@ -245,6 +245,29 @@ public class TestBinary {
   }
 
   @Test
+  public void testDirectByteBufferEqualityWithOffset() {
+    ByteBuffer slicedBuffer = ByteBuffer.allocateDirect(3);
+    slicedBuffer.put(new byte[] {9, 1, 2});
+    slicedBuffer.position(1);
+    Binary sliced = Binary.fromConstantByteBuffer(slicedBuffer);
+
+    ByteBuffer equalBuffer = ByteBuffer.allocateDirect(2);
+    equalBuffer.put(new byte[] {1, 2});
+    equalBuffer.flip();
+    Binary equal = Binary.fromConstantByteBuffer(equalBuffer);
+
+    ByteBuffer differentBuffer = ByteBuffer.allocateDirect(2);
+    differentBuffer.put(new byte[] {9, 1});
+    differentBuffer.flip();
+    Binary different = Binary.fromConstantByteBuffer(differentBuffer);
+
+    assertThat(sliced).isEqualTo(equal);
+    assertThat(equal).isEqualTo(sliced);
+    assertThat(sliced.hashCode()).isEqualTo(equal.hashCode());
+    assertThat(different).isNotEqualTo(sliced);
+  }
+
+  @Test
   public void testWriteAllTo() throws Exception {
     byte[] orig = {10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
     testWriteAllToHelper(Binary.fromConstantByteBuffer(ByteBuffer.wrap(orig)), orig);


### PR DESCRIPTION
### Rationale for this change

`ByteBufferBackedBinary.equals(ByteBuffer, int, int)` compares from index 0 instead of the binary’s stored offset. For direct buffers with a non-zero position, this can make equal values compare unequal and can also make different values compare equal when prefix bytes happen to match.

### What changes are included in this PR?

Use the stored offset when comparing a `ByteBufferBackedBinary` with another `ByteBuffer`. Add regression coverage for equality symmetry, matching hash codes, and unequal values whose prefix bytes match.

### Are these changes tested?

Yes. `TestBinary` passes with 16 tests, and the Spotless check passes.

### Are there any user-facing changes?

Equality for direct `ByteBuffer`-backed binaries now uses the bytes represented by the binary slice.