### PR TITLE
MINOR: Preserve ByteBuffer order in little-endian reads

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -24,7 +24,6 @@ import java.io.ObjectStreamException;
 import java.io.OutputStream;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
@@ -587,7 +586,7 @@ public abstract class Binary implements Comparable<Binary>, Serializable {
         throw new IllegalArgumentException("length must be 2");
       }
 
-      return value.order(ByteOrder.LITTLE_ENDIAN).getShort(offset);
+      return (short) (((value.get(offset + 1) & 0xff) << 8) | (value.get(offset) & 0xff));
     }
 
     @Override

--- a/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
+++ b/parquet-column/src/main/java/org/apache/parquet/io/api/Binary.java
@@ -587,7 +587,7 @@ public abstract class Binary implements Comparable<Binary>, Serializable {
         throw new IllegalArgumentException("length must be 2");
       }
 
-      return value.order(ByteOrder.LITTLE_ENDIAN).getShort(offset);
+      return value.duplicate().order(ByteOrder.LITTLE_ENDIAN).getShort(offset);
     }
 
     @Override

--- a/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/io/api/TestBinary.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import org.apache.parquet.io.ParquetEncodingException;
@@ -420,6 +421,27 @@ public class TestBinary {
     // ByteArraySliceBackedBinary: get2BytesLittleEndian
     Binary b3 = Binary.fromConstantByteArray(new byte[] {0x00, 0x01, 0x02, 0x03}, 1, 2);
     assertThat(b3.get2BytesLittleEndian()).isEqualTo((short) 0x0201);
+  }
+
+  @Test
+  public void testGet2BytesLittleEndianPreservesByteBufferOrder() {
+    assertGet2BytesLittleEndianPreservesOrder(ByteBuffer.wrap(new byte[] {0x01, 0x02}));
+
+    ByteBuffer direct = ByteBuffer.allocateDirect(2);
+    direct.put(new byte[] {0x01, 0x02});
+    direct.flip();
+    assertGet2BytesLittleEndianPreservesOrder(direct);
+
+    assertGet2BytesLittleEndianPreservesOrder(
+        ByteBuffer.wrap(new byte[] {0x01, 0x02}).asReadOnlyBuffer());
+  }
+
+  private static void assertGet2BytesLittleEndianPreservesOrder(ByteBuffer buffer) {
+    buffer.order(ByteOrder.BIG_ENDIAN);
+    Binary binary = Binary.fromConstantByteBuffer(buffer);
+
+    assertThat(binary.get2BytesLittleEndian()).isEqualTo((short) 0x0201);
+    assertThat(buffer.order()).isEqualTo(ByteOrder.BIG_ENDIAN);
   }
 
   @Test


### PR DESCRIPTION
### Rationale for this change

`ByteBufferBackedBinary.get2BytesLittleEndian()` currently changes the byte order of its backing `ByteBuffer` to little endian. Because the buffer can be caller-owned, reading the binary can unexpectedly affect subsequent reads through the original buffer.

### What changes are included in this PR?

Read the short through a duplicate buffer so the original buffer order remains unchanged.

### Are these changes tested?

Yes. The regression test verifies the returned value and preserves the original big-endian order for heap, direct, and read-only buffers. The complete `TestBinary` class and Spotless check pass.

### Are there any user-facing changes?

Calling `get2BytesLittleEndian()` no longer changes the order of the caller-owned backing buffer.