### PR TITLE
GH-3715: Validate dictionary IDs while decoding

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/DictionaryValuesReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/values/dictionary/DictionaryValuesReader.java
@@ -39,10 +39,13 @@ public class DictionaryValuesReader extends ValuesReader {
 
   private Dictionary dictionary;
 
+  private final int maxDictionaryId;
+
   private RunLengthBitPackingHybridDecoder decoder;
 
   public DictionaryValuesReader(Dictionary dictionary) {
     this.dictionary = dictionary;
+    this.maxDictionaryId = dictionary.getMaxId();
   }
 
   @Override
@@ -65,62 +68,51 @@ public class DictionaryValuesReader extends ValuesReader {
 
   @Override
   public int readValueDictionaryId() {
-    try {
-      return decoder.readInt();
-    } catch (IOException e) {
-      throw new ParquetDecodingException(e);
-    }
+    return readDictionaryId();
   }
 
   @Override
   public Binary readBytes() {
-    try {
-      return dictionary.decodeToBinary(decoder.readInt());
-    } catch (IOException e) {
-      throw new ParquetDecodingException(e);
-    }
+    return dictionary.decodeToBinary(readDictionaryId());
   }
 
   @Override
   public float readFloat() {
-    try {
-      return dictionary.decodeToFloat(decoder.readInt());
-    } catch (IOException e) {
-      throw new ParquetDecodingException(e);
-    }
+    return dictionary.decodeToFloat(readDictionaryId());
   }
 
   @Override
   public double readDouble() {
-    try {
-      return dictionary.decodeToDouble(decoder.readInt());
-    } catch (IOException e) {
-      throw new ParquetDecodingException(e);
-    }
+    return dictionary.decodeToDouble(readDictionaryId());
   }
 
   @Override
   public int readInteger() {
-    try {
-      return dictionary.decodeToInt(decoder.readInt());
-    } catch (IOException e) {
-      throw new ParquetDecodingException(e);
-    }
+    return dictionary.decodeToInt(readDictionaryId());
   }
 
   @Override
   public long readLong() {
-    try {
-      return dictionary.decodeToLong(decoder.readInt());
-    } catch (IOException e) {
-      throw new ParquetDecodingException(e);
-    }
+    return dictionary.decodeToLong(readDictionaryId());
   }
 
   @Override
   public void skip() {
     try {
       decoder.readInt(); // Type does not matter as we are just skipping dictionary keys
+    } catch (IOException e) {
+      throw new ParquetDecodingException(e);
+    }
+  }
+
+  private int readDictionaryId() {
+    try {
+      int id = decoder.readInt();
+      if (id < 0 || id > maxDictionaryId) {
+        throw new ParquetDecodingException(
+            "Dictionary id " + id + " is outside the valid range 0 to " + maxDictionaryId);
+      }
+      return id;
     } catch (IOException e) {
       throw new ParquetDecodingException(e);
     }

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
@@ -25,6 +25,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Offset.offset;
 
 import java.io.IOException;
@@ -50,6 +51,7 @@ import org.apache.parquet.column.values.fallback.FallbackValuesWriter;
 import org.apache.parquet.column.values.plain.BinaryPlainValuesReader;
 import org.apache.parquet.column.values.plain.PlainValuesReader;
 import org.apache.parquet.column.values.plain.PlainValuesWriter;
+import org.apache.parquet.io.ParquetDecodingException;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.junit.jupiter.api.AfterEach;
@@ -801,6 +803,22 @@ public class TestDictionary {
       int offset = bytes.remaining();
       reader.initFromPage(100, bytes, offset);
     }
+  }
+
+  @Test
+  public void testInvalidDictionaryId() throws IOException {
+    BytesInput dictionaryBytes = BytesInput.fromInt(34);
+    DictionaryPage dictionaryPage = new DictionaryPage(dictionaryBytes, 1, PLAIN);
+    ColumnDescriptor descriptor = new ColumnDescriptor(new String[] {"foo"}, INT32, 0, 0);
+    Dictionary dictionary = PLAIN.initDictionary(descriptor, dictionaryPage);
+    DictionaryValuesReader reader = new DictionaryValuesReader(dictionary);
+
+    // A bit width of 1 can represent dictionary id 1, but this dictionary only contains id 0.
+    reader.initFromPage(1, BytesInput.from(new byte[] {0x01, 0x02, 0x01}).toInputStream());
+
+    assertThatThrownBy(reader::readInteger)
+        .isInstanceOf(ParquetDecodingException.class)
+        .hasMessage("Dictionary id 1 is outside the valid range 0 to 0");
   }
 
   @Test


### PR DESCRIPTION
### Rationale for this change

Dictionary-encoded data pages may contain an ID that exceeds the valid range of the associated dictionary. Currently, this causes an `ArrayIndexOutOfBoundsException` when the dictionary implementation accesses its backing array, obscuring the actual data corruption.

### What changes are included in this PR?

- Validate decoded dictionary IDs against the dictionary's maximum ID.
- Throw a descriptive `ParquetDecodingException` when an ID is outside the valid range.
- Apply validation to typed value reads and `readValueDictionaryId()`.
- Add a regression test covering an out-of-range dictionary ID.

### Are these changes tested?

Yes. A unit test constructs a dictionary-encoded page containing an out-of-range ID and verifies that reading it throws a descriptive `ParquetDecodingException`.

```shell
./mvnw -pl parquet-column -Dtest=TestDictionary test
```

### Are there any user-facing changes?

Yes. Corrupt dictionary-encoded data now produces a descriptive `ParquetDecodingException` instead of exposing an internal `ArrayIndexOutOfBoundsException`. Valid Parquet files are unaffected.

Closes #3715
