### PR TITLE
Fix Maven parent and JUnit test compatibility

### DIFF
--- a/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitScalarOptTest.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/bytestreamsplit/ByteStreamSplitScalarOptTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.parquet.column.values.bytestreamsplit;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
 import java.util.Random;
@@ -26,7 +26,7 @@ import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.bytes.BytesInput;
 import org.apache.parquet.bytes.DirectByteBufferAllocator;
 import org.apache.parquet.io.api.Binary;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the BYTE_STREAM_SPLIT scalar performance optimizations:
@@ -79,14 +79,14 @@ public class ByteStreamSplitScalarOptTest {
       writer.writeBytes(v);
     }
     BytesInput input = writer.getBytes();
-    assertEquals(numElements * typeLength, input.size());
+    assertThat(input.size()).isEqualTo(numElements * typeLength);
 
     ByteStreamSplitValuesReaderForFLBA reader = new ByteStreamSplitValuesReaderForFLBA(typeLength);
     reader.initFromPage(numElements, ByteBufferInputStream.wrap(input.toByteBuffer()));
 
     // Scalar read to verify each value
     for (int i = 0; i < numElements; i++) {
-      assertEquals("Mismatch at index " + i, values[i], reader.readBytes());
+      assertThat(reader.readBytes()).as("Mismatch at index " + i).isEqualTo(values[i]);
     }
 
     writer.reset();
@@ -151,7 +151,7 @@ public class ByteStreamSplitScalarOptTest {
     reader.initFromPage(numElements, ByteBufferInputStream.wrap(input.toByteBuffer()));
 
     for (int i = 0; i < numElements; i++) {
-      assertEquals("Mismatch at index " + i, values[i], reader.readInteger());
+      assertThat(reader.readInteger()).as("Mismatch at index " + i).isEqualTo(values[i]);
     }
 
     writer.reset();
@@ -174,7 +174,7 @@ public class ByteStreamSplitScalarOptTest {
     reader.initFromPage(numElements, ByteBufferInputStream.wrap(input.toByteBuffer()));
 
     for (int i = 0; i < numElements; i++) {
-      assertEquals("Mismatch at index " + i, values[i], reader.readLong());
+      assertThat(reader.readLong()).as("Mismatch at index " + i).isEqualTo(values[i]);
     }
 
     writer.reset();
@@ -195,16 +195,16 @@ public class ByteStreamSplitScalarOptTest {
     for (int i = 0; i < 10; i++) {
       writer.writeInteger(i);
     }
-    assertEquals(10 * 4, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(10 * 4);
 
     // Write more to cross a batch boundary
     for (int i = 0; i < BATCH_SIZE; i++) {
       writer.writeInteger(i);
     }
-    assertEquals((10 + BATCH_SIZE) * 4, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo((10 + BATCH_SIZE) * 4);
 
     writer.reset();
-    assertEquals(0, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(0);
     writer.close();
   }
 
@@ -217,10 +217,10 @@ public class ByteStreamSplitScalarOptTest {
     for (int i = 0; i < 10; i++) {
       writer.writeLong(i);
     }
-    assertEquals(10 * 8, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(10 * 8);
 
     writer.reset();
-    assertEquals(0, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(0);
     writer.close();
   }
 
@@ -255,7 +255,7 @@ public class ByteStreamSplitScalarOptTest {
     reader.initFromPage(numElements, ByteBufferInputStream.wrap(direct));
 
     for (int i = 0; i < numElements; i++) {
-      assertEquals("Mismatch at index " + i, values[i], reader.readFloat(), 0.0f);
+      assertThat(reader.readFloat()).as("Mismatch at index " + i).isEqualTo(values[i]);
     }
 
     writer.reset();
@@ -284,7 +284,7 @@ public class ByteStreamSplitScalarOptTest {
     reader.initFromPage(numElements, ByteBufferInputStream.wrap(direct));
 
     for (int i = 0; i < numElements; i++) {
-      assertEquals("Mismatch at index " + i, values[i], reader.readLong());
+      assertThat(reader.readLong()).as("Mismatch at index " + i).isEqualTo(values[i]);
     }
 
     writer.reset();
@@ -322,7 +322,7 @@ public class ByteStreamSplitScalarOptTest {
     reader.initFromPage(numElements, ByteBufferInputStream.wrap(direct));
 
     for (int i = 0; i < numElements; i++) {
-      assertEquals("Mismatch at index " + i, values[i], reader.readBytes());
+      assertThat(reader.readBytes()).as("Mismatch at index " + i).isEqualTo(values[i]);
     }
 
     writer.reset();
@@ -347,7 +347,7 @@ public class ByteStreamSplitScalarOptTest {
       rand.nextBytes(bytes);
       writer.writeBytes(Binary.fromConstantByteArray(bytes));
     }
-    assertEquals(10 * typeLength, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(10 * typeLength);
 
     // Write more to cross a batch boundary
     for (int i = 0; i < BATCH_SIZE; i++) {
@@ -355,10 +355,10 @@ public class ByteStreamSplitScalarOptTest {
       rand.nextBytes(bytes);
       writer.writeBytes(Binary.fromConstantByteArray(bytes));
     }
-    assertEquals((10 + BATCH_SIZE) * typeLength, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo((10 + BATCH_SIZE) * typeLength);
 
     writer.reset();
-    assertEquals(0, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(0);
     writer.close();
   }
 
@@ -375,9 +375,9 @@ public class ByteStreamSplitScalarOptTest {
     for (int i = 0; i < 10; i++) {
       writer.writeInteger(i);
     }
-    assertEquals(10 * 4, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(10 * 4);
     writer.close();
-    assertEquals(0, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(0);
   }
 
   @Test
@@ -388,9 +388,9 @@ public class ByteStreamSplitScalarOptTest {
     for (int i = 0; i < 10; i++) {
       writer.writeLong(i);
     }
-    assertEquals(10 * 8, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(10 * 8);
     writer.close();
-    assertEquals(0, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(0);
   }
 
   @Test
@@ -405,9 +405,9 @@ public class ByteStreamSplitScalarOptTest {
       rand.nextBytes(bytes);
       writer.writeBytes(Binary.fromConstantByteArray(bytes));
     }
-    assertEquals(10 * typeLength, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(10 * typeLength);
     writer.close();
-    assertEquals(0, writer.getBufferedSize());
+    assertThat(writer.getBufferedSize()).isEqualTo(0);
   }
 
   // ---------------------------------------------------------------------------
@@ -453,7 +453,7 @@ public class ByteStreamSplitScalarOptTest {
     reader.initFromPage(numElements, ByteBufferInputStream.wrap(direct));
 
     for (int i = 0; i < numElements; i++) {
-      assertEquals("Mismatch at index " + i, values[i], reader.readBytes());
+      assertThat(reader.readBytes()).as("Mismatch at index " + i).isEqualTo(values[i]);
     }
 
     writer.reset();

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestConcatenatingByteBufferCollector.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestConcatenatingByteBufferCollector.java
@@ -118,17 +118,17 @@ public class TestConcatenatingByteBufferCollector {
     collector.collect(BytesInput.from(bytes(" ")));
     collector.collect(BytesInput.from(bytes("World")));
 
-    Assert.assertEquals(11, collector.size());
+    assertThat(collector.size()).isEqualTo(11);
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     collector.writeAllTo(baos);
     result = baos.toByteArray();
 
     // After writeAllTo, the collector should be empty (buffers released progressively)
-    Assert.assertEquals(0, collector.size());
+    assertThat(collector.size()).isEqualTo(0);
 
     // Verify the data was written correctly
-    Assert.assertEquals("Hello World", new String(result, StandardCharsets.UTF_8));
+    assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("Hello World");
 
     // close() after writeAllTo is a safe no-op
     collector.close();
@@ -139,11 +139,11 @@ public class TestConcatenatingByteBufferCollector {
     ConcatenatingByteBufferCollector collector = new ConcatenatingByteBufferCollector(allocator);
     collector.collect(BytesInput.from(bytes("test data")));
 
-    Assert.assertEquals(9, collector.size());
+    assertThat(collector.size()).isEqualTo(9);
 
     // First close releases the buffers
     collector.close();
-    Assert.assertEquals(0, collector.size());
+    assertThat(collector.size()).isEqualTo(0);
 
     // Second close should be a no-op and not throw
     collector.close();
@@ -172,7 +172,7 @@ public class TestConcatenatingByteBufferCollector {
     result = baos.toByteArray();
 
     // Verify size: 4 (int) + 7 (string) + 4 (int) = 15 bytes
-    Assert.assertEquals(15, result.length);
+    assertThat(result.length).isEqualTo(15);
 
     // Already released by writeAllTo, close is a no-op
     collector.close();

--- a/parquet-plugins/parquet-encoding-vector/pom.xml
+++ b/parquet-plugins/parquet-encoding-vector/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.19.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/parquet-plugins/parquet-plugins-benchmarks/pom.xml
+++ b/parquet-plugins/parquet-plugins-benchmarks/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.parquet</groupId>
     <artifactId>parquet</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.19.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 


### PR DESCRIPTION
### Rationale for this change

The project version is now `1.19.0-SNAPSHOT`, but the vector plugin modules still declared `1.18.0-SNAPSHOT` as their parent. Once that reactor issue was corrected, CI exposed two test files that still used JUnit 4 even though this repository enforces JUnit 5 and AssertJ for non-benchmark tests.

### What changes are included in this PR?

- Update the parent version in `parquet-encoding-vector` to `1.19.0-SNAPSHOT`.
- Update the parent version in `parquet-plugins-benchmarks` to `1.19.0-SNAPSHOT`.
- Migrate `TestConcatenatingByteBufferCollector` assertions to AssertJ.
- Migrate `ByteStreamSplitScalarOptTest` to JUnit 5 and AssertJ.

### Are these changes tested?

The existing `Vector-plugins` and `CI Hadoop 3` workflows cover the updated Maven reactor and test sources.

### Are there any user-facing changes?

No. This aligns Maven metadata and test conventions so the existing CI/build can resolve the correct parent version and compile the tests.
