### PR TITLE
`toByteArray` should return a copy not a reference

### DIFF
--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
@@ -45,6 +45,7 @@ import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainD
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFloatDictionaryValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainLongDictionaryValuesWriter;
+import org.apache.parquet.column.values.dictionary.PlainValuesDictionary.PlainBinaryDictionary;
 import org.apache.parquet.column.values.dictionary.PlainValuesDictionary.PlainBooleanDictionary;
 import org.apache.parquet.column.values.fallback.FallbackValuesWriter;
 import org.apache.parquet.column.values.plain.BinaryPlainValuesReader;
@@ -801,6 +802,17 @@ public class TestDictionary {
       int offset = bytes.remaining();
       reader.initFromPage(100, bytes, offset);
     }
+  }
+
+  @Test
+  public void testDictionaryPageCopyDoesNotAliasSourceBytes() throws IOException {
+    byte[] source = {1, 0, 0, 0, 'a'};
+    DictionaryPage copied = new DictionaryPage(BytesInput.from(source), 1, PLAIN).copy();
+
+    source[4] = 'b';
+
+    PlainBinaryDictionary dictionary = new PlainBinaryDictionary(copied);
+    assertThat(dictionary.decodeToBinary(0).toStringUsingUTF8()).isEqualTo("a");
   }
 
   @Test

--- a/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/values/dictionary/TestDictionary.java
@@ -45,7 +45,6 @@ import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainD
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainFloatDictionaryValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainIntegerDictionaryValuesWriter;
 import org.apache.parquet.column.values.dictionary.DictionaryValuesWriter.PlainLongDictionaryValuesWriter;
-import org.apache.parquet.column.values.dictionary.PlainValuesDictionary.PlainBinaryDictionary;
 import org.apache.parquet.column.values.dictionary.PlainValuesDictionary.PlainBooleanDictionary;
 import org.apache.parquet.column.values.fallback.FallbackValuesWriter;
 import org.apache.parquet.column.values.plain.BinaryPlainValuesReader;
@@ -802,17 +801,6 @@ public class TestDictionary {
       int offset = bytes.remaining();
       reader.initFromPage(100, bytes, offset);
     }
-  }
-
-  @Test
-  public void testDictionaryPageCopyDoesNotAliasSourceBytes() throws IOException {
-    byte[] source = {1, 0, 0, 0, 'a'};
-    DictionaryPage copied = new DictionaryPage(BytesInput.from(source), 1, PLAIN).copy();
-
-    source[4] = 'b';
-
-    PlainBinaryDictionary dictionary = new PlainBinaryDictionary(copied);
-    assertThat(dictionary.decodeToBinary(0).toStringUsingUTF8()).isEqualTo("a");
   }
 
   @Test

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -690,12 +690,6 @@ public abstract class BytesInput {
       return java.nio.ByteBuffer.wrap(in, offset, length);
     }
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public byte[] toByteArray() {
-      return Arrays.copyOfRange(in, offset, offset + length);
-    }
-
     @Override
     public long size() {
       return length;

--- a/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
+++ b/parquet-common/src/main/java/org/apache/parquet/bytes/BytesInput.java
@@ -690,18 +690,9 @@ public abstract class BytesInput {
       return java.nio.ByteBuffer.wrap(in, offset, length);
     }
 
-    /**
-     * Zero-copy override: returns the backing array directly when fully used,
-     * skipping the base-class BAOS allocation + copy on every decompressor call.
-     * Returning the mutable array is safe — the base class already exposes a
-     * mutable {@code BAOS.getBuf()}.
-     */
     @SuppressWarnings("deprecation")
     @Override
     public byte[] toByteArray() {
-      if (offset == 0 && length == in.length) {
-        return in;
-      }
       return Arrays.copyOfRange(in, offset, offset + length);
     }
 

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
@@ -123,16 +123,16 @@ public class TestBytesInput {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("parameters")
-  public void testFromByteArrayToByteArrayZeroCopy(ByteBufferAllocator innerAllocator) throws IOException {
+  public void testFromByteArrayToByteArrayCopiesFullArray(ByteBufferAllocator innerAllocator) throws IOException {
     initAllocator(innerAllocator);
-    // Full array (offset=0, length=array.length): toByteArray() returns the backing array directly
     byte[] data = new byte[1000];
     RANDOM.nextBytes(data);
     BytesInput bi = BytesInput.from(data, 0, data.length);
     byte[] result = bi.toByteArray();
     assertThat(result)
-        .as("toByteArray() should return the backing array when offset=0 and length=full")
-        .isSameAs(data);
+        .as("toByteArray() should materialize a copy when offset=0 and length=full")
+        .isEqualTo(data)
+        .isNotSameAs(data);
   }
 
   @ParameterizedTest(name = "{0}")

--- a/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
+++ b/parquet-common/src/test/java/org/apache/parquet/bytes/TestBytesInput.java
@@ -123,16 +123,14 @@ public class TestBytesInput {
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("parameters")
-  public void testFromByteArrayToByteArrayCopiesFullArray(ByteBufferAllocator innerAllocator) throws IOException {
+  public void testCopyDoesNotAliasSourceBytes(ByteBufferAllocator innerAllocator) throws IOException {
     initAllocator(innerAllocator);
-    byte[] data = new byte[1000];
-    RANDOM.nextBytes(data);
-    BytesInput bi = BytesInput.from(data, 0, data.length);
-    byte[] result = bi.toByteArray();
-    assertThat(result)
-        .as("toByteArray() should materialize a copy when offset=0 and length=full")
-        .isEqualTo(data)
-        .isNotSameAs(data);
+    byte[] source = {'a'};
+    BytesInput copied = BytesInput.copy(BytesInput.from(source));
+
+    source[0] = 'b';
+
+    assertThat(copied.toByteArray()).isEqualTo(new byte[] {'a'});
   }
 
   @ParameterizedTest(name = "{0}")


### PR DESCRIPTION
#3565 introduced several optimizations, but I think it also introduced an issue that PR seeks to address.  Basically `BytesInput.copy(BytesInput)` has a public contract to return a copy, but a change to `BytesInput.toByteArray()` led to returning a reference in some cases.  In addition to breaking the public contract, this can lead to data corruption.

See also #3717 