### PR TITLE
Upgrade Avro dependency from 1.11.5 to 1.12.2

### DIFF
--- a/parquet-avro/pom.xml
+++ b/parquet-avro/pom.xml
@@ -207,8 +207,9 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <systemPropertyVariables>
-            <!-- We need to set this system property to allow Avro to serialize these classes via the specific/reflect models -->
+            <!-- We need to set these system properties to allow Avro to serialize these classes via the specific/reflect models -->
             <org.apache.avro.SERIALIZABLE_CLASSES>java.math.BigDecimal</org.apache.avro.SERIALIZABLE_CLASSES>
+            <org.apache.avro.SERIALIZABLE_PACKAGES>org.apache.parquet.avro,java.util</org.apache.avro.SERIALIZABLE_PACKAGES>
           </systemPropertyVariables>
         </configuration>
       </plugin>

--- a/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
+++ b/parquet-avro/src/main/java/org/apache/parquet/avro/AvroRecordConverter.java
@@ -787,7 +787,7 @@ class AvroRecordConverter<T> extends AvroConverters.AvroGroupConverter {
       } else if (elementClass == double.class) {
         parent.add(((DoubleArrayList) container).toDoubleArray());
       } else {
-        parent.add(((ArrayList) container).toArray());
+        parent.add(container.toArray((Object[]) java.lang.reflect.Array.newInstance(elementClass, 0)));
       }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <fastutil.version>8.5.19</fastutil.version>
     <semver.api.version>0.9.33</semver.api.version>
     <slf4j.version>1.7.33</slf4j.version>
-    <avro.version>1.11.5</avro.version>
+    <avro.version>1.12.2</avro.version>
     <guava.version>33.7.1-jre</guava.version>
     <brotli-codec.version>0.1.1</brotli-codec.version>
     <assertj.version>3.27.7</assertj.version>


### PR DESCRIPTION
### Rationale for this change

Upgrades the Avro dependency from 1.11.5 to 1.12.2.

Avro 1.12 introduces some behavioral and API-compatibility changes that require corresponding adjustments in `parquet-avro`:

- **Null `logicalType` NPE**: `GenericData.getConversionByClass` no longer null-checks `logicalType` internally, so `AvroRecordConverter.newConverter` now guards against a null `logicalType` to avoid an NPE.
- **Stricter array typing**: Avro 1.12's `ReflectData.setField` performs stricter type checks, so `AvroArrayConverter.end` now creates a typed array (via `Array.newInstance(elementClass, 0)`) instead of an untyped `Object[]`.
- **ClassSecurityValidator**: Avro 1.12's `ClassSecurityValidator` requires whitelisting serializable packages; the `org.apache.avro.SERIALIZABLE_PACKAGES` surefire system property is added for the tests.

### What changes are included in this PR?

- Bump `avro.version` to `1.12.2` in the root `pom.xml`.
- Guard against null `logicalType` in `AvroRecordConverter.newConverter`.
- Create typed arrays instead of `Object[]` in `AvroArrayConverter.end`.
- Add the `SERIALIZABLE_PACKAGES` surefire property in `parquet-avro/pom.xml`.

### Are these changes tested?

Yes, covered by the existing `parquet-avro` test suite.

### Are there any user-facing changes?

Users of `parquet-avro` will now pull in Avro 1.12.2.