### PR TITLE
GH-3574: Keep null_count when min/max stats exceed the size limit

### DIFF
--- a/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverter.java
@@ -815,15 +815,17 @@ public class ParquetMetadataConverter {
   public static Statistics toParquetStatistics(
       org.apache.parquet.column.statistics.Statistics stats, int truncateLength) {
     Statistics formatStats = new Statistics();
+    if (!stats.isEmpty()) {
+      formatStats.setNull_count(stats.getNumNulls());
+      if (stats.isNanCountSet()) {
+        formatStats.setNan_count(stats.getNanCount());
+      }
+    }
     // Don't write stats larger than the max size rather than truncating. The
     // rationale is that some engines may use the minimum value in the page as
     // the true minimum for aggregations and there is no way to mark that a
     // value has been truncated and is a lower bound and not in the page.
     if (!stats.isEmpty() && withinLimit(stats, truncateLength)) {
-      formatStats.setNull_count(stats.getNumNulls());
-      if (stats.isNanCountSet()) {
-        formatStats.setNan_count(stats.getNanCount());
-      }
       if (stats.hasNonNullValue()) {
         byte[] min;
         byte[] max;

--- a/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
+++ b/parquet-hadoop/src/test/java/org/apache/parquet/format/converter/TestParquetMetadataConverter.java
@@ -878,7 +878,7 @@ public class TestParquetMetadataConverter {
     }
     assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
 
-    // convert to empty stats because the values are too large
+    // min/max are not written because the values are too large, but null count is always written
     stats.setMinMaxFromBytes(max, max);
 
     formatStats = helper.toParquetStatistics(stats);
@@ -891,9 +891,7 @@ public class TestParquetMetadataConverter {
     assertThat(formatStats.isSetMax_value())
         .as("Max_value should not be set")
         .isFalse();
-    assertThat(formatStats.isSetNull_count())
-        .as("Num nulls should not be set")
-        .isFalse();
+    assertThat(formatStats.getNull_count()).as("Num nulls should match").isEqualTo(3004);
 
     Statistics roundTripStats = ParquetMetadataConverter.fromParquetStatisticsInternal(
         Version.FULL_VERSION,
@@ -903,7 +901,10 @@ public class TestParquetMetadataConverter {
 
     assertThat(roundTripStats.isEmpty())
         .as("Round-trip stats should not be empty (null count is set)")
-        .isTrue();
+        .isFalse();
+    assertThat(roundTripStats.getNumNulls())
+        .as("Round-trip null count should match")
+        .isEqualTo(3004);
   }
 
   @Test


### PR DESCRIPTION
### Rationale for this change

When column statistics exceed the max size for truncation, `toParquetStatistics` currently omits the entire `Statistics` payload, including `null_count`. Dropping min/max is reasonable (there is no way to mark a truncated bound as a lower/upper bound rather than a true min/max). `null_count` and `nan_count` are tiny counters and should still be written.

Missing `null_count` causes downstream readers to treat the column as if it might contain nulls. Snowflake reports:

```
non-nullable column without default has null values according to file statistics
```

[parquet-format](https://github.com/apache/parquet-format/blob/master/src/main/thrift/parquet.thrift) recommends always writing `null_count`, even when it is zero.

This re-lands the parquet-java side of #3575 after it was reverted in #3688 to unblock a release. The format contract is that min/max and null counts are independent: `Statistics.hasNonNullValue()` vs `Statistics.isNumNullsSet()`. Consumers that assumed "all stats or no stats" should treat a missing min/max independently of a present `null_count`. Iceberg already observes `num_nulls: N, min/max not defined` on older files.

### What changes are included in this PR?

In `ParquetMetadataConverter.toParquetStatistics`, write `null_count` (and `nan_count` when set) whenever stats are non-empty, even if min/max are omitted because they exceed `MAX_STATS_SIZE`. Min/max are still not written in that case (not truncated to an unmarked bound).

### Are these changes tested?

Yes. `TestParquetMetadataConverter.testBinaryStatsV1` / `testBinaryStatsV2` now assert that oversized binary min/max are omitted while `null_count` is still written and round-trips.

```
./mvnw -pl parquet-hadoop -am test -Dtest=TestParquetMetadataConverter -Dsurefire.failIfNoSpecifiedTests=false
```

`TestParquetMetadataConverter`: 72 tests, 0 failures (Temurin 21, macOS aarch64).

On current `master` without this change, the same assertions fail (`null_count` expected 3004, actual 0).

### Are there any user-facing changes?

Yes: files with oversized column min/max now still carry `null_count` (and `nan_count` when set) in column-chunk statistics. Readers that previously assumed the statistics object was all-or-nothing should use `hasNonNullValue()` / `isSetMin_value()` for bounds and `isNumNullsSet()` / `isSetNull_count()` for nulls.

Closes #3574