### PR TITLE
GH-3747: Preserve the final selected row when skipping pages

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/impl/SynchronizingColumnReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/impl/SynchronizingColumnReader.java
@@ -85,7 +85,9 @@ class SynchronizingColumnReader extends ColumnReaderBase {
 
   @Override
   boolean isFullyConsumed() {
-    return !rowIndexes.hasNext();
+    // The final target may have been taken from the iterator without being reached yet.
+    // Long.MAX_VALUE marks that there are no more target rows.
+    return !rowIndexes.hasNext() && (currentRow >= targetRow || targetRow == Long.MAX_VALUE);
   }
 
   @Override

--- a/parquet-column/src/test/java/org/apache/parquet/column/impl/TestColumnReaderImpl.java
+++ b/parquet-column/src/test/java/org/apache/parquet/column/impl/TestColumnReaderImpl.java
@@ -18,9 +18,12 @@
  */
 package org.apache.parquet.column.impl;
 
+import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_2_0;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.parquet.Version;
 import org.apache.parquet.VersionParser;
@@ -29,7 +32,9 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ColumnReader;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.DataPageV1;
 import org.apache.parquet.column.page.DataPageV2;
 import org.apache.parquet.column.page.DictionaryPage;
 import org.apache.parquet.column.page.mem.MemPageReader;
@@ -181,5 +186,110 @@ public class TestColumnReaderImpl {
         });
 
     validateExpectedValuesAndCount(col, pageReader);
+  }
+
+  @Test
+  public void testSynchronizingLastRowV1() throws Exception {
+    testSynchronizingReader(PARQUET_1_0, false);
+  }
+
+  @Test
+  public void testSynchronizingLastRowV2() throws Exception {
+    testSynchronizingReader(PARQUET_2_0, false);
+  }
+
+  @Test
+  public void testSynchronizingLastRepeatedRowV1() throws Exception {
+    testSynchronizingReader(PARQUET_1_0, true);
+  }
+
+  @Test
+  public void testSynchronizingLastRepeatedRowV2() throws Exception {
+    testSynchronizingReader(PARQUET_2_0, true);
+  }
+
+  private void testSynchronizingReader(WriterVersion writerVersion, boolean repeated) throws Exception {
+    MessageType schema = MessageTypeParser.parseMessageType(
+        "message test { " + (repeated ? "repeated" : "optional") + " int32 foo; }");
+    ColumnDescriptor col = schema.getColumns().get(0);
+    MemPageWriter pageWriter = new MemPageWriter();
+    ParquetProperties properties = ParquetProperties.builder()
+        .withWriterVersion(writerVersion)
+        .withDictionaryEncoding(false)
+        .build();
+    ColumnWriterBase columnWriter = writerVersion == PARQUET_1_0
+        ? new ColumnWriterV1(col, pageWriter, properties)
+        : new ColumnWriterV2(col, pageWriter, properties);
+    int valuesPerRow = repeated ? 3 : 1;
+    for (int row = 0; row < 8; ++row) {
+      if (row == 6) {
+        columnWriter.writeNull(0, 0);
+      } else {
+        for (int value = 0; value < valuesPerRow; ++value) {
+          columnWriter.write(row * 10 + value, value == 0 ? 0 : 1, 1);
+        }
+      }
+      if (row % 2 == 1) {
+        columnWriter.writePage();
+      }
+    }
+    columnWriter.finalizeColumnChunk();
+    columnWriter.close();
+
+    // Exercise a final target in a later page, at a page boundary, and before the end of a page.
+    for (long[] rowIndexes : new long[][] {{4}, {0, 4}, {0, 5}, {0, 6}, {0, 7}, {0}, {0, 1, 2, 3, 4, 5, 6, 7}}) {
+      List<DataPage> pages = new ArrayList<>();
+      for (int i = 0; i < pageWriter.getPages().size(); ++i) {
+        long firstRowIndex = i * 2;
+        if (Arrays.stream(rowIndexes).noneMatch(row -> firstRowIndex <= row && row < firstRowIndex + 2)) {
+          continue;
+        }
+        DataPage page = pageWriter.getPages().get(i);
+        if (page instanceof DataPageV1) {
+          DataPageV1 pageV1 = (DataPageV1) page;
+          pages.add(new DataPageV1(
+              pageV1.getBytes(),
+              pageV1.getValueCount(),
+              pageV1.getUncompressedSize(),
+              firstRowIndex,
+              2,
+              pageV1.getStatistics(),
+              pageV1.getRlEncoding(),
+              pageV1.getDlEncoding(),
+              pageV1.getValueEncoding()));
+        } else {
+          DataPageV2 pageV2 = (DataPageV2) page;
+          pages.add(DataPageV2.uncompressed(
+              pageV2.getRowCount(),
+              pageV2.getNullCount(),
+              pageV2.getValueCount(),
+              firstRowIndex,
+              pageV2.getRepetitionLevels(),
+              pageV2.getDefinitionLevels(),
+              pageV2.getDataEncoding(),
+              pageV2.getData(),
+              pageV2.getStatistics()));
+        }
+      }
+      MemPageReader pageReader = new MemPageReader(
+          pages.stream().mapToLong(DataPage::getValueCount).sum(), pages.iterator(), null);
+      ColumnReader reader = new SynchronizingColumnReader(
+          col,
+          pageReader,
+          new PrimitiveConverter() {},
+          VersionParser.parse(Version.FULL_VERSION),
+          Arrays.stream(rowIndexes).iterator());
+      for (long row : rowIndexes) {
+        for (int value = 0; value < (row == 6 ? 1 : valuesPerRow); ++value) {
+          assertThat(reader.getCurrentRepetitionLevel()).isEqualTo(value == 0 ? 0 : 1);
+          assertThat(reader.getCurrentDefinitionLevel()).isEqualTo(row == 6 ? 0 : 1);
+          if (row != 6) {
+            assertThat(reader.getInteger()).isEqualTo((int) row * 10 + value);
+          }
+          reader.consume();
+        }
+      }
+      assertThat(reader.getCurrentRepetitionLevel()).isEqualTo(0);
+    }
   }
 }


### PR DESCRIPTION
## Why are the changes needed?

A Parquet file stores each column in separate data pages, and the page boundaries do not have to line up across columns. When column-index filtering rules out pages for a predicate, the record reader must advance every projected column to the same retained row positions. Otherwise it can assemble a record using values from different rows.

The current reader can lose that synchronization at the final selected row. For example, consider a row group with these two required INT32 columns:

| Physical row | `predicate` | `payload` |
| --- | ---: | ---: |
| 0 | 0 | 0 |
| 1 | 0 | 10 |
| 2 | 100 | 20 |
| 3 | 100 | 30 |
| 4 | 0 | 40 |

Suppose `predicate` has pages covering rows **[0,1]**, **[2,3]**, and **[4]**, while `payload` has pages covering **[0,1,2]** and **[3,4]**. Filtering for `predicate = 0` eliminates predicate page [2,3], so the reader needs positions **0, 1, and 4**. It should return payloads **[0, 10, 40]**. With column-index filtering enabled, it instead returns **[0, 10, 20]**: the last payload comes from row 2, not row 4.

The payload reader has already taken row 4 from the selected-position iterator, but has not yet reached that row. When it needs to move to the next page, `SynchronizingColumnReader` mistakes the exhausted iterator for the end of the read and stops on the earlier page. Disabling column-index filtering gives the correct result for the same file.

## What changes were proposed in this PR?

Keep the synchronizing reader active while its final selected row is still pending. Iterator exhaustion is only sufficient to finish once the current target has been reached, or the reader has explicitly recorded that no target remains. This lets the existing page-advance and value-skipping logic reach the last selected row without changing how other rows are read.

The change is confined to that completion check, with regression coverage in the existing column-reader test class. It does not change public APIs, the Parquet format, or how pages are selected for filtering.

## How was this PR tested?

Validated locally against Apache `master` at `60175684378abff1ea001b6541ec38da42a2eff1`, with Java 17 and Thrift 0.23.0. All four added regression tests fail before the fix with an earlier row's value and pass afterward. They cover optional and repeated columns, V1 and V2 pages, null or empty rows, and selections ending at different positions within a page. The three pre-existing tests in the class remain passing.

The full `parquet-column` suite passes **675 tests**, and the existing `TestColumnIndexFiltering` file-reader suite passes **24 tests**. The column reactor's dependency tests and the `spotless:check` formatting check also pass.

An additional standalone check writes real files with the page layouts above and reads them through an ordinary `ParquetReader` predicate, without supplying row positions. It reproduces the wrong payload with the old reader and returns the correct values with this fix, for both V1 and V2 pages. Aligned-page and final-contiguous-range controls remain correct. This check is separate from the committed unit tests.

Closes #3747.
