### PR TITLE
GH-2142: Write fields of empty message types as proto bytes

### DIFF
--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoMessageConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoMessageConverter.java
@@ -36,6 +36,7 @@ import com.google.protobuf.DoubleValue;
 import com.google.protobuf.FloatValue;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Int64Value;
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.UInt32Value;
@@ -347,6 +348,9 @@ class ProtoMessageConverter extends GroupConverter {
           if (messageType.equals(BytesValue.getDescriptor())) {
             return new ProtoBytesValueConverter(pvc);
           }
+          // Otherwise the column holds the serialized message itself: ProtoSchemaConverter stores
+          // fields of empty message types and recursion beyond maxRecursion as proto bytes.
+          return new ProtoBinaryMessageConverter(pvc, parentBuilder, fieldDescriptor);
         }
         Message.Builder subBuilder = parentBuilder.newBuilderForField(fieldDescriptor);
         return new ProtoMessageConverter(conf, pvc, subBuilder, parquetType.asGroupType(), extraMetadata);
@@ -492,6 +496,39 @@ class ProtoMessageConverter extends GroupConverter {
         Binary binaryValue = dictionary.decodeToBinary(i);
         dict[i] = translateEnumValue(binaryValue);
       }
+    }
+  }
+
+  /**
+   * Reads a message field that {@link ProtoSchemaConverter} stored as the serialized proto bytes
+   * (a field of an empty message type, or recursion truncated at maxRecursion) back into the
+   * message.
+   */
+  static final class ProtoBinaryMessageConverter extends PrimitiveConverter {
+
+    private final ParentValueContainer parent;
+    private final Message.Builder parentBuilder;
+    private final Descriptors.FieldDescriptor fieldDescriptor;
+
+    ProtoBinaryMessageConverter(
+        ParentValueContainer parent,
+        Message.Builder parentBuilder,
+        Descriptors.FieldDescriptor fieldDescriptor) {
+      this.parent = parent;
+      this.parentBuilder = parentBuilder;
+      this.fieldDescriptor = fieldDescriptor;
+    }
+
+    @Override
+    public void addBinary(Binary binary) {
+      Message.Builder builder = parentBuilder.newBuilderForField(fieldDescriptor);
+      try {
+        builder.mergeFrom(ByteString.copyFrom(binary.toByteBuffer()));
+      } catch (InvalidProtocolBufferException e) {
+        throw new ParquetDecodingException(
+            "Cannot parse field " + fieldDescriptor.getFullName() + " from its serialized proto bytes", e);
+      }
+      parent.add(builder.build());
     }
   }
 

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoSchemaConverter.java
@@ -327,6 +327,18 @@ public class ProtoSchemaConverter {
       return addMapField(descriptor, builder, seen, depth);
     }
 
+    // Parquet forbids empty groups, so a field of an empty message type is terminated as proto
+    // bytes (zero bytes when the message is set - presence still round-trips), preserving the
+    // field's repetition so the write path (Array/Repeated/MapWriter) still matches the schema.
+    if (descriptor.getMessageType().getFields().isEmpty()) {
+      if (descriptor.isRepeated() && parquetSpecsCompliant) {
+        // LIST-wrap the truncated bytes the same way any repeated primitive is wrapped
+        return addRepeatedPrimitive(BINARY, null, builder);
+      }
+      // optional, required, or repeated in the old schema style
+      return builder.primitive(BINARY, getRepetition(descriptor)).as((LogicalTypeAnnotation) null);
+    }
+
     seen = ImmutableSetMultimap.<String, Integer>builder()
         .putAll(seen)
         .put(typeName, depth)

--- a/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
+++ b/parquet-protobuf/src/main/java/org/apache/parquet/proto/ProtoWriteSupport.java
@@ -356,42 +356,45 @@ public class ProtoWriteSupport<T extends MessageOrBuilder> extends WriteSupport<
       }
 
       // This can happen now that recursive schemas get truncated to bytes.  Write the bytes.
-      if (type.isPrimitive()
-          && type.asPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY) {
+      // The truncated type keeps the field's shape, so it may sit behind a LIST wrapper
+      // (repeated field) or be the value inside a MAP's key_value group.
+      Type contentType = getContentType(type);
+      if (contentType.isPrimitive()
+          && contentType.asPrimitiveType().getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.BINARY) {
         return new BinaryWriter();
       }
 
-      return new MessageWriter(fieldDescriptor.getMessageType(), getGroupType(type));
+      return new MessageWriter(fieldDescriptor.getMessageType(), contentType.asGroupType());
     }
 
-    private GroupType getGroupType(Type type) {
+    /** Unwraps the LIST/MAP wrapper groups to the type holding the message content itself. */
+    private Type getContentType(Type type) {
+      if (type.isPrimitive()) {
+        return type;
+      }
       LogicalTypeAnnotation logicalTypeAnnotation = type.getLogicalTypeAnnotation();
       if (logicalTypeAnnotation == null) {
-        return type.asGroupType();
+        return type;
       }
       return logicalTypeAnnotation
-          .accept(new LogicalTypeAnnotation.LogicalTypeAnnotationVisitor<GroupType>() {
+          .accept(new LogicalTypeAnnotation.LogicalTypeAnnotationVisitor<Type>() {
             @Override
-            public Optional<GroupType> visit(
-                LogicalTypeAnnotation.ListLogicalTypeAnnotation listLogicalType) {
+            public Optional<Type> visit(LogicalTypeAnnotation.ListLogicalTypeAnnotation listLogicalType) {
               return ofNullable(type.asGroupType()
                   .getType("list")
                   .asGroupType()
-                  .getType("element")
-                  .asGroupType());
+                  .getType("element"));
             }
 
             @Override
-            public Optional<GroupType> visit(
-                LogicalTypeAnnotation.MapLogicalTypeAnnotation mapLogicalType) {
+            public Optional<Type> visit(LogicalTypeAnnotation.MapLogicalTypeAnnotation mapLogicalType) {
               return ofNullable(type.asGroupType()
                   .getType("key_value")
                   .asGroupType()
-                  .getType("value")
-                  .asGroupType());
+                  .getType("value"));
             }
           })
-          .orElse(type.asGroupType());
+          .orElse(type);
     }
 
     private MapWriter createMapWriter(FieldDescriptor fieldDescriptor, Type type) {

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoEmptyMessageTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoEmptyMessageTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.parquet.proto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.protobuf.Message;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
+import org.apache.parquet.proto.test.Trees;
+import org.apache.parquet.schema.InvalidSchemaException;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Fields typed as an EMPTY proto message cannot map to a parquet group (parquet forbids empty
+ * groups, so writer construction used to fail with an {@code InvalidSchemaException}). They are
+ * now terminated as proto bytes, like recursion beyond maxRecursion, which also keeps the field's
+ * presence observable (null vs an empty byte array).
+ */
+public class ProtoEmptyMessageTest {
+
+  private static Path write(boolean specsCompliant, Message... messages) throws IOException {
+    Path file = TestUtils.someTemporaryFilePath();
+    Configuration conf = new Configuration();
+    ProtoWriteSupport.setWriteSpecsCompliant(conf, specsCompliant);
+    try (ParquetWriter<Message> writer = ProtoParquetWriter.<Message>builder(file)
+        .withMessage(messages[0].getClass())
+        .withConf(conf)
+        .build()) {
+      for (Message message : messages) {
+        writer.write(message);
+      }
+    }
+    return file;
+  }
+
+  private static List<Group> read(Path file) throws IOException {
+    List<Group> rows = new ArrayList<>();
+    try (ParquetReader<Group> reader =
+        ParquetReader.builder(new GroupReadSupport(), file).build()) {
+      for (Group group = reader.read(); group != null; group = reader.read()) {
+        rows.add(group);
+      }
+    }
+    return rows;
+  }
+
+  @Test
+  public void emptyMessageFieldsWriteAsBytes() throws Exception {
+    Trees.StubBox box = Trees.StubBox.newBuilder()
+        .setStub(Trees.Stub.getDefaultInstance())
+        .addStubs(Trees.Stub.getDefaultInstance())
+        .addStubs(Trees.Stub.getDefaultInstance())
+        .putStubMap("k", Trees.Stub.getDefaultInstance())
+        .setName("x")
+        .build();
+
+    Group row = read(write(true, box)).get(0);
+    assertThat(row.getBinary("stub", 0).length())
+        .as("optional empty message present as zero bytes")
+        .isEqualTo(0);
+    assertThat(row.getGroup("stubs", 0).getFieldRepetitionCount("list"))
+        .as("repeated empty messages keep their cardinality")
+        .isEqualTo(2);
+    Group entry = row.getGroup("stub_map", 0).getGroup("key_value", 0);
+    assertThat(entry.getString("key", 0)).as("map keys stay typed").isEqualTo("k");
+    assertThat(entry.getBinary("value", 0).length())
+        .as("map value is zero bytes")
+        .isEqualTo(0);
+    assertThat(row.getString("name", 0)).isEqualTo("x");
+  }
+
+  @Test
+  public void emptyMessagePresenceRoundTrips() throws Exception {
+    Trees.StubBox with = Trees.StubBox.newBuilder()
+        .setStub(Trees.Stub.getDefaultInstance())
+        .build();
+    Trees.StubBox without = Trees.StubBox.getDefaultInstance();
+
+    List<Group> rows = read(write(true, with, without));
+    assertThat(rows.get(0).getFieldRepetitionCount("stub"))
+        .as("set empty message is present")
+        .isEqualTo(1);
+    assertThat(rows.get(1).getFieldRepetitionCount("stub"))
+        .as("unset empty message is null")
+        .isEqualTo(0);
+  }
+
+  @Test
+  public void emptyMessageFieldsWriteAsBytesOldStyle() throws Exception {
+    Trees.StubBox box = Trees.StubBox.newBuilder()
+        .addStubs(Trees.Stub.getDefaultInstance())
+        .addStubs(Trees.Stub.getDefaultInstance())
+        .build();
+
+    Group row = read(write(false, box)).get(0);
+    assertThat(row.getFieldRepetitionCount("stubs"))
+        .as("repeated empty messages keep their cardinality")
+        .isEqualTo(2);
+  }
+
+  @Test
+  public void emptyRootMessageStillRejected() {
+    // the root message itself cannot be terminated as bytes - there is no field to hold them
+    assertThatThrownBy(() -> write(true, Trees.Stub.getDefaultInstance()))
+        .isInstanceOf(InvalidSchemaException.class)
+        .hasMessageContaining("Cannot write a schema with an empty group");
+  }
+}

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoEmptyMessageTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoEmptyMessageTest.java
@@ -124,6 +124,58 @@ public class ProtoEmptyMessageTest {
   }
 
   @Test
+  public void emptyMessageFieldsRoundTripThroughProtoReader() throws Exception {
+    Trees.StubBox box = Trees.StubBox.newBuilder()
+        .setStub(Trees.Stub.getDefaultInstance())
+        .addStubs(Trees.Stub.getDefaultInstance())
+        .addStubs(Trees.Stub.getDefaultInstance())
+        .putStubMap("k", Trees.Stub.getDefaultInstance())
+        .setName("x")
+        .build();
+    Trees.StubBox without = Trees.StubBox.newBuilder().setName("y").build();
+
+    assertThat(TestUtils.readMessages(write(true, box, without), Trees.StubBox.class))
+        .as("ProtoParquetReader parses the proto bytes back, presence included")
+        .containsExactly(box, without);
+  }
+
+  @Test
+  public void emptyMessageFieldsRoundTripThroughProtoReaderOldStyle() throws Exception {
+    Trees.StubBox box = Trees.StubBox.newBuilder()
+        .setStub(Trees.Stub.getDefaultInstance())
+        .addStubs(Trees.Stub.getDefaultInstance())
+        .addStubs(Trees.Stub.getDefaultInstance())
+        .putStubMap("k", Trees.Stub.getDefaultInstance())
+        .build();
+
+    assertThat(TestUtils.readMessages(write(false, box), Trees.StubBox.class))
+        .containsExactly(box);
+  }
+
+  @Test
+  public void truncatedRecursionRoundTripsThroughProtoReader() throws Exception {
+    // the same binary-to-message read path serves recursion truncated at maxRecursion
+    Trees.BinaryTree.Builder tree = Trees.BinaryTree.newBuilder();
+    Trees.BinaryTree.Builder cursor = tree;
+    for (int i = 0; i < 6; i++) {
+      cursor.getValueBuilder().setTypeUrl("level-" + i);
+      cursor = cursor.getLeftBuilder();
+    }
+    Path file = TestUtils.someTemporaryFilePath();
+    Configuration conf = new Configuration();
+    ProtoWriteSupport.setWriteSpecsCompliant(conf, true);
+    ProtoSchemaConverter.setMaxRecursion(conf, 2);
+    try (ParquetWriter<Message> writer = ProtoParquetWriter.<Message>builder(file)
+        .withMessage(Trees.BinaryTree.class)
+        .withConf(conf)
+        .build()) {
+      writer.write(tree.build());
+    }
+
+    assertThat(TestUtils.readMessages(file, Trees.BinaryTree.class)).containsExactly(tree.build());
+  }
+
+  @Test
   public void emptyRootMessageStillRejected() {
     // the root message itself cannot be terminated as bytes - there is no field to hold them
     assertThatThrownBy(() -> write(true, Trees.Stub.getDefaultInstance()))

--- a/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
+++ b/parquet-protobuf/src/test/java/org/apache/parquet/proto/ProtoSchemaConverterTest.java
@@ -580,6 +580,27 @@ public class ProtoSchemaConverterTest {
   }
 
   @Test
+  public void testEmptyMessageFields() throws Exception {
+    String expectedSchema = JOINER.join(
+        "message Trees.StubBox {",
+        "  optional binary stub = 1;",
+        "  optional group stubs (LIST) = 2 {",
+        "    repeated group list {",
+        "      required binary element;",
+        "    }",
+        "  }",
+        "  optional group stub_map (MAP) = 3 {",
+        "    repeated group key_value {",
+        "      required binary key (STRING);",
+        "      optional binary value;",
+        "    }",
+        "  }",
+        "  optional binary name (STRING) = 4;",
+        "}");
+    testConversion(Trees.StubBox.class, expectedSchema, new ProtoSchemaConverter(true, 5, false));
+  }
+
+  @Test
   public void testDeepRecursion() {
     // The general idea is to test the fanout of the schema.
     // TODO: figured out closed forms of the binary tree and struct series.

--- a/parquet-protobuf/src/test/resources/Trees.proto
+++ b/parquet-protobuf/src/test/resources/Trees.proto
@@ -35,3 +35,15 @@ message WideTree {
     google.protobuf.Any value = 1;
     repeated WideTree children = 2;
 }
+
+// An empty message: parquet cannot represent an empty group, so fields of this
+// type are terminated as proto bytes (like recursion beyond maxRecursion).
+message Stub {
+}
+
+message StubBox {
+    Stub stub = 1;
+    repeated Stub stubs = 2;
+    map<string, Stub> stub_map = 3;
+    string name = 4;
+}


### PR DESCRIPTION
### Rationale for this change

Protobuf allows empty message definitions, but Parquet forbids empty groups. Converting a message
that merely *contains* a field of an empty message type produces a schema with an empty group,
which writer construction rejects with `InvalidSchemaException: Cannot write a schema with an
empty group`. Such fields appear in real-world schemas (deprecated stubs, marker/placeholder
messages), and a single one makes the whole message type unwritable.

### What changes are included in this PR?

`ProtoSchemaConverter.addMessageField` terminates a field whose message type has no fields as a
`BINARY` column holding the serialized message — the same mechanism PARQUET-1711 uses for
recursion beyond `maxRecursion`. Since an empty message serializes to zero bytes, the column is
cheap, and field **presence** still round-trips (null = unset vs empty bytes = set):

- singular field → `optional binary stub` (or `required`, per the field);
- repeated field, parquet-specs mode → LIST-wrapped binary via the existing
  `addRepeatedPrimitive`, so element cardinality survives;
- repeated field, old style → `repeated binary`;
- map value type → `optional binary value` inside the `key_value` group (keys stay typed).

`ProtoWriteSupport.createMessageWriter`'s existing truncated-field check (primitive BINARY where a
message field was declared → `BinaryWriter`) is generalized to look through the LIST/MAP wrapper
(`getGroupType` → `getContentType`), so the writer tree lines up with these schemas.

A message that is empty at the **root** is still rejected — there is no parent field to hold the
bytes, and a Parquet file with zero columns is not representable.

**Read side** (second commit, after review): `ProtoMessageConverter` used to cast every message
field's Parquet type to a group, so a message field stored as `BINARY` failed with a
`ClassCastException` while the converter tree was built — which also means files with
PARQUET-1711 recursion truncation have been unreadable by `ProtoParquetReader` since 1.13.0 (#995
shipped with an explicit "TODO: ReadSupport"). A new `ProtoBinaryMessageConverter` parses the
bytes back through `parentBuilder.newBuilderForField(field)` and hands the message to the existing
parent container, so singular fields, LIST elements, old-style repeated fields and map values all
round-trip without touching `ListConverter`/`MapConverter`. Parse failures surface as
`ParquetDecodingException`.

### Are these changes tested?

Yes. New `ProtoEmptyMessageTest` (new test messages `Stub`/`StubBox` in `Trees.proto`) writes
through the real write path (`ProtoParquetWriter` → `MessageColumnIO`, both specs-compliant and
old style) and reads back with `GroupReadSupport` and with `ProtoParquetReader`:

- singular / repeated / map-value empty-message fields round-trip with correct cardinality and
  zero-byte values;
- presence round-trips (set empty message vs unset field);
- `ProtoParquetReader` reads the written messages back equal to the originals (specs-compliant and
  old style), and the same read path round-trips a `BinaryTree` truncated at `maxRecursion`;
- an empty root message still fails with `InvalidSchemaException` ("Cannot write a schema with an
  empty group").

`ProtoSchemaConverterTest.testEmptyMessageFields` pins the converted schema. The full
parquet-protobuf suite passes (117 tests).

### Are there any user-facing changes?

Message types that previously could not be written to Parquet at all now can; fields of empty
message types appear as (possibly LIST/MAP-wrapped) `binary` columns and read back into the
original messages with `ProtoParquetReader`. Files with `maxRecursion` truncation, previously
unreadable by `ProtoParquetReader`, now read back as well. No change for schemas that were
previously writable. Error behavior for an empty root message is unchanged.

Closes #2142