### PR TITLE
GH-3682: Report an explicit revision in source builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -524,6 +524,11 @@
         <artifactId>buildnumber-maven-plugin</artifactId>
         <!-- Warning! 3.2.1 caused issues during verification, 3.2.0 is known to work correctly. -->
         <version>3.2.0</version>
+        <configuration>
+          <!-- Source distributions carry no .git metadata, so the revision cannot be read.
+               Record an explicit value instead of leaving ${buildNumber} unresolved. -->
+          <revisionOnScmFailure>unknown</revisionOnScmFailure>
+        </configuration>
         <executions>
           <execution>
             <phase>validate</phase>


### PR DESCRIPTION
### Rationale for this change

Apache source releases contain no `.git` directory. Building one leaves `${buildNumber}` unresolved in `Version.FULL_VERSION` and writes a blank `git-SHA-1` manifest entry. Parquet files and binaries built from the source release therefore carry misleading build metadata.

### What changes are included in this PR?

The existing `buildnumber-maven-plugin` now uses `unknown` when SCM metadata is unavailable. Builds from a Git checkout still record the real commit.

### Are these changes tested?

The generator was built from Git archives of the base and branch heads, matching the source-release path. The branch was also built from its normal Git checkout.

<details><summary>Commands and raw output</summary>

```console
$ for ref in e02f65e2ba41393f5d95f14d2ff27029f5c90639 \
             0528ba666ec5fc119611f0a103522db7812652b8; do
    work=$(mktemp -d)
    git archive "$ref" | tar -x -C "$work"
    (
      cd "$work"
      ./mvnw -f parquet-generator/pom.xml package -DskipTests
      out=$(mktemp -d)
      java -cp parquet-generator/target/parquet-generator-1.19.0-SNAPSHOT.jar \
        org.apache.parquet.version.Generator "$out"
      grep 'FULL_VERSION' "$out/org/apache/parquet/Version.java"
      unzip -p parquet-generator/target/parquet-generator-1.19.0-SNAPSHOT.jar \
        META-INF/MANIFEST.MF | grep 'git-SHA-1'
    )
  done

# Git archive of e02f65e2ba41393f5d95f14d2ff27029f5c90639
[INFO] Storing buildNumber: null
public static final String FULL_VERSION = "parquet-mr version 1.19.0-SNAPSHOT (build ${buildNumber})";
git-SHA-1:

# Git archive of 0528ba666ec5fc119611f0a103522db7812652b8
[INFO] Storing buildNumber: unknown
public static final String FULL_VERSION = "parquet-mr version 1.19.0-SNAPSHOT (build unknown)";
git-SHA-1: unknown

# Git checkout of 0528ba666ec5fc119611f0a103522db7812652b8
$ ./mvnw -N validate
[INFO] Storing buildNumber: 0528ba666ec5fc119611f0a103522db7812652b8
```

</details>

### Are there any user-facing changes?

Source-built artifacts now report `unknown` instead of an unresolved placeholder or blank revision.

Closes https://github.com/apache/parquet-java/issues/3682
