### PR TITLE
Fix/prepare rc self ci check

### DIFF
--- a/release/libs/_github.sh
+++ b/release/libs/_github.sh
@@ -44,31 +44,32 @@ function check_github_checks_passed() {
 
   local repo_info="${GITHUB_REPO}"
 
-  local num_incomplete
-  if ! num_incomplete=$(gh api "repos/${repo_info}/commits/${commit_sha}/check-runs" \
-    --jq '[.check_runs[] | select(.status != "completed")] | length'); then
-    print_error "Failed to fetch GitHub check runs for commit ${commit_sha}"
+  local runs_json
+  if ! runs_json=$(gh api "repos/${repo_info}/actions/runs?head_sha=${commit_sha}&per_page=100"); then
+    print_error "Failed to fetch GitHub workflow runs for commit ${commit_sha}"
     return 1
   fi
 
+  # Exclude release-*.yml workflows.
+  local ci_runs
+  ci_runs=$(echo "${runs_json}" \
+    | jq '[.workflow_runs[] | select((.path // "") | startswith(".github/workflows/release-") | not)]')
+
+  local num_incomplete
+  num_incomplete=$(echo "${ci_runs}" | jq '[.[] | select(.status != "completed")] | length')
+
   if [[ ${num_incomplete} -ne 0 ]]; then
     print_error "Found ${num_incomplete} still-running GitHub checks for commit ${commit_sha}"
-    gh api "repos/${repo_info}/commits/${commit_sha}/check-runs" \
-      --jq '.check_runs[] | select(.status != "completed") | "  - \(.name): \(.status)"' >&2
+    echo "${ci_runs}" | jq -r '.[] | select(.status != "completed") | "  - \(.name): \(.status)"' >&2
     return 1
   fi
 
   local num_failed
-  if ! num_failed=$(gh api "repos/${repo_info}/commits/${commit_sha}/check-runs" \
-    --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped")] | length'); then
-    print_error "Failed to fetch GitHub check runs for commit ${commit_sha}"
-    return 1
-  fi
+  num_failed=$(echo "${ci_runs}" | jq '[.[] | select(.conclusion != "success" and .conclusion != "skipped")] | length')
 
   if [[ ${num_failed} -ne 0 ]]; then
     print_error "Found ${num_failed} failed GitHub checks for commit ${commit_sha}"
-    gh api "repos/${repo_info}/commits/${commit_sha}/check-runs" \
-      --jq '.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped") | "  - \(.name): \(.conclusion)"' >&2
+    echo "${ci_runs}" | jq -r '.[] | select(.conclusion != "success" and .conclusion != "skipped") | "  - \(.name): \(.conclusion)"' >&2
     return 1
   fi
 

--- a/release/tests/github.bats
+++ b/release/tests/github.bats
@@ -106,45 +106,7 @@ JSON
   [[ "$output" == *"CI Hadoop 3"* ]]
 }
 
-@test "check_github_checks_passed: ignores in-progress release-*.yml self-reference" {
-  export GITHUB_TOKEN="fake-token"
-  DRY_RUN=0
-
-  gh() {
-    cat <<'JSON'
-{"workflow_runs": [
-  {"name": "Release - Prepare RC", "path": ".github/workflows/release-prepare-rc.yml", "status": "in_progress", "conclusion": null},
-  {"name": "CI Hadoop 3",          "path": ".github/workflows/ci-hadoop3.yml",         "status": "completed",   "conclusion": "success"}
-]}
-JSON
-  }
-  export -f gh
-
-  run check_github_checks_passed "abc123"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"All GitHub checks passed"* ]]
-}
-
-@test "check_github_checks_passed: ignores historical failed release-*.yml on same commit" {
-  export GITHUB_TOKEN="fake-token"
-  DRY_RUN=0
-
-  gh() {
-    cat <<'JSON'
-{"workflow_runs": [
-  {"name": "Release - Prepare RC", "path": ".github/workflows/release-prepare-rc.yml", "status": "completed", "conclusion": "failure"},
-  {"name": "CI Hadoop 3",          "path": ".github/workflows/ci-hadoop3.yml",         "status": "completed", "conclusion": "success"}
-]}
-JSON
-  }
-  export -f gh
-
-  run check_github_checks_passed "abc123"
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"All GitHub checks passed"* ]]
-}
-
-@test "check_github_checks_passed: detects CI failures when release workflows are present" {
+@test "check_github_checks_passed: ignores release-*.yml runs and still catches CI failures" {
   export GITHUB_TOKEN="fake-token"
   DRY_RUN=0
 

--- a/release/tests/github.bats
+++ b/release/tests/github.bats
@@ -54,8 +54,12 @@ setup() {
   DRY_RUN=0
 
   gh() {
-    echo "0"
-    return 0
+    cat <<'JSON'
+{"workflow_runs": [
+  {"name": "CI Hadoop 3",    "path": ".github/workflows/ci-hadoop3.yml",     "status": "completed", "conclusion": "success"},
+  {"name": "Vector Plugins", "path": ".github/workflows/vector-plugins.yml", "status": "completed", "conclusion": "success"}
+]}
+JSON
   }
   export -f gh
 
@@ -69,20 +73,18 @@ setup() {
   DRY_RUN=0
 
   gh() {
-    if [[ "$*" == *"status"* && "$*" == *"length"* ]]; then
-      echo "1"
-    elif [[ "$*" == *"status"* ]]; then
-      echo "  - CI Hadoop 3: in_progress"
-    else
-      echo "0"
-    fi
-    return 0
+    cat <<'JSON'
+{"workflow_runs": [
+  {"name": "CI Hadoop 3", "path": ".github/workflows/ci-hadoop3.yml", "status": "in_progress", "conclusion": null}
+]}
+JSON
   }
   export -f gh
 
   run check_github_checks_passed "abc123"
   [ "$status" -eq 1 ]
   [[ "$output" == *"still-running"* ]]
+  [[ "$output" == *"CI Hadoop 3"* ]]
 }
 
 @test "check_github_checks_passed: fails when checks have failed conclusions" {
@@ -90,22 +92,76 @@ setup() {
   DRY_RUN=0
 
   gh() {
-    if [[ "$*" == *"status"* && "$*" == *"length"* ]]; then
-      echo "0"
-    elif [[ "$*" == *"conclusion"* && "$*" == *"length"* ]]; then
-      echo "2"
-    elif [[ "$*" == *"conclusion"* ]]; then
-      echo "  - CI Hadoop 3: failure"
-    else
-      echo "0"
-    fi
-    return 0
+    cat <<'JSON'
+{"workflow_runs": [
+  {"name": "CI Hadoop 3", "path": ".github/workflows/ci-hadoop3.yml", "status": "completed", "conclusion": "failure"}
+]}
+JSON
   }
   export -f gh
 
   run check_github_checks_passed "abc123"
   [ "$status" -eq 1 ]
   [[ "$output" == *"failed GitHub checks"* ]]
+  [[ "$output" == *"CI Hadoop 3"* ]]
+}
+
+@test "check_github_checks_passed: ignores in-progress release-*.yml self-reference" {
+  export GITHUB_TOKEN="fake-token"
+  DRY_RUN=0
+
+  gh() {
+    cat <<'JSON'
+{"workflow_runs": [
+  {"name": "Release - Prepare RC", "path": ".github/workflows/release-prepare-rc.yml", "status": "in_progress", "conclusion": null},
+  {"name": "CI Hadoop 3",          "path": ".github/workflows/ci-hadoop3.yml",         "status": "completed",   "conclusion": "success"}
+]}
+JSON
+  }
+  export -f gh
+
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"All GitHub checks passed"* ]]
+}
+
+@test "check_github_checks_passed: ignores historical failed release-*.yml on same commit" {
+  export GITHUB_TOKEN="fake-token"
+  DRY_RUN=0
+
+  gh() {
+    cat <<'JSON'
+{"workflow_runs": [
+  {"name": "Release - Prepare RC", "path": ".github/workflows/release-prepare-rc.yml", "status": "completed", "conclusion": "failure"},
+  {"name": "CI Hadoop 3",          "path": ".github/workflows/ci-hadoop3.yml",         "status": "completed", "conclusion": "success"}
+]}
+JSON
+  }
+  export -f gh
+
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"All GitHub checks passed"* ]]
+}
+
+@test "check_github_checks_passed: detects CI failures when release workflows are present" {
+  export GITHUB_TOKEN="fake-token"
+  DRY_RUN=0
+
+  gh() {
+    cat <<'JSON'
+{"workflow_runs": [
+  {"name": "Release - Prepare RC", "path": ".github/workflows/release-prepare-rc.yml", "status": "in_progress", "conclusion": null},
+  {"name": "Vector Plugins",       "path": ".github/workflows/vector-plugins.yml",     "status": "completed",   "conclusion": "failure"}
+]}
+JSON
+  }
+  export -f gh
+
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"failed GitHub checks"* ]]
+  [[ "$output" == *"Vector Plugins"* ]]
 }
 
 @test "check_github_checks_passed: fails when gh api errors" {


### PR DESCRIPTION
### What changes are included in this PR?
The "Prepare Release" job now ignores github actions on a commit that are related to the release. Previously we would check that no actions were running (to make sure CI had finished) but by running the release job we started a new action on that commit. To fix this we just ignore all jobs that start with release-*.

### Are these changes tested?

New Bats tests checking this situation

### Are there any user-facing changes?

No
