### PR TITLE
Prepare RC: write generated Maven settings outside the repo

### DIFF
--- a/release/bin/prepare-rc.sh
+++ b/release/bin/prepare-rc.sh
@@ -255,7 +255,7 @@ step_summary "Created tag \`${rc_tag}\` at \`${tag_commit}\`"
 step_summary ""
 step_summary "### Nexus Deployment"
 
-settings_file=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/parquet-release-settings.XXXXXX")
+settings_file=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/parquet-release-settings.xml")
 generate_maven_settings "${settings_file}"
 
 maven_deploy "${settings_file}"

--- a/release/bin/prepare-rc.sh
+++ b/release/bin/prepare-rc.sh
@@ -32,7 +32,7 @@ source "${LIBS_DIR}/_nexus.sh"
 source "${LIBS_DIR}/_maven.sh"
 source "${LIBS_DIR}/_svn.sh"
 
-trap 'rm -f .release-settings.xml' EXIT
+trap 'rm -f "${settings_file:-}"' EXIT
 
 # ---------------------------------------------------------------------------
 # Usage
@@ -255,7 +255,7 @@ step_summary "Created tag \`${rc_tag}\` at \`${tag_commit}\`"
 step_summary ""
 step_summary "### Nexus Deployment"
 
-settings_file=".release-settings.xml"
+settings_file=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/parquet-release-settings.XXXXXX")
 generate_maven_settings "${settings_file}"
 
 maven_deploy "${settings_file}"


### PR DESCRIPTION
### Rationale for this change

Before we were making a temporary .release-settings.xml in the working directory. This caused RAT to fail since the temp file was not licensed correctly. 

Now we use mktemp under RUNNER_TEMP (with TMPDIR / /tmp fallbacks) so the file lives outside the tree RAT scans, and guard the EXIT trap with ${settings_file:-} in case the script exits before the variable is set.

### What changes are included in this PR?

Changes the position of the temporary file

### Are these changes tested?

Only locally, made sure the file writes outside of the working directory

### Are there any user-facing changes?

No
