### PR TITLE
Release: Keep random suffix in settings file

### DIFF
--- a/release/bin/prepare-rc.sh
+++ b/release/bin/prepare-rc.sh
@@ -255,7 +255,7 @@ step_summary "Created tag \`${rc_tag}\` at \`${tag_commit}\`"
 step_summary ""
 step_summary "### Nexus Deployment"
 
-settings_file=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/parquet-release-settings.xml")
+settings_file=$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/parquet-release-settings.XXXXXX")
 generate_maven_settings "${settings_file}"
 
 maven_deploy "${settings_file}"


### PR DESCRIPTION
### Rationale for this change

TIL: mktemp requires its template to end with at least three trailing X characters (which it replaces with random chars to make a unique name), and using --suffix=.ext lets you keep a file extension after that random run — a template like parquet-release-settings.xml fails because it has no Xs.

Revert "Update release/bin/prepare-rc.sh"

This reverts commit 784c1533f0d5920da10b7f8273b462c77884d21d.

### What changes are included in this PR?


### Are these changes tested?


### Are there any user-facing changes?


<!-- Please uncomment the line below and replace ${GITHUB_ISSUE_ID} with the actual Github issue id. -->
<!-- Closes #${GITHUB_ISSUE_ID} -->
