### PR TITLE
GH-3767: Make PageReader AutoCloseable

### DIFF
--- a/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
+++ b/parquet-column/src/main/java/org/apache/parquet/column/page/PageReader.java
@@ -21,7 +21,7 @@ package org.apache.parquet.column.page;
 /**
  * Reader for a sequence a page from a given column chunk
  */
-public interface PageReader {
+public interface PageReader extends AutoCloseable {
 
   /**
    * @return the dictionary page in that chunk or null if none
@@ -37,4 +37,10 @@ public interface PageReader {
    * @return the next page in that chunk or null if after the last page
    */
   DataPage readPage();
+
+  /**
+   * Releases any resources this reader holds (buffers, native handles, etc.).
+   */
+  @Override
+  default void close() {}
 }

--- a/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
+++ b/parquet-hadoop/src/main/java/org/apache/parquet/hadoop/ColumnChunkPageReadStore.java
@@ -338,7 +338,8 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
       }
     }
 
-    private void releaseBuffers() {
+    @Override
+    public void close() {
       releaser.close();
     }
   }
@@ -415,7 +416,7 @@ class ColumnChunkPageReadStore implements PageReadStore, DictionaryPageReadStore
     // Wrap each reader + the releaser as an AutoCloseable so AutoCloseables.uncheckedClose()
     // releases every resource even if one fails, and aggregates failures via suppressed exceptions
     List<AutoCloseable> toClose = new ArrayList<>(readers.size() + 1);
-    readers.values().forEach(reader -> toClose.add(reader::releaseBuffers));
+    readers.values().forEach(reader -> toClose.add(reader));
     toClose.add(releaser);
     AutoCloseables.uncheckedClose(toClose);
   }


### PR DESCRIPTION
### Rationale for this change

`PageReader` implementations can own resources — `ColumnChunkPageReader` owns decompression / decryption scratch buffers registered on a `ByteBufferReleaser` — but the interface has no standard teardown method. Today `ColumnChunkPageReadStore.close()` reaches into the concrete class through a package-private `releaseBuffers()` call. Alternative `PageReader` implementations have no idiomatic way to declare that they own resources.

### What changes are included in this PR?

- `PageReader` now extends `AutoCloseable` with a default no-op `close()`.
- `ColumnChunkPageReader.releaseBuffers()` is renamed to `close()`.
- `ColumnChunkPageReadStore.close()` hands its readers to `AutoCloseables.uncheckedClose(...)` directly instead of through a `reader::releaseBuffers` lambda.

### Are these changes tested?

Yes — covered by the existing `TestColumnChunkPageReadStore` suite, which exercises the store's `close()` path (including reader-throws and releaser-throws cases). No new tests are needed since behaviour is unchanged.

### Are there any user-facing changes?

No behavioural change. Source- and binary-compatible: existing `PageReader` implementations inherit the no-op default `close()`. Narrowing the `throws` clause from `Exception` to nothing is a legal covariant refinement.

<!-- Closes #3767 -->
