### PR TITLE
Release workflows: use JDK 17 to match project target

### DIFF
--- a/.github/workflows/release-prepare-rc.yml
+++ b/.github/workflows/release-prepare-rc.yml
@@ -56,11 +56,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
 
       - name: Import GPG key and configure Git
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -65,11 +65,11 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           distribution: temurin
-          java-version: '11'
+          java-version: '17'
 
       - name: Install Subversion
         run: sudo apt-get update -q && sudo apt-get install -q -y subversion


### PR DESCRIPTION
### Rationale for this change
Runner was using Java 17 for Compiling but 11 for running. 

### What changes are included in this PR?

Just always use 17.

### Are these changes tested?

No

### Are there any user-facing changes?