### PR TITLE
Prepare RC: install Thrift before the release build

### DIFF
--- a/.github/workflows/release-prepare-rc.yml
+++ b/.github/workflows/release-prepare-rc.yml
@@ -76,6 +76,10 @@ jobs:
       - name: Install Subversion
         run: sudo apt-get update -q && sudo apt-get install -q -y subversion
 
+      - name: Install Thrift
+        # parquet-format-structures needs the thrift compiler.
+        run: bash dev/ci-before_install.sh
+
       - name: Prepare Release Candidate
         env:
           DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}


### PR DESCRIPTION
### Rationale for this change
We need thrift to compile and test parquet-format-structures

### What changes are included in this PR?
We run the dev cli script which installs thrift

### Are these changes tested?
No

### Are there any user-facing changes?
No
